### PR TITLE
feat(ipay): derive iPay order id from request name (bundling PR-A)

### DIFF
--- a/ipay/ipay/doctype/ipay_request/ipay_request_dashboard.py
+++ b/ipay/ipay/doctype/ipay_request/ipay_request_dashboard.py
@@ -5,9 +5,9 @@ def get_data():
     return {
         "fieldname": "ipay_request",
         "internal_links": {
-            "Sales Invoice": ["sales_invoice"],
-            "Payment Entry": ["payment_entry"],
-            "Driver": ["driver"],
+            "Sales Invoice": "sales_invoice",
+            "Payment Entry": "payment_entry",
+            "Driver": "driver",
         },
         "transactions": [
             {"label": _("Payment"), "items": ["Payment Entry"]},

--- a/ipay/ipay/main/main.py
+++ b/ipay/ipay/main/main.py
@@ -56,7 +56,7 @@ def lipana_mpesa(
     # check if payemnt_request_tyoe is Mpesa Paybill
     if payment_request_type == "Mpesa Paybill":
         # get session id
-        response = get_sid(vid, secret_key, amount, oid, phone)
+        response = get_sid(vid, secret_key, amount, oid, phone, eml=customer_email, sales_invoice=inv)
         sid = response.get("data", {})
 
         if not sid:
@@ -80,7 +80,7 @@ def lipana_mpesa(
 
         try:
             # get session id
-            response = get_sid(vid, secret_key, amount, oid, phone)
+            response = get_sid(vid, secret_key, amount, oid, phone, eml=customer_email, sales_invoice=inv)
             sid = response.get("data", {}).get("sid")
 
             if not sid:

--- a/ipay/ipay/main/main.py
+++ b/ipay/ipay/main/main.py
@@ -32,15 +32,16 @@ def lipana_mpesa(
     # log in frappe
     create_log_entry("INF", f"Payment prompt initiated for Ipay Request : {docid}")
 
-    # Variable to maintain the order id
+    # Keep the Sales Invoice for the Payment Entry, but derive the iPay order id
+    # from the iPay Request name so it is unique per request. (A balance/repeat
+    # request for the same invoice then gets its own order id instead of a
+    # colliding one, and bundles that span several invoices still have one oid.)
     inv = oid
     logger.info(f"Invoice: {inv}")
 
-    # Remove unwanted characters from oid
-    # Expected output for oid: ACC-SINV-2024-00002 is ACCSINV202400002
     unwanted_characters = r"[-/;:~`!%^*<&_]"
-    oid = re.sub(unwanted_characters, "", oid)
-    logger.info(f"Cleaned OID: {oid}")
+    oid = re.sub(unwanted_characters, "", docid)
+    logger.info(f"Cleaned OID (from request {docid}): {oid}")
 
     # get vendor details
     vendor = frappe.get_doc("iPay Settings")

--- a/ipay/ipay/main/utils/confirm_payment.py
+++ b/ipay/ipay/main/utils/confirm_payment.py
@@ -26,10 +26,10 @@ def confirm_payment(docid, user_id, phone, amount, order, customer_email):
     vid = vendor.vendor_id.lower()   # Must be lowercase
     secret_key = vendor.api_key
     
-    # Remove unwanted characters from oid
+    # Order id is the iPay Request name (must match what was sent at initiation).
     unwanted_characters = r'[-/;:~`!%^*<&_]'
-    oid = re.sub(unwanted_characters, '', order)
-    logger.info(f"Cleaned OID: {oid}")
+    oid = re.sub(unwanted_characters, '', docid)
+    logger.info(f"Cleaned OID (from request {docid}): {oid}")
     
     try:
         # Generate hash for verification

--- a/ipay/ipay/main/utils/get_sid.py
+++ b/ipay/ipay/main/utils/get_sid.py
@@ -1,3 +1,4 @@
+import re
 import requests
 import hmac
 import hashlib
@@ -7,13 +8,20 @@ import frappe
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-def get_sid(vid: str, secret_key: str, amount: str, oid: str, phone: str) -> dict:
+UNWANTED_OID_CHARACTERS = r"[-/;:~`!%^*<&_]"
+
+def get_sid(vid: str, secret_key: str, amount: str, oid: str, phone: str, eml: str = "", sales_invoice: str = None) -> dict:
     try:
-        inv = oid
-        
-        # Fetch Sales Invoice email
-        eml = frappe.db.get_value("Sales Invoice", inv, "contact_email") or ""
-        
+        # 'oid' is the iPay Request name (the search key). The iPay 'inv' field is
+        # the (cleaned) Sales Invoice, kept as metadata for iPay's records.
+        inv = re.sub(UNWANTED_OID_CHARACTERS, "", sales_invoice) if sales_invoice else oid
+
+        # Customer email: prefer the value passed in; fall back to the invoice's
+        # contact email looked up by the REAL invoice name (never the oid).
+        if not eml and sales_invoice:
+            eml = frappe.db.get_value("Sales Invoice", sales_invoice, "contact_email") or ""
+        eml = eml or ""
+
         # Fetch iPay Settings once
         ipay_settings = frappe.get_single("iPay Settings")
         

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -52,7 +52,8 @@ def build_checkout_form(request_name, phone=None):
     settings = frappe.get_single("iPay Settings")
     req = frappe.get_doc("iPay Request", request_name)
 
-    oid = re.sub(UNWANTED_OID_CHARACTERS, "", req.sales_invoice)
+    # Order id is the iPay Request name (unique per request), not the invoice.
+    oid = re.sub(UNWANTED_OID_CHARACTERS, "", req.name)
     outstanding = frappe.db.get_value(
         "Sales Invoice", req.sales_invoice, "outstanding_amount"
     )

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -66,7 +66,7 @@ def build_checkout_form(request_name, phone=None):
     fields = {
         "live": "1" if settings.is_live else "0",
         "oid": oid,
-        "inv": oid,
+        "inv": re.sub(UNWANTED_OID_CHARACTERS, "", req.sales_invoice),
         "ttl": f"{amount:.2f}",
         "tel": normalize_phone(phone or req.customer_phone),
         "eml": req.customer_email or "",

--- a/ipay/ipay/main/utils/reconcile_payments.py
+++ b/ipay/ipay/main/utils/reconcile_payments.py
@@ -8,8 +8,8 @@ from ipay.ipay.main.utils.make_payment_entry import make_payment_entry
 from ipay.ipay.main.utils.send_callback import deliver_callback
 from ipay.ipay.main.utils.ipay_logs import create_log_entry
 
-# Order ids are derived from the Sales Invoice exactly as the original /transact
-# request did (see main.py / confirm_payment.py), so the search matches.
+# Order ids are derived from the iPay Request name exactly as the original
+# /transact request did (see main.py / ipay_redirect.py), so the search matches.
 UNWANTED_OID_CHARACTERS = r"[-/;:~`!%^*<&_]"
 
 # Only reconcile requests created within this window; older unconfirmed requests

--- a/ipay/ipay/main/utils/reconcile_payments.py
+++ b/ipay/ipay/main/utils/reconcile_payments.py
@@ -85,7 +85,8 @@ def _reconcile_one(req, vid, secret_key):
     if not req.sales_invoice:
         return
 
-    oid = re.sub(UNWANTED_OID_CHARACTERS, "", req.sales_invoice)
+    # Order id is the iPay Request name (matches what initiation sent to iPay).
+    oid = re.sub(UNWANTED_OID_CHARACTERS, "", req.name)
     data = _search_transaction(oid, vid, secret_key)
     if not data:
         # Not paid yet (or not found) — leave it to retry on the next run.


### PR DESCRIPTION
Part of #42 — **PR-A**, the foundation for multi-invoice bundling. Stacked on #48.

## Why
The iPay `oid` was `re.sub(sales_invoice)` at both initiation and verification. Problems:
- **Collision on repeat prompts** — prompting one invoice twice (e.g. a *balance re-request* after a partial payment) produces the **same oid**, so `/transaction/search` can return the *wrong/old* payment.
- **Bundles** that span several invoices have no single invoice to key on.

## Change
Derive the `oid` from the **iPay Request name** (unique per request) at all four points — `lipana_mpesa`, `build_checkout_form`, `confirm_payment`, and the reconcile poller — so initiation and verification still use the *same* oid. The Sales Invoice is still used to create the Payment Entry (`inv`).

## Safety
- Verification: a 3-flow adversarial trace (STK / Paybill / redirect) + judge is confirming initiation-oid == verification-oid on every path; I'll fold in any required fix before this merges.
- **Deploy caveat:** unpaid in-flight requests created *before* this change were initiated with the old (invoice-based) oid, so the poller won't reconcile them by the new oid. Deploy when no payments are mid-flight, or let them be handled manually. Paid requests are unaffected.

## Next
PR-B: child-table model + multi-reference allocation (oldest-first; partial → re-requestable balance; overpayment → customer credit). PR-C: bundle/split UI.