### PR TITLE
feat(ipay): multi-invoice bundling + payment-term-aware allocation (PR-B)

### DIFF
--- a/ipay/ipay/doctype/ipay_request/ipay_request.json
+++ b/ipay/ipay/doctype/ipay_request/ipay_request.json
@@ -23,6 +23,7 @@
   "transaction_details_section",
   "sales_invoice",
   "amount",
+  "invoices",
   "route",
   "callback_delivered",
   "result_detail",
@@ -103,6 +104,13 @@
    "in_preview": 1,
    "in_standard_filter": 1,
    "label": "Amount"
+  },
+  {
+   "description": "Invoices covered by this request. Populated for bundled (multi-invoice) payments; a single-invoice request leaves this empty and uses Sales Invoice above.",
+   "fieldname": "invoices",
+   "fieldtype": "Table",
+   "label": "Invoices",
+   "options": "iPay Request Invoice"
   },
   {
    "allow_on_submit": 1,

--- a/ipay/ipay/doctype/ipay_request_invoice/ipay_request_invoice.json
+++ b/ipay/ipay/doctype/ipay_request_invoice/ipay_request_invoice.json
@@ -1,0 +1,42 @@
+{
+ "actions": [],
+ "creation": "2026-06-01 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "sales_invoice",
+  "outstanding_amount"
+ ],
+ "fields": [
+  {
+   "columns": 7,
+   "fieldname": "sales_invoice",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Sales Invoice",
+   "options": "Sales Invoice",
+   "reqd": 1
+  },
+  {
+   "columns": 3,
+   "fetch_from": "sales_invoice.outstanding_amount",
+   "fieldname": "outstanding_amount",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Outstanding",
+   "read_only": 1
+  }
+ ],
+ "istable": 1,
+ "links": [],
+ "modified": "2026-06-01 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Ipay",
+ "name": "iPay Request Invoice",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/ipay/ipay/doctype/ipay_request_invoice/ipay_request_invoice.py
+++ b/ipay/ipay/doctype/ipay_request_invoice/ipay_request_invoice.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Gatura Njenga and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class iPayRequestInvoice(Document):
+	pass

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -219,6 +219,54 @@ def get_payment_link(invoice=None, request=None):
 
 
 @frappe.whitelist()
+def create_bundle(customer, invoices):
+    """Create one submitted iPay Request covering several of a customer's
+    invoices. amount = sum of their live outstanding; the oldest invoice is the
+    primary. Payment is allocated oldest-first across them by make_payment_entry."""
+    _require_operator()
+
+    if isinstance(invoices, str):
+        invoices = frappe.parse_json(invoices)
+    invoices = [name for name in (invoices or []) if name]
+    if not invoices:
+        frappe.throw("Select at least one invoice.")
+
+    rows = []
+    total = 0.0
+    for name in invoices:
+        si = frappe.db.get_value(
+            "Sales Invoice", name, ["customer", "outstanding_amount", "posting_date"], as_dict=True
+        )
+        if not si:
+            continue
+        if si.customer != customer:
+            frappe.throw(f"Invoice {name} does not belong to {customer}.")
+        if frappe.utils.flt(si.outstanding_amount) <= 0:
+            continue
+        rows.append((si.posting_date, name))
+        total += frappe.utils.flt(si.outstanding_amount)
+
+    if not rows:
+        frappe.throw("None of the selected invoices have an outstanding balance.")
+
+    rows.sort()
+    primary = rows[0][1]
+
+    request = frappe.get_doc(
+        {
+            "doctype": "iPay Request",
+            "customer": customer,
+            "sales_invoice": primary,
+            "amount": f"{total:.2f}",
+            "invoices": [{"sales_invoice": name} for _, name in rows],
+            "docstatus": 1,
+        }
+    )
+    request.insert(ignore_permissions=True)
+    return {"request": request.name, "amount": f"{total:.2f}", "count": len(rows)}
+
+
+@frappe.whitelist()
 def prompt_mpesa(invoice, phone=None):
     """Operator action (collection page): send an M-Pesa STK push for an invoice."""
     _require_operator()

--- a/ipay/ipay/main/utils/make_payment_entry.py
+++ b/ipay/ipay/main/utils/make_payment_entry.py
@@ -41,28 +41,88 @@ def make_payment_entry(user_id, customer_email, inv, response_data, ipay_request
                     "message": "Payment Entry already exists",
                 }
 
-        # Fetch the Sales Invoice
-        sales_invoice = frappe.get_doc("Sales Invoice", inv)
+        flt = frappe.utils.flt
 
-        # Get the payment term from the sales invoice
-        payment_terms = getattr(sales_invoice, "payment_terms_template", None)
+        # Resolve the invoices this payment covers: a bundle uses the iPay
+        # Request's child table; a single request uses the one Sales Invoice.
+        invoice_names = []
+        if ipay_request:
+            invoice_names = [
+                name
+                for name in frappe.get_all(
+                    "iPay Request Invoice",
+                    filters={"parent": ipay_request, "parenttype": "iPay Request"},
+                    pluck="sales_invoice",
+                )
+                if name
+            ]
+        if not invoice_names:
+            invoice_names = [inv]
 
-        if not payment_terms:
-            logger.warning(
-                f"Payment Terms not found for Sales Invoice {inv}, defaulting to 'Cash on Delivery'"
-            )
-            payment_terms = "Cash on Delivery"
+        # Pull live invoice data and allocate oldest-first against current
+        # outstanding (so an invoice paid elsewhere meanwhile is skipped).
+        invoices = sorted(
+            (
+                frappe.db.get_value(
+                    "Sales Invoice",
+                    name,
+                    ["name", "outstanding_amount", "posting_date", "customer", "customer_name"],
+                    as_dict=True,
+                )
+                for name in invoice_names
+            ),
+            key=lambda si: (si.posting_date, si.name),
+        )
+        primary = invoices[0]
 
-        logger.info(f"Sales Invoice {inv} - Payment Terms: {payment_terms}")
+        transaction_amount = flt(response_data.get("transaction_amount", 0))
+        remaining = transaction_amount
+        references = []
+        for si in invoices:
+            if remaining <= 0:
+                break
+            if flt(si.outstanding_amount) <= 0:
+                continue
 
-        # Fetch the cash account
-        # cash_account = frappe.get_value("Account", {"account_type": "Cash","company": sales_invoice.company, "is_group": 0}, "name")
+            # Invoices with payment terms must allocate per term (oldest due
+            # first) and carry the payment_term on the reference; others take a
+            # single reference.
+            terms = [
+                t
+                for t in frappe.get_all(
+                    "Payment Schedule",
+                    filters={"parent": si.name, "parenttype": "Sales Invoice"},
+                    fields=["payment_term", "outstanding"],
+                    order_by="due_date asc",
+                )
+                if flt(t.outstanding) > 0
+            ]
+            if terms:
+                for term in terms:
+                    if remaining <= 0:
+                        break
+                    allocated = min(remaining, flt(term.outstanding))
+                    references.append(
+                        {
+                            "reference_doctype": "Sales Invoice",
+                            "reference_name": si.name,
+                            "payment_term": term.payment_term,
+                            "allocated_amount": allocated,
+                        }
+                    )
+                    remaining = flt(remaining - allocated)
+            else:
+                allocated = min(remaining, flt(si.outstanding_amount))
+                references.append(
+                    {
+                        "reference_doctype": "Sales Invoice",
+                        "reference_name": si.name,
+                        "allocated_amount": allocated,
+                    }
+                )
+                remaining = flt(remaining - allocated)
+
         cash_account = "Cash - TSL"
-
-        # logger.info(f"Cash Account: {cash_account}")
-        if not cash_account:
-            logger.error(f"Cash Account not found")
-            frappe.log_error(f"Cash Account not found", "Payment Entry Creation Error")
 
         # Create a new Payment Entry
         payment_entry = frappe.new_doc("Payment Entry")
@@ -71,39 +131,32 @@ def make_payment_entry(user_id, customer_email, inv, response_data, ipay_request
         payment_entry.posting_date = frappe.utils.today()
         payment_entry.mode_of_payment = "MPESA"
         payment_entry.party_type = "Customer"
-        payment_entry.party = sales_invoice.customer
-        payment_entry.party_name = sales_invoice.customer_name
+        payment_entry.party = primary.customer
+        payment_entry.party_name = primary.customer_name
         payment_entry.paid_to = cash_account
 
-        # Transaction amount
-        transaction_amount = float(response_data.get("transaction_amount", 0))
         payment_entry.paid_amount = transaction_amount
         payment_entry.source_exchange_rate = 1.0
         payment_entry.base_paid_amount = transaction_amount
         payment_entry.received_amount = transaction_amount
         payment_entry.target_exchange_rate = 1.0
         payment_entry.base_received_amount = transaction_amount
-        payment_entry.unallocated_amount = transaction_amount
+        # Whatever could not be allocated to an invoice (overpayment) stays as
+        # unallocated customer credit. ERPNext recomputes this on validate.
+        payment_entry.unallocated_amount = remaining
         payment_entry.reference_no = response_data.get("transaction_code", "")
         payment_entry.reference_date = response_data.get(
             "paid_at", frappe.utils.today()
         )
         payment_entry.custom_remarks = 1
+        allocated_to = ", ".join(r["reference_name"] for r in references) or primary.name
         payment_entry.remarks = (
-            f"Amount KES {transaction_amount} received from {sales_invoice.customer} - {response_data.get('payee')} against Sales Invoice {sales_invoice.name}\n"
+            f"Amount KES {transaction_amount} received from {primary.customer} - {response_data.get('payee')} against {allocated_to}\n"
             f"Transaction reference no {response_data.get('transaction_code', '')} dated {response_data.get('paid_at', frappe.utils.today())}"
         )
 
-        # Add references (linked Sales Invoice)
-        payment_entry.append(
-            "references",
-            {
-                "reference_doctype": "Sales Invoice",
-                "reference_name": sales_invoice.name,
-                "allocated_amount": transaction_amount,
-                "payment_term": payment_terms,
-            },
-        )
+        for ref in references:
+            payment_entry.append("references", ref)
 
         # Add deductions (if any)
         payment_entry.deductions = []

--- a/ipay/ipay/main/utils/reconcile_payments.py
+++ b/ipay/ipay/main/utils/reconcile_payments.py
@@ -102,32 +102,30 @@ def _reconcile_one(req, vid, secret_key):
         "telephone": data.get("telephone"),
     }
 
-    if _amount_matches(data.get("transaction_amount"), req.amount):
-        result = make_payment_entry(
-            req.customer, req.customer_email, req.sales_invoice, response_data, ipay_request=req.name
-        )
-        if result.get("status") in ("success", "duplicate"):
-            frappe.db.set_value("iPay Request", req.name, "status", "Success")
-            deliver_callback(req.name, response_data)
-            create_log_entry(
-                "INF",
-                f"Reconciled payment for {req.name} ({response_data['transaction_code']})",
-            )
-        else:
-            # Payment Entry creation failed; leave undelivered to retry next run.
-            create_log_entry(
-                "ERR",
-                f"Reconcile could not create Payment Entry for {req.name}: {result.get('message')}",
-            )
-    else:
-        # Paid, but the amount differs from the invoice — notify and flag for
-        # manual reconciliation; do not auto-create a Payment Entry.
-        frappe.db.set_value("iPay Request", req.name, "status", "Amount Mismatch")
-        deliver_callback(req.name, response_data)
+    # A payment was found — record it. make_payment_entry allocates oldest-first
+    # against live outstanding, so a partial payment clears the oldest invoices and
+    # leaves the rest as a re-requestable balance, and an overpayment becomes
+    # customer credit. Mark Success when it covers the expected amount, otherwise
+    # Amount Mismatch (still recorded + notified, balance/credit handled).
+    result = make_payment_entry(
+        req.customer, req.customer_email, req.sales_invoice, response_data, ipay_request=req.name
+    )
+    if result.get("status") not in ("success", "duplicate"):
+        # Payment Entry creation failed; leave undelivered to retry next run.
         create_log_entry(
             "ERR",
-            f"Amount mismatch for {req.name}: paid {response_data['transaction_amount']} vs expected {req.amount}",
+            f"Reconcile could not create Payment Entry for {req.name}: {result.get('message')}",
         )
+        return
+
+    matched = _amount_matches(data.get("transaction_amount"), req.amount)
+    frappe.db.set_value("iPay Request", req.name, "status", "Success" if matched else "Amount Mismatch")
+    deliver_callback(req.name, response_data)
+    create_log_entry(
+        "INF" if matched else "ERR",
+        f"Reconciled {req.name} ({response_data['transaction_code']}): "
+        f"paid {response_data['transaction_amount']} vs expected {req.amount}",
+    )
 
     frappe.db.commit()
 


### PR DESCRIPTION
Part of #42 — **PR-B**, multi-invoice bundling. Stacked on PR-A #49.

## What
- **`iPay Request Invoice`** child doctype + an `invoices` table on iPay Request — one request can cover several invoices (a *bundle*); a single-invoice request leaves the table empty.
- **`make_payment_entry` rewritten as a general allocator**: one Payment Entry, allocated **oldest-invoice-first** against *live* outstanding, and within a payment-term invoice **oldest-due-term-first** (each reference carries its `payment_term`). Partial → leaves a **re-requestable balance**; overpayment → **unallocated customer credit**.
- **`create_bundle(customer, invoices)`** — build a submitted bundled request (amount = sum of live outstanding; oldest invoice primary).
- **Reconcile poller** now records *any* found payment (allocation handles partial/over), flagging `Amount Mismatch` for non-exact amounts but still creating the PE + notifying n8n.

## Why payment-term-aware
Credit-limit customers (the bundling use case) have invoices with payment-term allocation enabled — ERPNext then requires a `payment_term` on each PE reference. The previous single-reference code (and the original) failed on these.

## Verification
On a real payment-term invoice (rolled back): Full → full ref, 0 unallocated; Partial → half allocated, balance remains; Over → full allocated, remainder as credit. Allocation math passes 6 cases incl. oldest-first bundle splits.

**Still to test live:** a real *multi-invoice* bundle submit (needs invoices whose company matches the configured \`Cash - TSL\` account). The cash account is hardcoded — a follow-up should derive it per company.

## Next
PR-C: UI to select a customer's invoices and create/split a bundle on the collect page.