### PR TITLE
fix(ipay): deliver callback from confirm_payment path and harden delivery

### DIFF
--- a/ipay/ipay/main/main.py
+++ b/ipay/ipay/main/main.py
@@ -5,8 +5,8 @@ from ipay.ipay.main.utils.trigger_stk_push import trigger_stk_push
 from ipay.ipay.main.utils.verify_mpesa_payment import verify_mpesa_payment
 from ipay.ipay.main.utils.make_payment_entry import make_payment_entry
 from ipay.ipay.main.utils.ipay_logs import create_log_entry
+from ipay.ipay.main.utils.send_callback import send_callback
 import re
-import requests
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -127,9 +127,7 @@ def lipana_mpesa(
                 frappe.msgprint("Payment received successfully")
 
                 # send post request to call back url
-                call_back_url = frappe.get_doc("iPay Settings").callback_url
-                if call_back_url:
-                    requests.post(call_back_url, json=response_data)
+                send_callback(response_data)
 
                 # call function to create payment entry
                 result = make_payment_entry(user_id, customer_email, inv, response_data)

--- a/ipay/ipay/main/utils/confirm_payment.py
+++ b/ipay/ipay/main/utils/confirm_payment.py
@@ -5,6 +5,7 @@ import logging
 import re
 import frappe
 from ipay.ipay.main.utils.ipay_logs import create_log_entry
+from ipay.ipay.main.utils.send_callback import send_callback
 
 
 logging.basicConfig(level=logging.INFO)
@@ -79,7 +80,10 @@ def confirm_payment(docid, user_id, phone, amount, order, customer_email):
                        'paid_at': data.get('paid_at'),
                        'telephone': data.get('telephone'),
                       }
-                    
+
+                    # notify the configured callback URL
+                    send_callback(data)
+
                     return {"status": "success", "message": "Payment verified", "data": data}
                   
                 else:

--- a/ipay/ipay/main/utils/ipay_logs.py
+++ b/ipay/ipay/main/utils/ipay_logs.py
@@ -20,7 +20,7 @@ def create_log_entry(log_type, description):
   try:
     log_entry = frappe.get_doc({
       "doctype": "iPay Logs",
-      "type": log_type,
+      "log_type": log_type,
       "description": description,
       "time": datetime.now()
     })

--- a/ipay/ipay/main/utils/send_callback.py
+++ b/ipay/ipay/main/utils/send_callback.py
@@ -1,0 +1,17 @@
+import requests
+import frappe
+from ipay.ipay.main.utils.ipay_logs import create_log_entry
+
+
+def send_callback(response_data):
+    """POST the payment result to the configured callback URL, if one is set."""
+    callback_url = frappe.db.get_single_value("iPay Settings", "callback_url")
+    if not callback_url:
+        return
+
+    try:
+        resp = requests.post(callback_url, json=response_data, timeout=15)
+        resp.raise_for_status()
+        create_log_entry("INF", f"Callback delivered (HTTP {resp.status_code}) to {callback_url}")
+    except requests.RequestException as error:
+        create_log_entry("ERR", f"Callback to {callback_url} failed: {error}")

--- a/ipay/ipay/main/utils/verify_mpesa_payment.py
+++ b/ipay/ipay/main/utils/verify_mpesa_payment.py
@@ -93,11 +93,10 @@ def verify_mpesa_payment(oid, phone, vid, secret_key):
             elif "The User Wallet balance is insufficient for the transaction" in error_message:
               message = "The User has insufficient funds"
               frappe.throw(message)
-              
-            elif "The transaction was timed out" in error_message:
-              message = "The transaction was timed out"
-              frappe.throw(message)
-            
+
+            # "The transaction was timed out" is transient while iPay waits for the
+            # customer to pay, so keep polling instead of aborting.
+
             logger.error(
                 f"Attempt {attempt}: Failed due to an error: {error_message}\nRetrying..."
             )


### PR DESCRIPTION
Closes #40

## Problem
The configured **Callback URL** has never received a notification for successful payments.

Two reasons:
1. The outbound POST to the callback URL existed **only** in `lipana_mpesa`'s success branch. That branch often never completes because `verify_mpesa_payment` treated iPay's transient `"The transaction was timed out"` message (returned while iPay waits for the customer to pay) as fatal and aborted.
2. The payment then gets recorded by the **"Verify Payment"** button → `confirm_payment()`, which contained **no callback code at all**.

The original POST was also fire-and-forget: no timeout, no status check, no logging — so any failure was invisible.

## What iPay actually does vs. what this app does
In this STK-push **API** integration the app sends `crl=0` (browser-redirect callback). iPay does **not** push an unsolicited server-to-server notification to `cbk` in this flow — the documented pattern is to **poll** `transaction/search` to confirm payment, which the app already does. So the only thing that ever notifies the callback URL is the **app posting to it itself**. This PR makes that app-driven notification fire reliably from every success path.

## Changes
- **New `utils/send_callback.py`** — shared helper: POST with a 15s timeout, `raise_for_status()`, and logs the outcome via `create_log_entry`.
- **`main.py`** — replace the inline fire-and-forget POST with `send_callback()` (drop now-unused `import requests`).
- **`confirm_payment.py`** — call `send_callback()` on success (the gap that caused the silence).
- **`verify_mpesa_payment.py`** — stop aborting on the transient `"transaction was timed out"`; keep polling.
- **`ipay_logs.py`** — fix `create_log_entry` writing `"type"` instead of `log_type`, so the log-level column populates.

## Known trade-offs / follow-ups (not in this PR)
- With the timeout no longer fatal, a slow/abandoned payment now polls all 20 attempts (~44s) synchronously inside the web request, which can exceed a 30s gunicorn/proxy timeout. The proper fix is to move verification to a background job.
- `send_callback` can fire twice if both "Prompt iPay" and "Verify Payment" run for the same invoice — the callback consumer should be idempotent on `transaction_code`.
- Pre-existing: `lipana_mpesa` checks `isinstance(make_payment_entry(...), dict)`, but that function returns a string/None, so it always logs "Failed to create Payment Entry" even on success.

## Testing
To be verified on dev.bulkbox.cloud: run an Mpesa Express payment via both the "Prompt iPay" and "Verify Payment" paths and confirm the n8n webhook receives the POST in both cases.