### PR TITLE
feat(ipay): collect-payments UX — dual action, search, delivery note, auto-return (PR-4)

### DIFF
--- a/ipay/ipay/doctype/ipay_request/ipay_request.json
+++ b/ipay/ipay/doctype/ipay_request/ipay_request.json
@@ -24,7 +24,8 @@
   "sales_invoice",
   "amount",
   "route",
-  "callback_delivered"
+  "callback_delivered",
+  "result_detail"
  ],
  "fields": [
   {
@@ -160,6 +161,13 @@
    "fieldname": "callback_delivered",
    "fieldtype": "Check",
    "label": "Callback Delivered",
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "result_detail",
+   "fieldtype": "Small Text",
+   "label": "Result Detail",
    "read_only": 1
   }
  ],

--- a/ipay/ipay/main/main.py
+++ b/ipay/ipay/main/main.py
@@ -122,7 +122,16 @@ def lipana_mpesa(
                 logger.info("response_data: %s", response_data)
 
                 # set status to success on the ipay request and show success message
-                frappe.db.set_value("iPay Request", docid, "status", "Success")
+                result_detail = (
+                    f"KES {response_data.get('transaction_amount')} received from "
+                    f"{response_data.get('payee')} ({response_data.get('telephone')}) — "
+                    f"M-Pesa ref {response_data.get('transaction_code')}, {response_data.get('paid_at')}"
+                )
+                frappe.db.set_value(
+                    "iPay Request",
+                    docid,
+                    {"status": "Success", "result_detail": result_detail},
+                )
                 frappe.db.commit()
                 frappe.msgprint("Payment received successfully")
 
@@ -181,7 +190,11 @@ def lipana_mpesa(
             create_log_entry(
                 "ERR", f"An error occurred during the payment proces: {error}"
             )
-            # set status to error
-            frappe.db.set_value("iPay Request", docid, "status", "Error")
+            # set status to error and record the reason for the operator
+            frappe.db.set_value(
+                "iPay Request",
+                docid,
+                {"status": "Error", "result_detail": str(error)},
+            )
             frappe.db.commit()
             # frappe.throw("An error occurred during the payment process")

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -1,7 +1,6 @@
 import re
 import hmac
 import hashlib
-from urllib.parse import quote
 
 import frappe
 
@@ -16,6 +15,21 @@ HASH_FIELD_ORDER = [
     "live", "oid", "inv", "ttl", "tel", "eml", "vid",
     "curr", "p1", "p2", "p3", "p4", "cbk", "cst", "crl",
 ]
+
+
+def normalize_phone(phone):
+    """Normalise a Kenyan number to MSISDN form (2547XXXXXXXX / 2541XXXXXXXX):
+    strip non-digits and the leading +/0, so iPay charges a consistent number."""
+    digits = re.sub(r"\D", "", phone or "")
+    if not digits:
+        return ""
+    if digits.startswith("254"):
+        return digits
+    if digits.startswith("0"):
+        return "254" + digits[1:]
+    if digits.startswith(("7", "1")):
+        return "254" + digits
+    return digits
 
 
 def build_checkout_form(request_name, phone=None):
@@ -44,7 +58,7 @@ def build_checkout_form(request_name, phone=None):
         "oid": oid,
         "inv": oid,
         "ttl": f"{amount:.2f}",
-        "tel": (phone or req.customer_phone or "").strip(),
+        "tel": normalize_phone(phone or req.customer_phone),
         "eml": req.customer_email or "",
         "vid": (settings.vendor_id or "").lower(),
         "curr": "KES",
@@ -108,16 +122,14 @@ def _ensure_request(invoice):
 
 
 @frappe.whitelist()
-def start_checkout(invoice, phone=None):
+def start_checkout(invoice):
     """Operator action from the collection page: ensure a submitted iPay Request
-    exists for the invoice, then send the browser to the hosted checkout. An
-    optional phone (the number that will pay) is passed through to the form."""
+    exists for the invoice, then send the browser to the hosted checkout. The
+    payer's number defaults to the customer's number on file (iPay requires a
+    tel); the checkout page asks for one only if none is on file."""
     request_name = _ensure_request(invoice)
-    location = f"/ipay_checkout?request={request_name}"
-    if phone:
-        location += "&phone=" + quote(phone)
     frappe.local.response["type"] = "redirect"
-    frappe.local.response["location"] = location
+    frappe.local.response["location"] = f"/ipay_checkout?request={request_name}"
 
 
 @frappe.whitelist()
@@ -134,7 +146,7 @@ def prompt_mpesa(invoice, phone=None):
         as_dict=True,
     )
 
-    phone = phone or req.customer_phone
+    phone = normalize_phone(phone or req.customer_phone)
     if not phone:
         return {"status": "error", "message": "No phone number on file for this customer."}
 

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -39,7 +39,10 @@ def build_checkout_form(request_name):
         "oid": oid,
         "inv": oid,
         "ttl": f"{amount:.2f}",
-        "tel": req.customer_phone or "",
+        # Leave tel blank: iPay locks the M-Pesa phone field (readOnlyMpesa) to
+        # whatever tel we send. Omitting it lets the payer enter their own number
+        # on the hosted page; the payment is still tied to the invoice via oid.
+        "tel": "",
         "eml": req.customer_email or "",
         "vid": (settings.vendor_id or "").lower(),
         "curr": "KES",

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -163,5 +163,22 @@ def prompt_mpesa(invoice, phone=None):
     )
     return {
         "status": "sent",
+        "request": request_name,
         "message": "M-Pesa prompt sent to the customer. The payment will confirm automatically.",
+    }
+
+
+@frappe.whitelist()
+def payment_state(request):
+    """Lightweight poll target for the collection page: report whether a request
+    has been paid/failed yet and the human-readable result detail."""
+    row = frappe.db.get_value(
+        "iPay Request", request, ["status", "result_detail"], as_dict=True
+    ) or {}
+    status = row.get("status") or ""
+    return {
+        "status": status,
+        "paid": status == "Success",
+        "failed": status in ("Error", "Failed to complete request"),
+        "detail": row.get("result_detail") or "",
     }

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -80,25 +80,67 @@ def ipay_return(**kwargs):
     frappe.local.response["location"] = f"/payment_status?request={request_name or ''}"
 
 
+def _ensure_request(invoice):
+    """Return the name of a submitted iPay Request for the invoice, creating one
+    if none exists yet."""
+    request_name = frappe.db.get_value(
+        "iPay Request", {"sales_invoice": invoice, "docstatus": 1}, "name"
+    )
+    if request_name:
+        return request_name
+
+    invoice_doc = frappe.get_doc("Sales Invoice", invoice)
+    request = frappe.get_doc(
+        {
+            "doctype": "iPay Request",
+            "customer": invoice_doc.customer,
+            "sales_invoice": invoice,
+            "docstatus": 1,
+        }
+    )
+    request.insert(ignore_permissions=True)
+    return request.name
+
+
 @frappe.whitelist()
 def start_checkout(invoice):
     """Operator action from the collection page: ensure a submitted iPay Request
     exists for the invoice, then send the browser to the hosted checkout."""
-    request_name = frappe.db.get_value(
-        "iPay Request", {"sales_invoice": invoice, "docstatus": 1}, "name"
-    )
-    if not request_name:
-        invoice_doc = frappe.get_doc("Sales Invoice", invoice)
-        request = frappe.get_doc(
-            {
-                "doctype": "iPay Request",
-                "customer": invoice_doc.customer,
-                "sales_invoice": invoice,
-                "docstatus": 1,
-            }
-        )
-        request.insert(ignore_permissions=True)
-        request_name = request.name
-
+    request_name = _ensure_request(invoice)
     frappe.local.response["type"] = "redirect"
     frappe.local.response["location"] = f"/ipay_checkout?request={request_name}"
+
+
+@frappe.whitelist()
+def prompt_mpesa(invoice, phone=None):
+    """Operator action: send an M-Pesa STK push for the invoice (creating the
+    iPay Request if needed). The STK + verify flow is enqueued on a background
+    worker so the web request returns immediately (the verify loop can exceed the
+    30s gunicorn timeout); the reconcile poller backstops finalisation."""
+    request_name = _ensure_request(invoice)
+    req = frappe.db.get_value(
+        "iPay Request",
+        request_name,
+        ["customer", "customer_phone", "customer_email", "amount", "sales_invoice"],
+        as_dict=True,
+    )
+
+    phone = phone or req.customer_phone
+    if not phone:
+        return {"status": "error", "message": "No phone number on file for this customer."}
+
+    frappe.enqueue(
+        "ipay.ipay.main.main.lipana_mpesa",
+        queue="long",
+        docid=request_name,
+        user_id=req.customer,
+        phone=phone,
+        amount=req.amount,
+        oid=req.sales_invoice,
+        customer_email=req.customer_email,
+        payment_request_type="Mpesa Express",
+    )
+    return {
+        "status": "sent",
+        "message": "M-Pesa prompt sent to the customer. The payment will confirm automatically.",
+    }

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -1,6 +1,7 @@
 import re
 import hmac
 import hashlib
+from urllib.parse import quote
 
 import frappe
 
@@ -17,10 +18,14 @@ HASH_FIELD_ORDER = [
 ]
 
 
-def build_checkout_form(request_name):
+def build_checkout_form(request_name, phone=None):
     """Build the field set (including the SHA1 hash) for an auto-submitting
     hosted-checkout form for the given iPay Request. The request name is sent as
-    p1 so iPay echoes it back to the return handler."""
+    p1 so iPay echoes it back to the return handler.
+
+    iPay requires `tel` and locks the M-Pesa phone field to it, so the paying
+    number must be decided here (before redirect): use the caller-supplied phone
+    if given, else the customer's number on file."""
     settings = frappe.get_single("iPay Settings")
     req = frappe.get_doc("iPay Request", request_name)
 
@@ -39,10 +44,7 @@ def build_checkout_form(request_name):
         "oid": oid,
         "inv": oid,
         "ttl": f"{amount:.2f}",
-        # Leave tel blank: iPay locks the M-Pesa phone field (readOnlyMpesa) to
-        # whatever tel we send. Omitting it lets the payer enter their own number
-        # on the hosted page; the payment is still tied to the invoice via oid.
-        "tel": "",
+        "tel": (phone or req.customer_phone or "").strip(),
         "eml": req.customer_email or "",
         "vid": (settings.vendor_id or "").lower(),
         "curr": "KES",
@@ -106,12 +108,16 @@ def _ensure_request(invoice):
 
 
 @frappe.whitelist()
-def start_checkout(invoice):
+def start_checkout(invoice, phone=None):
     """Operator action from the collection page: ensure a submitted iPay Request
-    exists for the invoice, then send the browser to the hosted checkout."""
+    exists for the invoice, then send the browser to the hosted checkout. An
+    optional phone (the number that will pay) is passed through to the form."""
     request_name = _ensure_request(invoice)
+    location = f"/ipay_checkout?request={request_name}"
+    if phone:
+        location += "&phone=" + quote(phone)
     frappe.local.response["type"] = "redirect"
-    frappe.local.response["location"] = f"/ipay_checkout?request={request_name}"
+    frappe.local.response["location"] = location
 
 
 @frappe.whitelist()

--- a/ipay/www/collect_payments.html
+++ b/ipay/www/collect_payments.html
@@ -9,6 +9,8 @@
       <h3 class="card-title mb-1">Collect Payment</h3>
       <p class="text-muted">Prompt a customer for payment via iPay. Choose M-Pesa (STK) or the iPay checkout page.</p>
 
+      <div id="ipay-alerts"></div>
+
       <input type="text" id="ipay-search" class="form-control mb-3"
              placeholder="Search by invoice, customer or delivery note…" autocomplete="off">
 
@@ -26,7 +28,7 @@
           </thead>
           <tbody>
             {% for inv in invoices %}
-            <tr>
+            <tr data-invoice="{{ inv.name }}">
               <td>{{ inv.name }}</td>
               <td>{{ inv.customer_name }}</td>
               <td>{{ inv.delivery_note or "" }}</td>
@@ -57,26 +59,62 @@
 </div>
 
 <script>
+function ipayNotify(message, type) {
+  var c = document.getElementById("ipay-alerts");
+  if (!c) { return; }
+  var div = document.createElement("div");
+  div.className = "alert alert-" + (type || "info") + " alert-dismissible";
+  div.innerHTML = message +
+    ' <button type="button" class="close" onclick="this.parentNode.remove()">&times;</button>';
+  c.prepend(div);
+}
+
+function ipayRemoveRow(invoice) {
+  var row = document.querySelector('#ipay-invoice-table tbody tr[data-invoice="' + invoice + '"]');
+  if (row) { row.remove(); }
+}
+
+function ipayPoll(request, invoice) {
+  var tries = 0, max = 25;
+  var iv = setInterval(function () {
+    tries++;
+    frappe.call({
+      method: "ipay.ipay.main.utils.ipay_redirect.payment_state",
+      args: { request: request },
+      callback: function (r) {
+        var s = r.message || {};
+        if (s.paid) {
+          clearInterval(iv);
+          ipayNotify("<strong>Payment received</strong> &mdash; " + (s.detail || invoice), "success");
+          ipayRemoveRow(invoice);
+        } else if (s.failed) {
+          clearInterval(iv);
+          ipayNotify("<strong>Payment failed</strong> (" + invoice + ") &mdash; " + (s.detail || "no reason given"), "danger");
+        } else if (tries >= max) {
+          clearInterval(iv);
+          ipayNotify("Still awaiting payment for " + invoice + ". It will confirm automatically if the customer pays.", "warning");
+        }
+      }
+    });
+  }, 4000);
+}
+
 function ipayPromptMpesa(invoice) {
   var phone = prompt("Customer phone for M-Pesa (leave blank to use the number on file):", "");
   if (phone === null) { return; }
   frappe.call({
     method: "ipay.ipay.main.utils.ipay_redirect.prompt_mpesa",
     args: { invoice: invoice, phone: phone },
-    callback: function(r) {
+    callback: function (r) {
       var res = r.message || {};
-      frappe.msgprint(res.message || "Done.");
+      if (res.status === "error") {
+        ipayNotify("Cannot prompt " + invoice + ": " + (res.message || "unknown error"), "danger");
+        return;
+      }
+      ipayNotify("M-Pesa prompt sent for " + invoice + ". Waiting for the customer to pay&hellip;", "info");
+      if (res.request) { ipayPoll(res.request, invoice); }
     }
   });
-}
-
-function ipayRedirect(invoice) {
-  // iPay requires a phone and locks it on its page, so capture it here.
-  var phone = prompt("M-Pesa number that will pay (leave blank to use the number on file):", "");
-  if (phone === null) { return; }
-  var url = "/api/method/ipay.ipay.main.utils.ipay_redirect.start_checkout?invoice=" + encodeURIComponent(invoice);
-  if (phone) { url += "&phone=" + encodeURIComponent(phone); }
-  window.location = url;
 }
 
 (function() {

--- a/ipay/www/collect_payments.html
+++ b/ipay/www/collect_payments.html
@@ -3,42 +3,71 @@
 {% block title %}Collect Payment{% endblock %}
 
 {% block page_content %}
-<div class="container" style="max-width: 960px; margin-top: 40px; margin-bottom: 60px;">
-  <div class="card shadow-sm">
-    <div class="card-body">
-      <h3 class="card-title mb-1">Collect Payment</h3>
-      <p class="text-muted">Prompt a customer for payment. Pick the option that matches how they want to pay.</p>
+<style>
+  .ipay-collect { max-width: 920px; margin: 40px auto 60px; }
+  .ipay-collect .ipay-card { border: none; border-radius: 14px; box-shadow: 0 8px 30px rgba(17, 24, 39, .08); }
+  .ipay-collect h3 { font-weight: 600; letter-spacing: -.01em; }
+  .ipay-help-toggle { cursor: pointer; color: #4a5568; font-size: .9rem; user-select: none; display: inline-block; }
+  .ipay-help-toggle:hover { color: #2b6cb0; }
+  .ipay-help { background: #f7fafc; border: 1px solid #edf2f7; border-radius: 10px; padding: 14px 18px; margin-top: 10px; }
+  .ipay-help ul { padding-left: 1.1rem; margin-bottom: 0; }
+  .ipay-help li + li { margin-top: 8px; }
+  .ipay-search { position: relative; margin-top: 18px; }
+  .ipay-search .ipay-search-icon { position: absolute; left: 14px; top: 50%; transform: translateY(-50%); opacity: .45; }
+  .ipay-search input { border-radius: 10px; padding-left: 40px; height: 46px; }
+  .ipay-table { margin-top: 20px; }
+  .ipay-table thead th { border-top: none; border-bottom: 2px solid #edf2f7; font-size: .74rem; text-transform: uppercase;
+    letter-spacing: .04em; color: #94a3b8; padding-top: .5rem; padding-bottom: .5rem; }
+  .ipay-table td { vertical-align: middle; padding-top: .85rem; padding-bottom: .85rem; }
+  .ipay-table tbody tr:hover { background: #f8fafc; }
+  .ipay-inv { font-weight: 600; color: #1f2937; }
+  .ipay-dn { color: #94a3b8; font-size: .85rem; }
+  .ipay-amount { font-weight: 600; font-variant-numeric: tabular-nums; color: #1f2937; }
+  .ipay-actions .btn { border-radius: 8px; font-weight: 500; }
+  .ipay-empty { text-align: center; color: #94a3b8; padding: 48px 0; }
+  #ipay-alerts:not(:empty) { margin-top: 16px; }
+  @media (max-width: 576px) { .ipay-collect { margin: 16px; } .ipay-collect .card-body { padding: 1.25rem !important; } }
+</style>
 
-      <div class="card bg-light mb-3">
-        <div class="card-body py-2">
-          <strong>Which option should I use?</strong>
-          <ul class="mb-0 mt-2 small" style="padding-left: 1.1rem;">
-            <li class="mb-1">
-              <span class="badge badge-success">Prompt M-Pesa</span>
-              Sends an M-Pesa PIN prompt straight to the customer's phone — they just enter their PIN.
-              Use this for M-Pesa: you can charge <em>any</em> M-Pesa number (you'll be asked for it), and
-              the result — success with the payment details, or the reason it failed — appears on this page.
-            </li>
-            {% if enable_redirect %}
-            <li>
-              <span class="badge badge-primary">Pay via iPay</span>
-              Opens iPay's secure checkout page where the customer can pay by <strong>card, Airtel Money or M-Pesa</strong>.
-              Use this for cards or Airtel. Note: on that page the M-Pesa number is fixed to the customer's saved
-              number — to charge a <em>different</em> M-Pesa number, use <span class="badge badge-success">Prompt M-Pesa</span> instead.
-            </li>
-            {% endif %}
-          </ul>
-        </div>
+<div class="ipay-collect">
+  <div class="card ipay-card">
+    <div class="card-body p-4">
+      <h3 class="mb-1">Collect Payment</h3>
+      <p class="text-muted mb-2">Prompt a customer for payment. Pick the option that matches how they want to pay.</p>
+
+      <span class="ipay-help-toggle" onclick="ipayToggleHelp()">
+        <span id="ipay-help-caret">&#9656;</span> Which option should I use?
+      </span>
+      <div class="ipay-help" id="ipay-help" style="display: none;">
+        <ul class="small">
+          <li>
+            <span class="badge badge-success">Prompt M-Pesa</span>
+            Sends an M-Pesa PIN prompt straight to the customer's phone — they just enter their PIN.
+            You can charge <em>any</em> M-Pesa number (you'll be asked for it), and the result —
+            success with the payment details, or the reason it failed — appears on this page.
+          </li>
+          {% if enable_redirect %}
+          <li>
+            <span class="badge badge-primary">Pay via iPay</span>
+            Opens iPay's secure checkout where the customer can pay by <strong>card, Airtel Money or M-Pesa</strong>.
+            Use this for cards or Airtel. On that page the M-Pesa number is fixed to the customer's saved number —
+            to charge a <em>different</em> M-Pesa number, use <span class="badge badge-success">Prompt M-Pesa</span>.
+          </li>
+          {% endif %}
+        </ul>
       </div>
 
       <div id="ipay-alerts"></div>
 
-      <input type="text" id="ipay-search" class="form-control mb-3"
-             placeholder="Search by invoice, customer or delivery note…" autocomplete="off">
+      <div class="ipay-search">
+        <span class="ipay-search-icon">&#128269;</span>
+        <input type="text" id="ipay-search" class="form-control"
+               placeholder="Search invoice, customer or delivery note…" autocomplete="off">
+      </div>
 
       {% if invoices %}
       <div class="table-responsive">
-        <table class="table table-hover align-middle" id="ipay-invoice-table">
+        <table class="table ipay-table" id="ipay-invoice-table">
           <thead>
             <tr>
               <th>Invoice</th>
@@ -51,11 +80,11 @@
           <tbody>
             {% for inv in invoices %}
             <tr data-invoice="{{ inv.name }}">
-              <td>{{ inv.name }}</td>
+              <td class="ipay-inv">{{ inv.name }}</td>
               <td>{{ inv.customer_name }}</td>
-              <td>{{ inv.delivery_note or "" }}</td>
-              <td class="text-right">{{ "{:,.2f}".format(inv.outstanding_amount) }}</td>
-              <td class="text-right" style="white-space: nowrap;">
+              <td class="ipay-dn">{{ inv.delivery_note or "—" }}</td>
+              <td class="text-right ipay-amount">{{ "{:,.2f}".format(inv.outstanding_amount) }}</td>
+              <td class="text-right ipay-actions" style="white-space: nowrap;">
                 <button type="button" class="btn btn-success btn-sm"
                         onclick="ipayPromptMpesa('{{ inv.name }}')">
                   Prompt M-Pesa
@@ -72,15 +101,24 @@
           </tbody>
         </table>
       </div>
-      <p class="text-muted small mb-0" id="ipay-no-match" style="display:none;">No invoices match your search.</p>
+      <p class="ipay-empty" id="ipay-no-match" style="display: none;">No invoices match your search.</p>
       {% else %}
-      <p class="text-muted">No invoices awaiting payment.</p>
+      <div class="ipay-empty">No invoices awaiting payment.</div>
       {% endif %}
     </div>
   </div>
 </div>
 
 <script>
+function ipayToggleHelp() {
+  var box = document.getElementById("ipay-help");
+  var caret = document.getElementById("ipay-help-caret");
+  if (!box) { return; }
+  var open = box.style.display !== "none";
+  box.style.display = open ? "none" : "block";
+  if (caret) { caret.innerHTML = open ? "&#9656;" : "&#9662;"; }
+}
+
 function ipayNotify(message, type) {
   var c = document.getElementById("ipay-alerts");
   if (!c) { return; }
@@ -139,14 +177,14 @@ function ipayPromptMpesa(invoice) {
   });
 }
 
-(function() {
+(function () {
   var search = document.getElementById("ipay-search");
   if (!search) { return; }
-  search.addEventListener("keyup", function() {
+  search.addEventListener("keyup", function () {
     var q = this.value.toLowerCase();
     var rows = document.querySelectorAll("#ipay-invoice-table tbody tr");
     var shown = 0;
-    rows.forEach(function(row) {
+    rows.forEach(function (row) {
       var match = row.textContent.toLowerCase().indexOf(q) > -1;
       row.style.display = match ? "" : "none";
       if (match) { shown++; }

--- a/ipay/www/collect_payments.html
+++ b/ipay/www/collect_payments.html
@@ -37,10 +37,10 @@
                   Prompt M-Pesa
                 </button>
                 {% if enable_redirect %}
-                <button type="button" class="btn btn-primary btn-sm"
-                        onclick="ipayRedirect('{{ inv.name }}')">
+                <a class="btn btn-primary btn-sm"
+                   href="/api/method/ipay.ipay.main.utils.ipay_redirect.start_checkout?invoice={{ inv.name }}">
                   Pay via iPay
-                </button>
+                </a>
                 {% endif %}
               </td>
             </tr>

--- a/ipay/www/collect_payments.html
+++ b/ipay/www/collect_payments.html
@@ -37,10 +37,10 @@
                   Prompt M-Pesa
                 </button>
                 {% if enable_redirect %}
-                <a class="btn btn-primary btn-sm"
-                   href="/api/method/ipay.ipay.main.utils.ipay_redirect.start_checkout?invoice={{ inv.name }}">
+                <button type="button" class="btn btn-primary btn-sm"
+                        onclick="ipayRedirect('{{ inv.name }}')">
                   Pay via iPay
-                </a>
+                </button>
                 {% endif %}
               </td>
             </tr>
@@ -68,6 +68,15 @@ function ipayPromptMpesa(invoice) {
       frappe.msgprint(res.message || "Done.");
     }
   });
+}
+
+function ipayRedirect(invoice) {
+  // iPay requires a phone and locks it on its page, so capture it here.
+  var phone = prompt("M-Pesa number that will pay (leave blank to use the number on file):", "");
+  if (phone === null) { return; }
+  var url = "/api/method/ipay.ipay.main.utils.ipay_redirect.start_checkout?invoice=" + encodeURIComponent(invoice);
+  if (phone) { url += "&phone=" + encodeURIComponent(phone); }
+  window.location = url;
 }
 
 (function() {

--- a/ipay/www/collect_payments.html
+++ b/ipay/www/collect_payments.html
@@ -7,7 +7,29 @@
   <div class="card shadow-sm">
     <div class="card-body">
       <h3 class="card-title mb-1">Collect Payment</h3>
-      <p class="text-muted">Prompt a customer for payment via iPay. Choose M-Pesa (STK) or the iPay checkout page.</p>
+      <p class="text-muted">Prompt a customer for payment. Pick the option that matches how they want to pay.</p>
+
+      <div class="card bg-light mb-3">
+        <div class="card-body py-2">
+          <strong>Which option should I use?</strong>
+          <ul class="mb-0 mt-2 small" style="padding-left: 1.1rem;">
+            <li class="mb-1">
+              <span class="badge badge-success">Prompt M-Pesa</span>
+              Sends an M-Pesa PIN prompt straight to the customer's phone — they just enter their PIN.
+              Use this for M-Pesa: you can charge <em>any</em> M-Pesa number (you'll be asked for it), and
+              the result — success with the payment details, or the reason it failed — appears on this page.
+            </li>
+            {% if enable_redirect %}
+            <li>
+              <span class="badge badge-primary">Pay via iPay</span>
+              Opens iPay's secure checkout page where the customer can pay by <strong>card, Airtel Money or M-Pesa</strong>.
+              Use this for cards or Airtel. Note: on that page the M-Pesa number is fixed to the customer's saved
+              number — to charge a <em>different</em> M-Pesa number, use <span class="badge badge-success">Prompt M-Pesa</span> instead.
+            </li>
+            {% endif %}
+          </ul>
+        </div>
+      </div>
 
       <div id="ipay-alerts"></div>
 

--- a/ipay/www/collect_payments.html
+++ b/ipay/www/collect_payments.html
@@ -1,38 +1,90 @@
 {% extends "templates/web.html" %}
 
-{% block page_content %}
-<div class="container" style="max-width: 720px; margin-top: 40px;">
-  <h2>Collect Payment</h2>
-  <p class="text-muted">Select an invoice to prompt the customer for payment via iPay.</p>
+{% block title %}Collect Payment{% endblock %}
 
-  {% if invoices %}
-  <table class="table table-bordered" style="margin-top: 20px;">
-    <thead>
-      <tr>
-        <th>Invoice</th>
-        <th>Customer</th>
-        <th class="text-right">Outstanding</th>
-        <th></th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for inv in invoices %}
-      <tr>
-        <td>{{ inv.name }}</td>
-        <td>{{ inv.customer_name }}</td>
-        <td class="text-right">{{ "%.2f"|format(inv.outstanding_amount) }}</td>
-        <td class="text-right">
-          <a class="btn btn-primary btn-sm"
-             href="/api/method/ipay.ipay.main.utils.ipay_redirect.start_checkout?invoice={{ inv.name }}">
-            Prompt Payment
-          </a>
-        </td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-  {% else %}
-  <p style="margin-top: 20px;">No invoices awaiting payment.</p>
-  {% endif %}
+{% block page_content %}
+<div class="container" style="max-width: 960px; margin-top: 40px; margin-bottom: 60px;">
+  <div class="card shadow-sm">
+    <div class="card-body">
+      <h3 class="card-title mb-1">Collect Payment</h3>
+      <p class="text-muted">Prompt a customer for payment via iPay. Choose M-Pesa (STK) or the iPay checkout page.</p>
+
+      <input type="text" id="ipay-search" class="form-control mb-3"
+             placeholder="Search by invoice, customer or delivery note…" autocomplete="off">
+
+      {% if invoices %}
+      <div class="table-responsive">
+        <table class="table table-hover align-middle" id="ipay-invoice-table">
+          <thead>
+            <tr>
+              <th>Invoice</th>
+              <th>Customer</th>
+              <th>Delivery Note</th>
+              <th class="text-right">Outstanding</th>
+              <th class="text-right">Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for inv in invoices %}
+            <tr>
+              <td>{{ inv.name }}</td>
+              <td>{{ inv.customer_name }}</td>
+              <td>{{ inv.delivery_note or "" }}</td>
+              <td class="text-right">{{ "{:,.2f}".format(inv.outstanding_amount) }}</td>
+              <td class="text-right" style="white-space: nowrap;">
+                <button type="button" class="btn btn-success btn-sm"
+                        onclick="ipayPromptMpesa('{{ inv.name }}')">
+                  Prompt M-Pesa
+                </button>
+                {% if enable_redirect %}
+                <a class="btn btn-primary btn-sm"
+                   href="/api/method/ipay.ipay.main.utils.ipay_redirect.start_checkout?invoice={{ inv.name }}">
+                  Pay via iPay
+                </a>
+                {% endif %}
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      <p class="text-muted small mb-0" id="ipay-no-match" style="display:none;">No invoices match your search.</p>
+      {% else %}
+      <p class="text-muted">No invoices awaiting payment.</p>
+      {% endif %}
+    </div>
+  </div>
 </div>
+
+<script>
+function ipayPromptMpesa(invoice) {
+  var phone = prompt("Customer phone for M-Pesa (leave blank to use the number on file):", "");
+  if (phone === null) { return; }
+  frappe.call({
+    method: "ipay.ipay.main.utils.ipay_redirect.prompt_mpesa",
+    args: { invoice: invoice, phone: phone },
+    callback: function(r) {
+      var res = r.message || {};
+      frappe.msgprint(res.message || "Done.");
+    }
+  });
+}
+
+(function() {
+  var search = document.getElementById("ipay-search");
+  if (!search) { return; }
+  search.addEventListener("keyup", function() {
+    var q = this.value.toLowerCase();
+    var rows = document.querySelectorAll("#ipay-invoice-table tbody tr");
+    var shown = 0;
+    rows.forEach(function(row) {
+      var match = row.textContent.toLowerCase().indexOf(q) > -1;
+      row.style.display = match ? "" : "none";
+      if (match) { shown++; }
+    });
+    var none = document.getElementById("ipay-no-match");
+    if (none) { none.style.display = shown ? "none" : ""; }
+  });
+})();
+</script>
 {% endblock %}

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -14,10 +14,27 @@ def get_context(context):
     if not (ALLOWED_ROLES & set(frappe.get_roles())):
         frappe.throw("You are not permitted to collect payments.", frappe.PermissionError)
 
-    context.invoices = frappe.get_all(
+    invoices = frappe.get_all(
         "Sales Invoice",
         filters={"docstatus": 1, "is_return": 0, "outstanding_amount": [">", 0]},
         fields=["name", "customer_name", "outstanding_amount", "posting_date"],
         order_by="posting_date desc",
-        limit_page_length=50,
+        limit_page_length=100,
     )
+
+    # Attach the delivery note(s) linked to each invoice (one batched query).
+    if invoices:
+        names = [inv.name for inv in invoices]
+        links = frappe.get_all(
+            "Sales Invoice Item",
+            filters={"parent": ["in", names], "delivery_note": ["is", "set"]},
+            fields=["parent", "delivery_note"],
+        )
+        dn_map = {}
+        for link in links:
+            dn_map.setdefault(link.parent, set()).add(link.delivery_note)
+        for inv in invoices:
+            inv.delivery_note = ", ".join(sorted(dn_map.get(inv.name, [])))
+
+    context.invoices = invoices
+    context.enable_redirect = frappe.db.get_single_value("iPay Settings", "enable_redirect")

--- a/ipay/www/ipay_checkout.html
+++ b/ipay/www/ipay_checkout.html
@@ -7,8 +7,13 @@
   {% elif not_found %}
     <p>Payment request not found.</p>
   {% elif phone_required %}
-    <p>A phone number is required to start the iPay checkout.</p>
-    <a href="/collect_payments" class="btn btn-primary">Go back</a>
+    <p>This customer has no phone number on file. Enter the number to use for this payment:</p>
+    <form method="GET" action="/ipay_checkout">
+      <input type="hidden" name="request" value="{{ request_name }}">
+      <input type="tel" name="phone" class="form-control mb-2" placeholder="e.g. 0712345678"
+             required style="max-width: 280px; margin: 0 auto;">
+      <button type="submit" class="btn btn-primary">Continue</button>
+    </form>
   {% else %}
     <p>Redirecting you to iPay&hellip;</p>
     <form id="ipay-checkout-form" method="POST" action="{{ action }}">

--- a/ipay/www/ipay_checkout.html
+++ b/ipay/www/ipay_checkout.html
@@ -6,6 +6,9 @@
     <p>Hosted checkout is not enabled.</p>
   {% elif not_found %}
     <p>Payment request not found.</p>
+  {% elif phone_required %}
+    <p>A phone number is required to start the iPay checkout.</p>
+    <a href="/collect_payments" class="btn btn-primary">Go back</a>
   {% else %}
     <p>Redirecting you to iPay&hellip;</p>
     <form id="ipay-checkout-form" method="POST" action="{{ action }}">

--- a/ipay/www/ipay_checkout.py
+++ b/ipay/www/ipay_checkout.py
@@ -21,6 +21,7 @@ def get_context(context):
     # iPay requires a telephone number; if none was supplied or on file, ask for one.
     if not fields.get("tel"):
         context.phone_required = True
+        context.request_name = request_name
         return
 
     context.action = action

--- a/ipay/www/ipay_checkout.py
+++ b/ipay/www/ipay_checkout.py
@@ -16,4 +16,12 @@ def get_context(context):
         context.not_found = True
         return
 
-    context.action, context.fields = build_checkout_form(request_name)
+    action, fields = build_checkout_form(request_name, frappe.form_dict.get("phone"))
+
+    # iPay requires a telephone number; if none was supplied or on file, ask for one.
+    if not fields.get("tel"):
+        context.phone_required = True
+        return
+
+    context.action = action
+    context.fields = fields

--- a/ipay/www/payment_status.html
+++ b/ipay/www/payment_status.html
@@ -1,16 +1,40 @@
 {% extends "templates/web.html" %}
 
+{% block title %}Payment Status{% endblock %}
+
 {% block page_content %}
-<div class="container" style="max-width: 540px; margin-top: 60px; text-align: center;">
-  {% if confirmed %}
-    <h2>Payment received</h2>
-    <p>Thank you. Your payment has been confirmed.</p>
-  {% elif mismatch %}
-    <h2>Payment received &mdash; under review</h2>
-    <p>We received a payment with a different amount than expected. Our team will reconcile it shortly.</p>
-  {% else %}
-    <h2>Confirming your payment&hellip;</h2>
-    <p>If you have paid, your payment is being confirmed and will reflect within a few minutes.</p>
-  {% endif %}
+<div class="container" style="max-width: 540px; margin-top: 60px; margin-bottom: 60px; text-align: center;">
+  <div class="card shadow-sm">
+    <div class="card-body" style="padding: 40px 24px;">
+      {% if confirmed %}
+        <h2 class="text-success">Payment received</h2>
+        <p>Thank you. The payment has been confirmed.</p>
+      {% elif mismatch %}
+        <h2 class="text-warning">Payment received &mdash; under review</h2>
+        <p>We received a payment with a different amount than expected. Our team will reconcile it shortly.</p>
+      {% else %}
+        <h2>Confirming the payment&hellip;</h2>
+        <p>If payment was made, it is being confirmed and will reflect within a few minutes.</p>
+      {% endif %}
+
+      <a href="/collect_payments" class="btn btn-primary mt-3">Collect another payment</a>
+      <p class="text-muted small mt-3">Returning to the collection page in <span id="ipay-countdown">15</span>s&hellip;</p>
+    </div>
+  </div>
 </div>
+
+<script>
+(function() {
+  var remaining = 15;
+  var el = document.getElementById("ipay-countdown");
+  var timer = setInterval(function() {
+    remaining -= 1;
+    if (el) { el.textContent = remaining; }
+    if (remaining <= 0) {
+      clearInterval(timer);
+      window.location = "/collect_payments";
+    }
+  }, 1000);
+})();
+</script>
 {% endblock %}


### PR DESCRIPTION
Part of #42 (PR-4). **Stacked on PR-3 #46** (→ #45 → #44 → #43).

Enhancements to the collection page requested for field use:

1. **Optional action per invoice** — each row offers **Prompt M-Pesa** (STK) and **Pay via iPay** (hosted redirect). The redirect button shows only when `enable_redirect` is on; M-Pesa is always available.
2. **Auto-create iPay Request** — both actions ensure a submitted iPay Request exists for the invoice (`_ensure_request`), so invoices without one work on first click.
3. **Delivery Note column** — resolved via a single batched `Sales Invoice Item` lookup.
4. **Search** — client-side filter across invoice / customer / delivery note.
5. **Paid invoices drop off** — list is filtered to `outstanding_amount > 0`; combined with the new 15s auto-return, a paid invoice disappears on the next load. (If you actually want paid invoices to *remain* visible with a "Paid" badge, say so — one-line change.)
6. **Result page** — `/payment_status` now auto-returns to `/collect_payments` after 15s and has a **Collect another payment** button.

### Key implementation note
The M-Pesa option **enqueues** `lipana_mpesa` on the `long` queue rather than calling it inline: the STK verify loop can take ~40s, which would exceed the **30s gunicorn timeout**. The web request returns immediately ("prompt sent; confirms automatically"), the background worker runs STK → verify → Payment Entry → n8n, and the reconcile poller backstops. This reuses the existing flow end-to-end.

### Testing
Open `/collect_payments` (logged in, iPay role): search works; "Prompt M-Pesa" sends the STK (enter/confirm the phone) and confirms in the background; "Pay via iPay" redirects to the hosted page and returns to `/payment_status`, which bounces back to the list in 15s. Paid invoices no longer appear.