### PR TITLE
feat(ipay): reconcile poller — guaranteed webhook notification + Paybill auto-confirm (PR-1)

### DIFF
--- a/ipay/hooks.py
+++ b/ipay/hooks.py
@@ -138,6 +138,11 @@ scheduler_events = {
 	"daily": [
 		"ipay.ipay.main.utils.log_cleanup.del_old_logs"
 	],
+	"cron": {
+		"*/5 * * * *": [
+			"ipay.ipay.main.utils.reconcile_payments.reconcile_pending_payments"
+		]
+	},
 # 	"hourly": [
 # 		"ipay.tasks.hourly"
 # 	],

--- a/ipay/ipay/doctype/ipay_request/ipay_request.json
+++ b/ipay/ipay/doctype/ipay_request/ipay_request.json
@@ -23,7 +23,8 @@
   "transaction_details_section",
   "sales_invoice",
   "amount",
-  "route"
+  "route",
+  "callback_delivered"
  ],
  "fields": [
   {
@@ -105,7 +106,7 @@
    "fieldname": "status",
    "fieldtype": "Select",
    "label": "Status",
-   "options": "\nFailed to complete request\nSuccess\nError",
+   "options": "\nFailed to complete request\nSuccess\nError\nAmount Mismatch",
    "read_only": 1
   },
   {
@@ -152,6 +153,14 @@
    "fieldname": "published",
    "fieldtype": "Check",
    "label": "Published"
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "0",
+   "fieldname": "callback_delivered",
+   "fieldtype": "Check",
+   "label": "Callback Delivered",
+   "read_only": 1
   }
  ],
  "has_web_view": 1,

--- a/ipay/ipay/main/main.py
+++ b/ipay/ipay/main/main.py
@@ -5,7 +5,7 @@ from ipay.ipay.main.utils.trigger_stk_push import trigger_stk_push
 from ipay.ipay.main.utils.verify_mpesa_payment import verify_mpesa_payment
 from ipay.ipay.main.utils.make_payment_entry import make_payment_entry
 from ipay.ipay.main.utils.ipay_logs import create_log_entry
-from ipay.ipay.main.utils.send_callback import send_callback
+from ipay.ipay.main.utils.send_callback import deliver_callback
 import re
 
 logging.basicConfig(level=logging.INFO)
@@ -127,7 +127,7 @@ def lipana_mpesa(
                 frappe.msgprint("Payment received successfully")
 
                 # send post request to call back url
-                send_callback(response_data)
+                deliver_callback(docid, response_data)
 
                 # call function to create payment entry
                 result = make_payment_entry(user_id, customer_email, inv, response_data)

--- a/ipay/ipay/main/utils/confirm_payment.py
+++ b/ipay/ipay/main/utils/confirm_payment.py
@@ -5,7 +5,7 @@ import logging
 import re
 import frappe
 from ipay.ipay.main.utils.ipay_logs import create_log_entry
-from ipay.ipay.main.utils.send_callback import send_callback
+from ipay.ipay.main.utils.send_callback import deliver_callback
 
 
 logging.basicConfig(level=logging.INFO)
@@ -82,7 +82,7 @@ def confirm_payment(docid, user_id, phone, amount, order, customer_email):
                       }
 
                     # notify the configured callback URL
-                    send_callback(data)
+                    deliver_callback(docid, data)
 
                     return {"status": "success", "message": "Payment verified", "data": data}
                   

