### PR TITLE
feat(ipay): hosted-checkout redirect engine + public pages (PR-2)

### DIFF
--- a/ipay/ipay/doctype/ipay_settings/ipay_settings.json
+++ b/ipay/ipay/doctype/ipay_settings/ipay_settings.json
@@ -10,7 +10,8 @@
   "api_key",
   "callback_url",
   "is_live",
-  "request_for_cod"
+  "request_for_cod",
+  "enable_redirect"
  ],
  "fields": [
   {
@@ -43,6 +44,12 @@
    "fieldname": "request_for_cod",
    "fieldtype": "Check",
    "label": "Automatically Create iPay Request for COD Customers Enabled"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_redirect",
+   "fieldtype": "Check",
+   "label": "Use Hosted Checkout Redirect"
   }
  ],
  "index_web_pages_for_search": 1,

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -1,0 +1,80 @@
+import re
+import hmac
+import hashlib
+
+import frappe
+
+from ipay.ipay.main.utils.reconcile_payments import reconcile_request
+from ipay.ipay.main.utils.ipay_logs import create_log_entry
+
+# Hosted checkout (HTML form POST). NB: this flow uses HMAC-SHA1 over the
+# documented field order — it is NOT the REST /transact SHA256 flow.
+CHECKOUT_URL = "https://payments.ipayafrica.com/v3/ke"
+UNWANTED_OID_CHARACTERS = r"[-/;:~`!%^*<&_]"
+HASH_FIELD_ORDER = [
+    "live", "oid", "inv", "ttl", "tel", "eml", "vid",
+    "curr", "p1", "p2", "p3", "p4", "cbk", "cst", "crl",
+]
+
+
+def build_checkout_form(request_name):
+    """Build the field set (including the SHA1 hash) for an auto-submitting
+    hosted-checkout form for the given iPay Request. The request name is sent as
+    p1 so iPay echoes it back to the return handler."""
+    settings = frappe.get_single("iPay Settings")
+    req = frappe.get_doc("iPay Request", request_name)
+
+    oid = re.sub(UNWANTED_OID_CHARACTERS, "", req.sales_invoice)
+    outstanding = frappe.db.get_value(
+        "Sales Invoice", req.sales_invoice, "outstanding_amount"
+    )
+    amount = frappe.utils.flt(req.amount) or frappe.utils.flt(outstanding)
+
+    cbk = frappe.utils.get_url(
+        "/api/method/ipay.ipay.main.utils.ipay_redirect.ipay_return"
+    )
+
+    fields = {
+        "live": "1" if settings.is_live else "0",
+        "oid": oid,
+        "inv": oid,
+        "ttl": f"{amount:.2f}",
+        "tel": req.customer_phone or "",
+        "eml": req.customer_email or "",
+        "vid": (settings.vendor_id or "").lower(),
+        "curr": "KES",
+        "p1": req.name,
+        "p2": "",
+        "p3": "",
+        "p4": "",
+        "cbk": cbk,
+        "cst": "0",
+        "crl": "0",
+    }
+
+    data_string = "".join(fields[k] for k in HASH_FIELD_ORDER)
+    fields["hsh"] = hmac.new(
+        (settings.api_key or "").encode(), data_string.encode(), hashlib.sha1
+    ).hexdigest()
+
+    return CHECKOUT_URL, fields
+
+
+@frappe.whitelist(allow_guest=True)
+def ipay_return(**kwargs):
+    """Browser return target (iPay cbk). iPay redirects here via GET after the
+    customer pays. The GET status is NOT trusted: we re-verify server-side (via
+    reconcile_request -> /transaction/search) before finalising, then send the
+    customer to the result page. The poller backstops if the browser never returns."""
+    request_name = frappe.form_dict.get("p1") or frappe.form_dict.get("request")
+
+    try:
+        if request_name:
+            reconcile_request(request_name)
+    except Exception as error:
+        create_log_entry(
+            "ERR", f"iPay return handler failed for {request_name}: {error}"
+        )
+
+    frappe.local.response["type"] = "redirect"
+    frappe.local.response["location"] = f"/payment_status?request={request_name or ''}"

--- a/ipay/ipay/main/utils/reconcile_payments.py
+++ b/ipay/ipay/main/utils/reconcile_payments.py
@@ -59,6 +59,28 @@ def reconcile_pending_payments():
             create_log_entry("ERR", f"Reconcile failed for {req.name}: {error}")
 
 
+def reconcile_request(request_name):
+    """Finalise a single iPay Request on demand (used by the redirect return
+    handler). Verifies the payment, creates the Payment Entry and delivers the
+    n8n callback, reusing the same idempotent path as the scheduled poller."""
+    req = frappe.db.get_value(
+        "iPay Request",
+        request_name,
+        ["name", "sales_invoice", "amount", "customer", "customer_email"],
+        as_dict=True,
+    )
+    if not req:
+        return
+
+    settings = frappe.get_single("iPay Settings")
+    vid = (settings.vendor_id or "").lower()
+    secret_key = settings.api_key
+    if not vid or not secret_key:
+        return
+
+    _reconcile_one(req, vid, secret_key)
+
+
 def _reconcile_one(req, vid, secret_key):
     if not req.sales_invoice:
         return

