### PR TITLE
feat(ipay): idempotent make_payment_entry returning a status dict (PR-0 foundation)

### DIFF
--- a/ipay/ipay/main/utils/make_payment_entry.py
+++ b/ipay/ipay/main/utils/make_payment_entry.py
@@ -19,6 +19,26 @@ def make_payment_entry(user_id, customer_email, inv, response_data):
         if isinstance(response_data, str):
             response_data = json.loads(response_data)
 
+        # Idempotency: never create a second Payment Entry for the same M-Pesa
+        # transaction. Multiple paths (STK, manual confirm, callback) can finalise
+        # the same payment, so guard on the transaction code.
+        transaction_code = response_data.get("transaction_code")
+        if transaction_code:
+            existing = frappe.db.get_value(
+                "Payment Entry",
+                {"reference_no": transaction_code, "docstatus": ["<", 2]},
+                "name",
+            )
+            if existing:
+                logger.info(
+                    f"Payment Entry {existing} already exists for transaction {transaction_code}"
+                )
+                return {
+                    "status": "duplicate",
+                    "payment_entry": existing,
+                    "message": "Payment Entry already exists",
+                }
+
         # Fetch the Sales Invoice
         sales_invoice = frappe.get_doc("Sales Invoice", inv)
 
@@ -94,10 +114,14 @@ def make_payment_entry(user_id, customer_email, inv, response_data):
         logger.info(
             f"Payment Entry {payment_entry.name} created successfully for Sales Invoice {inv}."
         )
-        return payment_entry.name
+        return {
+            "status": "success",
+            "payment_entry": payment_entry.name,
+            "message": "Payment Entry created",
+        }
 
     except Exception as e:
         # Log the exception
         logger.error(f"Error creating Payment Entry: {str(e)}", exc_info=True)
         frappe.log_error(frappe.get_traceback(), "Payment Entry Creation Error")
-        return None
+        return {"status": "error", "payment_entry": None, "message": str(e)}


### PR DESCRIPTION
Part of #42 (PR-0, the foundation for the reconcile poller + redirect flow).

## Problem
`make_payment_entry` returned a bare string (`payment_entry.name`) on success or `None` on error. But both callers already expect a dict:
- `main.py` does `if isinstance(result, dict): result.get("status") ...` with `success`/`duplicate` branches.
- `ipay_request.js` reads `res.status`, `res.payment_entry`, `res.message`.

So the dict branches were **dead code** and every successful creation was misreported — the desk showed *"Failed to create Payment Entry"* and the portal showed *"Payment Entry Error"* even though the entry was created (this is the `"Unexpected response from make_payment_entry"` seen in the logs). There was also **no duplicate guard**, so multiple finalisation paths could create two Payment Entries for one M-Pesa transaction.

## Change (minimal)
- Return `{status, payment_entry, message}` on success/duplicate/error — the shape both callers already consume, so **no caller changes are needed**.
- Before creating, check for an existing Payment Entry with the same `reference_no` (the M-Pesa `transaction_code`); if found, return `{"status": "duplicate", ...}` instead of inserting a second one.

## Why now
This is the idempotency keystone for the next PRs: a reconcile poller and a redirect return handler can both finalise the same payment, so creation must be safe to call more than once.

## Testing
- Confirm a successful payment now shows the Payment Entry link (not "Failed to create Payment Entry").
- Re-running finalisation for the same transaction returns "duplicate" and does not create a second Payment Entry.