--- a/ipay/ipay/main/utils/reconcile_payments.py
+++ b/ipay/ipay/main/utils/reconcile_payments.py
@@ -1,0 +1,140 @@
+import re
+import hmac
+import hashlib
+import requests
+import frappe
+
+from ipay.ipay.main.utils.make_payment_entry import make_payment_entry
+from ipay.ipay.main.utils.send_callback import deliver_callback
+from ipay.ipay.main.utils.ipay_logs import create_log_entry
+
+# Order ids are derived from the Sales Invoice exactly as the original /transact
+# request did (see main.py / confirm_payment.py), so the search matches.
+UNWANTED_OID_CHARACTERS = r"[-/;:~`!%^*<&_]"
+
+# Only reconcile requests created within this window; older unconfirmed requests
+# are assumed abandoned and are left alone (so we don't poll forever).
+RECONCILE_WINDOW_HOURS = 24
+
+SEARCH_URL = "https://apis.ipayafrica.com/payments/v2/transaction/search"
+
+
+def reconcile_pending_payments():
+    """Scheduled backstop that guarantees a payment is finalised and the n8n
+    callback is delivered even when the in-session flow never completed
+    (abandoned redirect, unattended Paybill, or a failed callback).
+
+    Polls iPay for every submitted iPay Request whose callback has not yet been
+    delivered, within the reconcile window. Idempotent and safe to re-run: the
+    Payment Entry is deduped on the transaction code and the callback on the
+    callback_delivered flag.
+    """
+    window_start = frappe.utils.add_to_date(
+        frappe.utils.now_datetime(), hours=-RECONCILE_WINDOW_HOURS
+    )
+    pending = frappe.get_all(
+        "iPay Request",
+        filters={
+            "docstatus": 1,
+            "callback_delivered": 0,
+            "creation": [">", window_start],
+        },
+        fields=["name", "sales_invoice", "amount", "customer", "customer_email"],
+    )
+    if not pending:
+        return
+
+    settings = frappe.get_single("iPay Settings")
+    vid = (settings.vendor_id or "").lower()
+    secret_key = settings.api_key
+    if not vid or not secret_key:
+        create_log_entry("ERR", "Reconcile skipped: vendor id or api key not set")
+        return
+
+    for req in pending:
+        try:
+            _reconcile_one(req, vid, secret_key)
+        except Exception as error:
+            frappe.db.rollback()
+            create_log_entry("ERR", f"Reconcile failed for {req.name}: {error}")
+
+
+def _reconcile_one(req, vid, secret_key):
+    if not req.sales_invoice:
+        return
+
+    oid = re.sub(UNWANTED_OID_CHARACTERS, "", req.sales_invoice)
+    data = _search_transaction(oid, vid, secret_key)
+    if not data:
+        # Not paid yet (or not found) — leave it to retry on the next run.
+        return
+
+    response_data = {
+        "order_id": data.get("oid"),
+        "transaction_amount": data.get("transaction_amount"),
+        "transaction_code": data.get("transaction_code"),
+        "payee": data.get("firstname"),
+        "payment_mode": data.get("payment_mode"),
+        "paid_at": data.get("paid_at"),
+        "telephone": data.get("telephone"),
+    }
+
+    if _amount_matches(data.get("transaction_amount"), req.amount):
+        result = make_payment_entry(
+            req.customer, req.customer_email, req.sales_invoice, response_data
+        )
+        if result.get("status") in ("success", "duplicate"):
+            frappe.db.set_value("iPay Request", req.name, "status", "Success")
+            deliver_callback(req.name, response_data)
+            create_log_entry(
+                "INF",
+                f"Reconciled payment for {req.name} ({response_data['transaction_code']})",
+            )
+        else:
+            # Payment Entry creation failed; leave undelivered to retry next run.
+            create_log_entry(
+                "ERR",
+                f"Reconcile could not create Payment Entry for {req.name}: {result.get('message')}",
+            )
+    else:
+        # Paid, but the amount differs from the invoice — notify and flag for
+        # manual reconciliation; do not auto-create a Payment Entry.
+        frappe.db.set_value("iPay Request", req.name, "status", "Amount Mismatch")
+        deliver_callback(req.name, response_data)
+        create_log_entry(
+            "ERR",
+            f"Amount mismatch for {req.name}: paid {response_data['transaction_amount']} vs expected {req.amount}",
+        )
+
+    frappe.db.commit()
+
+
+def _search_transaction(oid, vid, secret_key):
+    """Single-shot lookup of a payment by order id. Returns the data dict if a
+    paid transaction is found, else None.
+
+    iPay returns HTTP 404 ("no record found") while a payment is still pending,
+    so a missing transaction is treated as a quiet None rather than an error;
+    only genuine transport failures raise (caught and retried by the caller).
+    """
+    hash_value = hmac.new(
+        secret_key.encode(), f"{oid}{vid}".encode(), hashlib.sha256
+    ).hexdigest()
+    resp = requests.post(
+        SEARCH_URL,
+        data={"vid": vid, "hash": hash_value, "oid": oid},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        timeout=15,
+    )
+    try:
+        data = resp.json().get("data") or {}
+    except ValueError:
+        return None
+    return data if data.get("transaction_code") else None
+
+
+def _amount_matches(transaction_amount, expected_amount):
+    try:
+        return abs(float(transaction_amount) - float(expected_amount)) < 1e-2
+    except (TypeError, ValueError):
+        return False