--- a/ipay/www/ipay_checkout.html
+++ b/ipay/www/ipay_checkout.html
@@ -1,0 +1,22 @@
+{% extends "templates/web.html" %}
+
+{% block page_content %}
+<div class="container" style="max-width: 540px; margin-top: 60px; text-align: center;">
+  {% if disabled %}
+    <p>Hosted checkout is not enabled.</p>
+  {% elif not_found %}
+    <p>Payment request not found.</p>
+  {% else %}
+    <p>Redirecting you to iPay&hellip;</p>
+    <form id="ipay-checkout-form" method="POST" action="{{ action }}">
+      {% for key, value in fields.items() %}
+      <input type="hidden" name="{{ key }}" value="{{ value }}">
+      {% endfor %}
+      <noscript>
+        <button type="submit" class="btn btn-primary">Continue to iPay</button>
+      </noscript>
+    </form>
+    <script>document.getElementById("ipay-checkout-form").submit();</script>
+  {% endif %}
+</div>
+{% endblock %}

--- a/ipay/www/ipay_checkout.py
+++ b/ipay/www/ipay_checkout.py
@@ -1,0 +1,19 @@
+import frappe
+
+from ipay.ipay.main.utils.ipay_redirect import build_checkout_form
+
+
+def get_context(context):
+    context.no_cache = 1
+    request_name = frappe.form_dict.get("request")
+    settings = frappe.get_single("iPay Settings")
+
+    if not settings.enable_redirect:
+        context.disabled = True
+        return
+
+    if not request_name or not frappe.db.exists("iPay Request", request_name):
+        context.not_found = True
+        return
+
+    context.action, context.fields = build_checkout_form(request_name)

--- a/ipay/www/payment_status.html
+++ b/ipay/www/payment_status.html
@@ -1,0 +1,16 @@
+{% extends "templates/web.html" %}
+
+{% block page_content %}
+<div class="container" style="max-width: 540px; margin-top: 60px; text-align: center;">
+  {% if confirmed %}
+    <h2>Payment received</h2>
+    <p>Thank you. Your payment has been confirmed.</p>
+  {% elif mismatch %}
+    <h2>Payment received &mdash; under review</h2>
+    <p>We received a payment with a different amount than expected. Our team will reconcile it shortly.</p>
+  {% else %}
+    <h2>Confirming your payment&hellip;</h2>
+    <p>If you have paid, your payment is being confirmed and will reflect within a few minutes.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/ipay/www/payment_status.py
+++ b/ipay/www/payment_status.py
@@ -1,0 +1,13 @@
+import frappe
+
+
+def get_context(context):
+    context.no_cache = 1
+    request_name = frappe.form_dict.get("request")
+
+    status = None
+    if request_name and frappe.db.exists("iPay Request", request_name):
+        status = frappe.db.get_value("iPay Request", request_name, "status")
+
+    context.confirmed = status == "Success"
+    context.mismatch = status == "Amount Mismatch"


### PR DESCRIPTION
Part of #42 (PR-2). **Stacked on PR-1 #44** (which is stacked on PR-0 #43). Merge order: #43 → #44 → this. Bases will retarget as each lands.

## What this delivers
The redirect engine: an operator/customer can be sent to iPay's hosted page to pay, and the payment is finalised + n8n-notified on return — with the reconcile poller (PR-1) guaranteeing it even if the browser never comes back.

Validated live: the SHA1 `v3/ke` form is accepted by iPay (demo returned the hosted checkout page), and `build_checkout_form` produces a correct 40-char hash, stripped `oid`, and `p1`=request name on a real request.

## Changes
1. **`enable_redirect` toggle** in iPay Settings ("Use Hosted Checkout Redirect"). Off = current STK/Paybill behaviour unchanged.
2. **`ipay_redirect.py`**:
   - `build_checkout_form(request)` — builds the `v3/ke` field set + **HMAC-SHA1** hash (field order `live oid inv ttl tel eml vid curr p1 p2 p3 p4 cbk cst crl`); sends the request name as `p1` so iPay echoes it back; `cbk` points at the return handler.
   - `ipay_return` (`allow_guest`) — iPay's browser return target. **Does not trust the GET status**; re-verifies server-side via `reconcile_request` → `/transaction/search`, finalises idempotently, then redirects to the result page.
   - `reconcile_request(name)` (added to the poller) — single-request finaliser shared by the return handler and the scheduled poller.
3. **Public pages**: `/ipay_checkout?request=<name>` (auto-submits the form, gated by the toggle) and `/payment_status?request=<name>` (confirmed / under review / still confirming).

## Security model
The return handler is unauthenticated by necessity (iPay redirects an arbitrary browser back), so it treats the GET purely as a trigger and **finalises only on a server-side `/transaction/search` confirmation** keyed on the request's own `oid`. A forged return cannot create a fake payment or Payment Entry. n8n delivery and Payment Entry creation are both idempotent (PR-0/PR-1).

## Deferred to PR-3 (proposed)
The **delivery-team listing page** (multiple invoices, "Prompt Payment" per row) is a thin UI layer that simply links to `/ipay_checkout?request=<name>`. Kept separate so this PR stays focused on the (hash-confirmed) engine. For now the entry point is the `/ipay_checkout?request=<name>` URL directly.

## Activation / testing notes
- Needs `bench migrate` for the `enable_redirect` field; then enable it in iPay Settings.
- Confirm the site `host_name` is `https://…` so `cbk` is HTTPS.
- Test: open `/ipay_checkout?request=<submitted request>` → pay on iPay (demo: vid=demo) → confirm redirect back to `/payment_status`, exactly one Payment Entry, one n8n POST. If the browser is closed mid-flow, the poller should still finalise + notify within ~5 min.