### PR TITLE
feat(ipay): delivery-team payment collection page (PR-3)

### DIFF
--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -78,3 +78,27 @@ def ipay_return(**kwargs):
 
     frappe.local.response["type"] = "redirect"
     frappe.local.response["location"] = f"/payment_status?request={request_name or ''}"
+
+
+@frappe.whitelist()
+def start_checkout(invoice):
+    """Operator action from the collection page: ensure a submitted iPay Request
+    exists for the invoice, then send the browser to the hosted checkout."""
+    request_name = frappe.db.get_value(
+        "iPay Request", {"sales_invoice": invoice, "docstatus": 1}, "name"
+    )
+    if not request_name:
+        invoice_doc = frappe.get_doc("Sales Invoice", invoice)
+        request = frappe.get_doc(
+            {
+                "doctype": "iPay Request",
+                "customer": invoice_doc.customer,
+                "sales_invoice": invoice,
+                "docstatus": 1,
+            }
+        )
+        request.insert(ignore_permissions=True)
+        request_name = request.name
+
+    frappe.local.response["type"] = "redirect"
+    frappe.local.response["location"] = f"/ipay_checkout?request={request_name}"

--- a/ipay/www/collect_payments.html
+++ b/ipay/www/collect_payments.html
@@ -1,0 +1,38 @@
+{% extends "templates/web.html" %}
+
+{% block page_content %}
+<div class="container" style="max-width: 720px; margin-top: 40px;">
+  <h2>Collect Payment</h2>
+  <p class="text-muted">Select an invoice to prompt the customer for payment via iPay.</p>
+
+  {% if invoices %}
+  <table class="table table-bordered" style="margin-top: 20px;">
+    <thead>
+      <tr>
+        <th>Invoice</th>
+        <th>Customer</th>
+        <th class="text-right">Outstanding</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for inv in invoices %}
+      <tr>
+        <td>{{ inv.name }}</td>
+        <td>{{ inv.customer_name }}</td>
+        <td class="text-right">{{ "%.2f"|format(inv.outstanding_amount) }}</td>
+        <td class="text-right">
+          <a class="btn btn-primary btn-sm"
+             href="/api/method/ipay.ipay.main.utils.ipay_redirect.start_checkout?invoice={{ inv.name }}">
+            Prompt Payment
+          </a>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p style="margin-top: 20px;">No invoices awaiting payment.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -1,0 +1,23 @@
+import frappe
+
+# Roles allowed to use the collection page.
+ALLOWED_ROLES = {"System Manager", "iPay Manager", "iPay User"}
+
+
+def get_context(context):
+    context.no_cache = 1
+
+    if frappe.session.user == "Guest":
+        frappe.local.flags.redirect_location = "/login?redirect-to=/collect_payments"
+        raise frappe.Redirect
+
+    if not (ALLOWED_ROLES & set(frappe.get_roles())):
+        frappe.throw("You are not permitted to collect payments.", frappe.PermissionError)
+
+    context.invoices = frappe.get_all(
+        "Sales Invoice",
+        filters={"docstatus": 1, "is_return": 0, "outstanding_amount": [">", 0]},
+        fields=["name", "customer_name", "outstanding_amount", "posting_date"],
+        order_by="posting_date desc",
+        limit_page_length=50,
+    )


### PR DESCRIPTION
Part of #42 (PR-3). **Stacked on PR-2 #45** (→ #44 → #43). Merge order: #43 → #44 → #45 → this.

## What this delivers
The operator-facing entry point for the redirect flow: a page the delivery team opens to prompt a customer for payment.

## Changes
- **`/collect_payments`** (`www/collect_payments`): login + iPay-role gated page (`System Manager` / `iPay Manager` / `iPay User`; guests are redirected to login). Lists submitted, non-return Sales Invoices with `outstanding_amount > 0` (most recent 50). Each row has a **Prompt Payment** action.
- **`start_checkout(invoice)`** (in `ipay_redirect.py`): ensures a submitted iPay Request exists for the invoice (find-or-create, following the app's existing `docstatus: 1` insert pattern), then redirects the browser to `/ipay_checkout?request=<name>` — which auto-submits the SHA1 form to iPay (PR-2).

## Flow
`/collect_payments` → tap **Prompt Payment** → `start_checkout` (ensures request) → `/ipay_checkout` (auto-submit to iPay) → customer pays → iPay returns to `ipay_return` → re-verify + finalise + notify n8n → `/payment_status`. The PR-1 poller backstops if the browser never returns.

## Tunable / noted
- **Invoice filter** is intentionally simple (submitted + unpaid + not-return). Refine to the real delivery scope (e.g. by driver/route/COD) as needed.
- `start_checkout` is reachable via GET so a plain link works (no CSRF token needed); creating an iPay Request is benign and idempotent per invoice, but it can be switched to POST if you prefer.
- Needs the same `bench migrate` + `enable_redirect` toggle as PR-2 to function end to end.

## Testing
Log in as an iPay user, open `/collect_payments`, tap Prompt Payment on an unpaid invoice, and confirm you land on iPay's hosted page; complete payment and confirm `/payment_status`, a single Payment Entry, and one n8n POST.