--- a/ipay/ipay/main/utils/send_callback.py
+++ b/ipay/ipay/main/utils/send_callback.py
@@ -4,14 +4,39 @@ from ipay.ipay.main.utils.ipay_logs import create_log_entry
 
 
 def send_callback(response_data):
-    """POST the payment result to the configured callback URL, if one is set."""
+    """POST the payment result to the configured callback URL.
+
+    Returns True when the notification is considered delivered (a 2xx response,
+    or no callback URL configured so there is nothing to deliver), and False
+    when a configured callback URL could not be reached.
+    """
     callback_url = frappe.db.get_single_value("iPay Settings", "callback_url")
     if not callback_url:
-        return
+        return True
 
     try:
         resp = requests.post(callback_url, json=response_data, timeout=15)
         resp.raise_for_status()
         create_log_entry("INF", f"Callback delivered (HTTP {resp.status_code}) to {callback_url}")
+        return True
     except requests.RequestException as error:
         create_log_entry("ERR", f"Callback to {callback_url} failed: {error}")
+        return False
+
+
+def deliver_callback(docid, response_data):
+    """Notify the n8n callback URL for an iPay Request exactly once.
+
+    Idempotent on the request's `callback_delivered` flag, so the fast paths
+    (STK success, manual confirm) and the reconcile poller never double-notify.
+    Returns True if the callback is (or was already) delivered.
+    """
+    if frappe.db.get_value("iPay Request", docid, "callback_delivered"):
+        return True
+
+    if send_callback(response_data):
+        frappe.db.set_value("iPay Request", docid, "callback_delivered", 1)
+        frappe.db.commit()
+        return True
+
+    return False


### PR DESCRIPTION
Part of #42 (PR-1). **Stacked on PR-0 #43** — review/merge #43 first; this PR's base will retarget to `main` once #43 lands.

## What this delivers
Makes the n8n callback notification a **guarantee** instead of best-effort, and **auto-confirms unattended Mpesa Paybill** payments — the same backbone needed for the redirect flow (PR-2).

## Changes
1. **Schema** (`ipay_request.json`): add a read-only `callback_delivered` flag and an `Amount Mismatch` status option.
2. **Centralised delivery** (`send_callback.py`): `send_callback` now returns whether delivery succeeded (True on 2xx or when no callback URL is configured; False on a failed configured URL). New `deliver_callback(docid, response_data)` notifies n8n **at most once**, idempotent on `callback_delivered`. The STK-success path (`main.py`) and manual confirm path (`confirm_payment.py`) now route through it, so they never double-post.
3. **Reconcile poller** (`reconcile_payments.py` + `hooks.py` cron, every 5 min): for each submitted iPay Request with `callback_delivered = 0` within a 24h window, polls `/transaction/search` by order id; on a found payment it creates the Payment Entry (deduped on transaction code via PR-0) and delivers the n8n callback. Amount mismatches are flagged `Amount Mismatch` and still notified, **without** creating a Payment Entry. A not-yet-paid lookup (iPay HTTP 404) is a quiet retry; per-request failures are isolated and rolled back.

## Design decisions (per discussion)
- **Cadence/window:** every 5 min, 24h window (aligns with iPay's "retry in ~5 min"; serves unattended Paybill; bounds polling of abandoned requests).
- **Partial/overpayment:** notify n8n + flag `Amount Mismatch`, no auto Payment Entry.
- **Guarantee model:** fast paths notify instantly and set the flag; the poller backstops anything undelivered (abandoned redirect, unattended Paybill, n8n downtime) — gated by `callback_delivered` so nothing is double-sent.

## Activation / testing notes
- Requires `bench migrate` to create the `callback_delivered` column and `Amount Mismatch` option. **Until migrated, the scheduled job is a harmless no-op** (its query errors before doing any work — no Payment Entries created).
- After migrate, the cron runs every 5 min. Suggested test: leave a submitted Paybill request unconfirmed, pay it, and confirm within ~5 min that the Payment Entry is created once and the n8n webhook receives exactly one POST. Re-running must not duplicate either.
- Overlapping runs are safe (idempotent on transaction code + `callback_delivered`); no explicit lock added.