### PR TITLE
fix(ipay-request): grant submit/cancel/amend permissions

### DIFF
--- a/ipay/ipay/doctype/ipay_request/ipay_request.json
+++ b/ipay/ipay/doctype/ipay_request/ipay_request.json
@@ -178,6 +178,8 @@
    "write": 1
   },
   {
+   "amend": 1,
+   "cancel": 1,
    "create": 1,
    "delete": 1,
    "email": 1,
@@ -187,6 +189,7 @@
    "report": 1,
    "role": "iPay Manager",
    "share": 1,
+   "submit": 1,
    "write": 1
   },
   {
@@ -199,6 +202,7 @@
    "report": 1,
    "role": "iPay User",
    "share": 1,
+   "submit": 1,
    "write": 1
   }
  ],


### PR DESCRIPTION
## Problem

Users with the iPay roles got the following error when trying to request a payment:

> `User <email> does not have doctype access via role permission for document iPay Request`
> `No permission for iPay Request`

## Root cause

`iPay Request` is a **submittable** doctype, and the **Prompt iPay** button in `ipay_request.js` only renders once the document is submitted (`docstatus === 1`). To request a payment, a user must therefore submit the document first.

However, none of the roles in `ipay_request.json` had the **Submit** permission (`submit: 0` for all). So the submit check failed — even though the users had `read`/`write`/`create` — producing the misleading "doctype access" error (it's really the *submit* permission that was missing).

## Fix

Grant the necessary permissions in the doctype definition:

- **iPay Manager**: `submit`, `cancel`, `amend`
- **iPay User**: `submit`

System Manager is left unchanged.