### PR TITLE
feat(ipay): bundling UI, payment-finalisation refactor + status taxonomy, and operational APIs

### DIFF
--- a/ipay/api.py
+++ b/ipay/api.py
@@ -1,0 +1,50 @@
+"""Public iPay API for other applications.
+
+A thin, authenticated surface over the iPay transaction lookup so any external
+app can confirm a payment and read its details with a single call.
+"""
+
+import requests
+import frappe
+from frappe import _
+
+from ipay.ipay.main.utils.reconcile_payments import _search_transaction
+
+
+@frappe.whitelist()
+def get_transaction(oid):
+    """Return iPay payment details for an order id (``oid``).
+
+    Looks the payment up on iPay (scoped to this site's vendor account) and
+    returns a small, easy-to-consume envelope::
+
+        {
+          "oid":  "<the oid queried>",
+          "paid": true | false,
+          "data": { ...full iPay record... } | null
+        }
+
+    ``paid`` is True only when iPay has a completed transaction for the oid.
+    ``data`` carries the full iPay record (transaction_amount, transaction_code,
+    firstname/lastname, telephone, payment_mode, paid_at, ...), or is null when
+    no payment has been recorded for the oid yet.
+
+    Authenticated endpoint (not public): the calling application authenticates
+    with a Frappe API key/secret, e.g.
+        Authorization: token <api_key>:<api_secret>
+    """
+    if not oid:
+        frappe.throw(_("An oid is required."))
+
+    settings = frappe.get_single("iPay Settings")
+    vid = (settings.vendor_id or "").lower()
+    secret_key = settings.api_key
+    if not vid or not secret_key:
+        frappe.throw(_("iPay vendor id or API key is not configured."))
+
+    try:
+        data = _search_transaction(oid, vid, secret_key)
+    except requests.RequestException as error:
+        frappe.throw(_("Could not reach iPay: {0}").format(error))
+
+    return {"oid": oid, "paid": bool(data), "data": data}

--- a/ipay/ipay/doctype/ipay_logs/ipay_logs.json
+++ b/ipay/ipay/doctype/ipay_logs/ipay_logs.json
@@ -38,7 +38,7 @@
   },
   {
    "fieldname": "time",
-   "fieldtype": "Data",
+   "fieldtype": "Datetime",
    "in_filter": 1,
    "in_list_view": 1,
    "in_preview": 1,

--- a/ipay/ipay/doctype/ipay_request/ipay_request.js
+++ b/ipay/ipay/doctype/ipay_request/ipay_request.js
@@ -281,62 +281,37 @@ function confirmPayment(frm) {
             const { status, message, data } = r.message;
 
             if (status === 'success') {
-               // Extract transaction details
+               // confirm_payment now records the Payment Entry server-side and
+               // returns it, so just surface the result here.
                const transactionCode = data?.transaction_code || 'N/A';
                const paymentMode = data?.payment_mode || 'N/A';
                const paidAt = data?.paid_at || 'N/A';
+               const paymentEntry = r.message.payment_entry;
+               const requestStatus = r.message.request_status || 'Recorded';
+               const dupNote = r.message.is_duplicate
+                  ? '<p><em>This payment was already recorded.</em></p>'
+                  : '';
 
-               // Display payment verification success message
                frappe.msgprint({
                   title: __('Payment Verified'),
                   message: `
-                    <p><strong>Status:</strong> The payment has been verified successfully.</p>
+                    <p><strong>Status:</strong> ${requestStatus}</p>
                     <p><strong>Transaction Code:</strong> ${transactionCode}</p>
                     <p><strong>Payment Mode:</strong> ${paymentMode}</p>
                     <p><strong>Paid At:</strong> ${paidAt}</p>
+                    ${dupNote}
+                    <p><strong>Payment Entry:</strong> <a href="/app/payment-entry/${paymentEntry}" target="_blank">${paymentEntry}</a></p>
                     `,
                   indicator: 'green',
                });
-
-               const inv = order;
-               const response_data = data;
-
-               frappe.call({
-                  method: 'ipay.ipay.main.utils.make_payment_entry.make_payment_entry',
-                  args: { user_id, customer_email, inv, response_data, ipay_request: frm.doc.name },
-                  freeze: false,
-                  async: true,
-
-                  callback: function (r) {
-                     const res = r.message;
-                     if (res.status === 'duplicate') {
-                        frappe.msgprint({
-                           title: __('Duplicate Payment Entry'),
-                           message: `A Payment Entry with the same transaction code already exists: 
-                                    <a href="/app/payment-entry/${res.payment_entry}" target="_blank">${res.payment_entry}</a>`,
-                           indicator: 'orange',
-                        });
-                     } else if (res.status === 'success') {
-                        frappe.msgprint({
-                           title: __('Payment Entry Created'),
-                           message: `Payment Entry: <a href="/app/payment-entry/${res.payment_entry}" target="_blank">${res.payment_entry}</a>`,
-                           indicator: 'green',
-                        });
-                     } else {
-                        frappe.msgprint({
-                           title: __('Payment Entry Error'),
-                           message: __(res.message || 'An unknown error occurred while creating the payment entry.'),
-                           indicator: 'red',
-                        });
-                     }
-                  },
-               });
+               frm.reload_doc();
             } else {
-               // Handle verification failure
+               // Surface the real reason from the server (payment not found, or
+               // the payment was found but could not be recorded) so the
+               // operator can act on a received-but-unrecorded payment.
                frappe.msgprint({
                   title: __('Verification Failed'),
-                  //  message: __(`Error: ${message}`),
-                  message: `Error: Payment Not Found.`,
+                  message: __(message || 'Payment not found.'),
                   indicator: 'red',
                });
             }

--- a/ipay/ipay/doctype/ipay_request/ipay_request.js
+++ b/ipay/ipay/doctype/ipay_request/ipay_request.js
@@ -35,6 +35,29 @@ frappe.ui.form.on('iPay Request', {
          });
       }
 
+      // Split a bundle back into individual requests (only before payment)
+      if (submitted && status !== 'Success' && (frm.doc.invoices || []).length > 1) {
+         frm.add_custom_button(__('Split into Individual Requests'), () => {
+            frappe.confirm(
+               __('Split this bundle into one request per invoice and cancel the bundle?'),
+               () => {
+                  frappe.call({
+                     method: 'ipay.ipay.main.utils.ipay_redirect.split_bundle',
+                     args: { request: frm.doc.name },
+                     freeze: true,
+                     callback: function (r) {
+                        const res = r.message || {};
+                        if (res.created) {
+                           frappe.show_alert({ message: __(`Created ${res.created.length} request(s)`), indicator: 'green' });
+                           frm.reload_doc();
+                        }
+                     },
+                  });
+               }
+            );
+         });
+      }
+
       // Add "Prompt iPay" button if submitted and status is not success
       if (submitted && status !== 'Success') {
          frm.add_custom_button(__('Prompt iPay'), () => {

--- a/ipay/ipay/doctype/ipay_request/ipay_request.js
+++ b/ipay/ipay/doctype/ipay_request/ipay_request.js
@@ -12,6 +12,11 @@ frappe.ui.form.on('iPay Request', {
          frm.set_df_property('status', 'read_only', 1);
       }
 
+      // Render a persistent, clickable payment link on the form.
+      if (submitted) {
+         render_payment_link(frm);
+      }
+
       // Copy a shareable payment link to send to the customer
       if (submitted && status !== 'Success') {
          frm.add_custom_button(__('Copy Payment Link'), () => {
@@ -23,6 +28,9 @@ frappe.ui.form.on('iPay Request', {
                   const res = r.message || {};
                   if (!res.url) { frappe.msgprint(__('Could not generate a payment link.')); return; }
                   if (navigator.clipboard) { navigator.clipboard.writeText(res.url); }
+                  // Populate the persistent field immediately (frm.doc.pay_token
+                  // is still stale on the client until the next reload).
+                  set_payment_link_html(frm, res.url);
                   const warn = res.redirect_enabled ? '' :
                      '<br><span style="color:#b7791f">Enable "Use Hosted Checkout Redirect" in iPay Settings so the card/iPay option works.</span>';
                   frappe.msgprint({
@@ -332,4 +340,28 @@ function confirmPayment(frm) {
          console.error('Verification Error:', err);
       },
    });
+}
+
+// Render the payment link into the read-only "Payment Link" HTML field so the
+// operator can click it directly from the form (not only via the popup).
+function render_payment_link(frm) {
+   const field = frm.get_field('payment_link');
+   if (!field) { return; }
+   if (frm.doc.status === 'Success') {
+      field.$wrapper.html('<span class="text-muted">This request has been paid.</span>');
+   } else if (frm.doc.pay_token) {
+      const url = `${window.location.origin}/pay?token=${encodeURIComponent(frm.doc.pay_token)}`;
+      set_payment_link_html(frm, url);
+   } else {
+      field.$wrapper.html('<span class="text-muted">Use "Copy Payment Link" to generate the link.</span>');
+   }
+}
+
+function set_payment_link_html(frm, url) {
+   const field = frm.get_field('payment_link');
+   if (!field) { return; }
+   const safe = frappe.utils.escape_html(url);
+   field.$wrapper.html(
+      `<a href="${safe}" target="_blank" rel="noopener" style="word-break:break-all">${safe}</a>`
+   );
 }

--- a/ipay/ipay/doctype/ipay_request/ipay_request.json
+++ b/ipay/ipay/doctype/ipay_request/ipay_request.json
@@ -28,6 +28,7 @@
   "callback_delivered",
   "result_detail",
   "pay_token",
+  "payment_link",
   "payment_entry"
  ],
  "fields": [
@@ -189,6 +190,12 @@
    "read_only": 1,
    "unique": 1,
    "no_copy": 1
+  },
+  {
+   "depends_on": "eval:doc.docstatus===1",
+   "fieldname": "payment_link",
+   "fieldtype": "HTML",
+   "label": "Payment Link"
   },
   {
    "allow_on_submit": 1,

--- a/ipay/ipay/doctype/ipay_request/ipay_request.json
+++ b/ipay/ipay/doctype/ipay_request/ipay_request.json
@@ -117,8 +117,9 @@
    "fieldname": "status",
    "fieldtype": "Select",
    "label": "Status",
-   "options": "\nFailed to complete request\nSuccess\nError\nAmount Mismatch",
-   "read_only": 1
+   "options": "Pending\nSuccess\nUnderpaid\nOverpaid\nFailed\nAbandoned",
+   "read_only": 1,
+   "default": "Pending"
   },
   {
    "fieldname": "column_break_1mkgo",

--- a/ipay/ipay/doctype/ipay_request/ipay_request.py
+++ b/ipay/ipay/doctype/ipay_request/ipay_request.py
@@ -1,8 +1,44 @@
 # Copyright (c) 2024, Gatura Njenga and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
+from frappe.utils import flt
 from frappe.website.website_generator import WebsiteGenerator
 
+
 class iPayRequest(WebsiteGenerator):
-	pass
+	def before_validate(self):
+		# For a bundle (the `invoices` table), default the primary Sales Invoice
+		# from the first row so the mandatory sales_invoice field is satisfied
+		# from the table alone (e.g. when created from the desk).
+		if self.invoices and not self.sales_invoice:
+			self.sales_invoice = self.invoices[0].sales_invoice
+
+	def validate(self):
+		# A single-invoice request keeps the fetched amount; a bundle's amount is
+		# the sum of its invoices' live outstanding, and all invoices must belong
+		# to this request's customer and one company.
+		if not self.invoices:
+			return
+
+		total = 0.0
+		companies = set()
+		for row in self.invoices:
+			si = frappe.db.get_value(
+				"Sales Invoice",
+				row.sales_invoice,
+				["customer", "company", "outstanding_amount"],
+				as_dict=True,
+			)
+			if not si:
+				continue
+			if self.customer and si.customer != self.customer:
+				frappe.throw(f"Invoice {row.sales_invoice} does not belong to {self.customer}.")
+			companies.add(si.company)
+			row.outstanding_amount = flt(si.outstanding_amount)
+			total += flt(si.outstanding_amount)
+
+		if len(companies) > 1:
+			frappe.throw("All invoices in a bundle must belong to the same company.")
+
+		self.amount = f"{total:.2f}"

--- a/ipay/ipay/doctype/ipay_settings/ipay_settings.json
+++ b/ipay/ipay/doctype/ipay_settings/ipay_settings.json
@@ -11,7 +11,8 @@
   "callback_url",
   "is_live",
   "request_for_cod",
-  "enable_redirect"
+  "enable_redirect",
+  "cash_account"
  ],
  "fields": [
   {
@@ -50,6 +51,13 @@
    "fieldname": "enable_redirect",
    "fieldtype": "Check",
    "label": "Use Hosted Checkout Redirect"
+  },
+  {
+   "description": "Fallback receiving account, used only when the invoice's company has no Default Cash Account set.",
+   "fieldname": "cash_account",
+   "fieldtype": "Link",
+   "label": "Cash Account (fallback)",
+   "options": "Account"
   }
  ],
  "index_web_pages_for_search": 1,

--- a/ipay/ipay/main/main.py
+++ b/ipay/ipay/main/main.py
@@ -3,10 +3,9 @@ import logging
 from ipay.ipay.main.utils.get_sid import get_sid
 from ipay.ipay.main.utils.trigger_stk_push import trigger_stk_push
 from ipay.ipay.main.utils.verify_mpesa_payment import verify_mpesa_payment
-from ipay.ipay.main.utils.make_payment_entry import make_payment_entry
+from ipay.ipay.main.utils.finalize_payment import finalize_payment
 from ipay.ipay.main.utils.ipay_logs import create_log_entry
-from ipay.ipay.main.utils.send_callback import deliver_callback
-import re
+from ipay.ipay.main.utils.constants import clean_oid
 
 logger = logging.getLogger(__name__)
 
@@ -38,8 +37,7 @@ def lipana_mpesa(
     inv = oid
     logger.info(f"Invoice: {inv}")
 
-    unwanted_characters = r"[-/;:~`!%^*<&_]"
-    oid = re.sub(unwanted_characters, "", docid)
+    oid = clean_oid(docid)
     logger.info(f"Cleaned OID (from request {docid}): {oid}")
 
     # get vendor details
@@ -103,85 +101,40 @@ def lipana_mpesa(
                     create_log_entry("ERR", "Payment Verification Failed")
                     frappe.throw("Payment Verification Failed")
 
-                # Process verification response
+                # Finalise via the shared path: record the Payment Entry, set
+                # the request status (Success / Underpaid / Overpaid) and notify
+                # the n8n callback exactly once.
                 data = verification_response.get("data", {})
-                response_data = {
-                    "order_id": data.get("oid"),
-                    "transaction_amount": data.get("transaction_amount"),
-                    "transaction_code": data.get("transaction_code"),
-                    "payee": data.get("firstname"),
-                    "payment_mode": data.get("payment_mode"),
-                    "paid_at": data.get("paid_at"),
-                    "telephone": data.get("telephone"),
-                }
-
+                result = finalize_payment(
+                    docid, data, amount,
+                    sales_invoice=inv, customer=user_id, customer_email=customer_email,
+                )
+                response_data = result.get("response_data", {})
                 create_log_entry(
-                    "INF",
-                    f"Payment received successfully with response_data: {response_data}",
+                    "INF", f"Payment received with response_data: {response_data}"
                 )
                 logger.info("response_data: %s", response_data)
 
-                # set status to success on the ipay request and show success message
-                result_detail = (
-                    f"KES {response_data.get('transaction_amount')} received from "
-                    f"{response_data.get('payee')} ({response_data.get('telephone')}) — "
-                    f"M-Pesa ref {response_data.get('transaction_code')}, {response_data.get('paid_at')}"
-                )
-                frappe.db.set_value(
-                    "iPay Request",
-                    docid,
-                    {"status": "Success", "result_detail": result_detail},
-                )
-                frappe.db.commit()
-                frappe.msgprint("Payment received successfully")
-
-                # send post request to call back url
-                deliver_callback(docid, response_data)
-
-                # call function to create payment entry
-                result = make_payment_entry(user_id, customer_email, inv, response_data, ipay_request=docid)
-
-                if isinstance(result, dict):
-                    status = result.get("status")
-                    payment_entry = result.get("payment_entry")
-                    message = result.get("message", "")
-
-                    if status == "success":
-                        logger.info(f"Payment Entry: {payment_entry}")
-                        frappe.msgprint(
-                            f"Payment Entry: <a href='/desk/payment-entry/{payment_entry}'>{payment_entry}</a>"
-                        )
-
-                    elif status == "duplicate":
-                        logger.warning(
-                            f"Duplicate Payment Entry detected: {payment_entry}"
-                        )
-                        frappe.msgprint(
-                            f"Duplicate Payment Entry: <a href='/desk/payment-entry/{payment_entry}'>{payment_entry}</a>"
-                        )
-
-                    else:
-                        logger.error(f"Payment Entry creation failed: {message}")
-                        create_log_entry(
-                            "ERR", f"Payment Entry creation failed: {message}"
-                        )
-                        frappe.msgprint("Failed to create Payment Entry")
-
-                else:
-                    logger.error("Unexpected response from make_payment_entry")
-                    create_log_entry(
-                        "ERR", "Unexpected response from make_payment_entry"
+                payment_entry = result.get("payment_entry")
+                if result.get("status") in ("success", "duplicate"):
+                    frappe.msgprint(
+                        f"Payment received ({result.get('request_status')}). "
+                        f"Payment Entry: <a href='/app/payment-entry/{payment_entry}'>{payment_entry}</a>"
                     )
-                    frappe.msgprint("Failed to create Payment Entry")
+                else:
+                    create_log_entry(
+                        "ERR", f"Payment Entry creation failed: {result.get('message')}"
+                    )
+                    frappe.msgprint(
+                        "Payment received, but creating the Payment Entry failed. "
+                        "It will be retried automatically."
+                    )
 
                 return response_data
 
             else:
                 create_log_entry("ERR", "Failed to initiate payment")
-                # set status to 'Failed to complete request'
-                frappe.db.set_value(
-                    "iPay Request", docid, "status", "Failed to complete request"
-                )
+                frappe.db.set_value("iPay Request", docid, "status", "Failed")
                 frappe.db.commit()
                 frappe.throw("Failed to initiate Payment")
 
@@ -190,11 +143,11 @@ def lipana_mpesa(
             create_log_entry(
                 "ERR", f"An error occurred during the payment proces: {error}"
             )
-            # set status to error and record the reason for the operator
+            # set status to Failed and record the reason for the operator
             frappe.db.set_value(
                 "iPay Request",
                 docid,
-                {"status": "Error", "result_detail": str(error)},
+                {"status": "Failed", "result_detail": str(error)},
             )
             frappe.db.commit()
             # frappe.throw("An error occurred during the payment process")

--- a/ipay/ipay/main/main.py
+++ b/ipay/ipay/main/main.py
@@ -8,11 +8,10 @@ from ipay.ipay.main.utils.ipay_logs import create_log_entry
 from ipay.ipay.main.utils.send_callback import deliver_callback
 import re
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def lipana_mpesa(
     docid, user_id, phone, amount, oid, customer_email, payment_request_type
 ):

--- a/ipay/ipay/main/utils/confirm_payment.py
+++ b/ipay/ipay/main/utils/confirm_payment.py
@@ -1,111 +1,63 @@
-import requests
-import hmac
-import hashlib
 import logging
-import re
-import frappe
-from ipay.ipay.main.utils.ipay_logs import create_log_entry
-from ipay.ipay.main.utils.send_callback import deliver_callback
 
+import requests
+import frappe
+
+from ipay.ipay.main.utils.ipay_logs import create_log_entry
+from ipay.ipay.main.utils.constants import clean_oid, search_hash
+from ipay.ipay.main.utils.finalize_payment import finalize_payment
 
 logger = logging.getLogger(__name__)
 
-@frappe.whitelist()
+SEARCH_URL = "https://apis.ipayafrica.com/payments/v2/transaction/search"
+
+
+@frappe.whitelist(methods=["POST"])
 def confirm_payment(docid, user_id, phone, amount, order, customer_email):
-    # Log the received parameters
-    logger.info(f"Received doc name: {docid}")
-    logger.info(f"Customer Email: {customer_email}")
-    logger.info(f"User ID: {user_id}")
-    logger.info(f"Phone Number: {phone}")
-    logger.info(f"Amount: {amount}")
-    logger.info(f"OID: {order}")
-    
-    # Get vendor details
+    """Manual desk action ("Verify Payment"): look the payment up on iPay and,
+    if found, finalise it via the shared path — record the Payment Entry, set
+    the request status and notify the callback. Returns the recorded result so
+    the desk can show the Payment Entry link."""
     vendor = frappe.get_doc("iPay Settings")
-    vid = vendor.vendor_id.lower()   # Must be lowercase
+    vid = (vendor.vendor_id or "").lower()
     secret_key = vendor.api_key
-    
-    # Order id is the iPay Request name (must match what was sent at initiation).
-    unwanted_characters = r'[-/;:~`!%^*<&_]'
-    oid = re.sub(unwanted_characters, '', docid)
-    logger.info(f"Cleaned OID (from request {docid}): {oid}")
-    
+
+    # Order id is the iPay Request name (must match what initiation sent to iPay).
+    oid = clean_oid(docid)
+    logger.info(f"Confirming payment for request {docid} (oid {oid})")
+
     try:
-        # Generate hash for verification
-        hash_value = create_hash(oid, vid, secret_key)
-        verification_payload = {
-            'vid': vid,
-            'hash': hash_value,
-            'oid': oid
-        }
-        logger.info(f"Verification Payload: {verification_payload}")
-        
-        # Make the verification API call
-        verification_response = requests.post(
-            'https://apis.ipayafrica.com/payments/v2/transaction/search',
-            data=verification_payload,
-            headers={'Content-Type': 'application/x-www-form-urlencoded'}
+        response = requests.post(
+            SEARCH_URL,
+            data={"vid": vid, "hash": search_hash(oid, vid, secret_key), "oid": oid},
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=15,
         )
-        
-        # Raise HTTP errors for bad responses
-        verification_response.raise_for_status()
-        logger.info(f"Verification Response: {verification_response.json()}")
-        
-        # Check if payment verification was successful
-        if verification_response.status_code == 200:
-            data = verification_response.json().get('data', {})
-            transaction_code = data.get('transaction_code')
-            transaction_amount = data.get('transaction_amount')
-            
-            # Validate payment amount
-            try:
-                transaction_amount_float = float(transaction_amount)
-                amount_float = float(amount)
-                if abs(transaction_amount_float - amount_float) < 1e-2:  # Allow small precision differences
-                    logger.info("Payment verification successful")
-                    # logging the transaction details
-                    create_log_entry("INF", f"Payment confirmed for Ipay Request : {docid} - {data}")
-                    # change the status of the iPay request
-                    frappe.db.set_value("iPay Request", docid, "status", "Success")
-                    frappe.db.commit()
-                    
-                    # parse the response_data
-                    data = {
-                       'order_id': data.get('oid'),
-                       'transaction_amount': data.get('transaction_amount'),
-                       'transaction_code': data.get('transaction_code'),
-                       'payee': data.get('firstname'),
-                       'payment_mode': data.get('payment_mode'),
-                       'paid_at': data.get('paid_at'),
-                       'telephone': data.get('telephone'),
-                      }
+        response.raise_for_status()
+        data = response.json().get("data", {})
 
-                    # notify the configured callback URL
-                    deliver_callback(docid, data)
-
-                    return {"status": "success", "message": "Payment verified", "data": data}
-                  
-                else:
-                    logger.warning(f"Payment amount mismatch: Expected {amount_float}, Received {transaction_amount_float}")
-                    return {"status": "error", "message": "Payment amount mismatch"}
-                  
-            except ValueError as ve:
-                logger.error(f"Error parsing amounts for comparison: {ve}")
-                return {"status": "error", "message": "Invalid amount format"}
-              
-        else:
-            logger.warning("Payment not found")
+        if not data.get("transaction_code"):
             return {"status": "error", "message": "Payment not found"}
-    
+
+        result = finalize_payment(
+            docid, data, amount,
+            sales_invoice=order, customer=user_id, customer_email=customer_email,
+        )
+        if result.get("status") not in ("success", "duplicate"):
+            return {"status": "error", "message": result.get("message", "Could not record payment")}
+
+        create_log_entry(
+            "INF", f"Payment confirmed for iPay Request {docid}: {result.get('response_data')}"
+        )
+        return {
+            "status": "success",
+            "message": "Payment verified",
+            "data": result.get("response_data"),
+            "payment_entry": result.get("payment_entry"),
+            "request_status": result.get("request_status"),
+            "is_duplicate": result.get("status") == "duplicate",
+        }
+
     except requests.RequestException as error:
         logger.error(f"Error during payment verification: {error}")
         return {"status": "error", "message": str(error)}
-      
-    except ValueError as ve:
-        logger.error(f"Validation Error: {ve}")
-        return {"status": "error", "message": str(ve)}
-
-# Helper function to create HMAC hash
-def create_hash(oid, vid, secret_key):
-    data_string = f'{oid}{vid}'
-    return hmac.new(secret_key.encode(), data_string.encode(), hashlib.sha256).hexdigest()

--- a/ipay/ipay/main/utils/confirm_payment.py
+++ b/ipay/ipay/main/utils/confirm_payment.py
@@ -8,7 +8,6 @@ from ipay.ipay.main.utils.ipay_logs import create_log_entry
 from ipay.ipay.main.utils.send_callback import deliver_callback
 
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 @frappe.whitelist()

--- a/ipay/ipay/main/utils/constants.py
+++ b/ipay/ipay/main/utils/constants.py
@@ -1,0 +1,42 @@
+"""Shared iPay constants and small helpers used across the payment flow.
+
+Centralised here so the order-id cleaning, the REST hash and the amount
+comparison are defined once instead of being copy-pasted into every module
+that talks to iPay.
+"""
+
+import re
+import hmac
+import hashlib
+
+# Characters iPay rejects in an order id. Order ids (and the `inv` field) are
+# derived from Frappe document names, which can contain these, so strip them
+# wherever an oid/inv is built. Must stay identical everywhere or the
+# /transaction/search lookup will not match what /transact was sent.
+UNWANTED_OID_CHARACTERS = r"[-/;:~`!%^*<&_]"
+
+
+def clean_oid(name):
+    """Derive an iPay-safe order id (or `inv`) from a document name."""
+    return re.sub(UNWANTED_OID_CHARACTERS, "", name or "")
+
+
+def search_hash(oid, vid, secret_key):
+    """HMAC-SHA256 over ``oid + vid`` for the REST /transact and
+    /transaction/search endpoints.
+
+    NB: this is NOT the hosted-checkout hash (that one is HMAC-SHA1 over a
+    different, ordered field set — see ipay_redirect.build_checkout_form).
+    """
+    return hmac.new(
+        (secret_key or "").encode(), f"{oid}{vid}".encode(), hashlib.sha256
+    ).hexdigest()
+
+
+def amounts_match(paid, expected, tolerance=1e-2):
+    """True when two money amounts are equal within a cent. Non-numeric input
+    (e.g. a missing amount) is treated as 'does not match'."""
+    try:
+        return abs(float(paid) - float(expected)) < tolerance
+    except (TypeError, ValueError):
+        return False

--- a/ipay/ipay/main/utils/finalize_payment.py
+++ b/ipay/ipay/main/utils/finalize_payment.py
@@ -1,0 +1,111 @@
+"""Single finalisation path for an iPay payment.
+
+Every way a payment can be confirmed — the in-session STK flow (main.py), the
+manual desk "Verify Payment" action (confirm_payment.py), the hosted-checkout
+redirect return and the scheduled reconcile poller (reconcile_payments.py) —
+ends here. Keeping one implementation guarantees the Payment Entry, the request
+status and the n8n callback stay consistent regardless of which path ran.
+"""
+
+import frappe
+
+from ipay.ipay.main.utils.make_payment_entry import make_payment_entry
+from ipay.ipay.main.utils.send_callback import deliver_callback
+from ipay.ipay.main.utils.constants import amounts_match
+
+
+def build_response_data(data):
+    """Normalise iPay's transaction-search / verify ``data`` dict into the
+    canonical payload used for the Payment Entry and the n8n callback."""
+    return {
+        "order_id": data.get("oid"),
+        "transaction_amount": data.get("transaction_amount"),
+        "transaction_code": data.get("transaction_code"),
+        "payee": data.get("firstname"),
+        "payment_mode": data.get("payment_mode"),
+        "paid_at": data.get("paid_at"),
+        "telephone": data.get("telephone"),
+    }
+
+
+def finalize_payment(
+    request_name,
+    data,
+    expected_amount=None,
+    *,
+    sales_invoice=None,
+    customer=None,
+    customer_email=None,
+):
+    """Record a found payment and finalise its iPay Request.
+
+    Creates the (idempotent) Payment Entry, sets the request status from how the
+    paid amount compares to what was expected, and delivers the n8n callback
+    exactly once. Any field not supplied is read from the request itself.
+
+    Returns the ``make_payment_entry`` result augmented with ``request_status``
+    (the resolved iPay Request status, or None if the payment could not be
+    recorded) and ``response_data`` (the canonical payload).
+    """
+    defaults = frappe.db.get_value(
+        "iPay Request",
+        request_name,
+        ["sales_invoice", "amount", "customer", "customer_email"],
+        as_dict=True,
+    ) or {}
+    sales_invoice = sales_invoice or defaults.get("sales_invoice")
+    customer = customer or defaults.get("customer")
+    customer_email = customer_email or defaults.get("customer_email")
+    if expected_amount is None:
+        expected_amount = defaults.get("amount")
+
+    response_data = build_response_data(data)
+
+    result = make_payment_entry(
+        customer, customer_email, sales_invoice, response_data, ipay_request=request_name
+    )
+    if result.get("status") not in ("success", "duplicate"):
+        # Could not record the payment — leave the request untouched so the
+        # poller retries it on the next run.
+        result["request_status"] = None
+        result["response_data"] = response_data
+        return result
+
+    paid = response_data.get("transaction_amount")
+    status = _resolve_status(result, paid, expected_amount)
+
+    result_detail = (
+        f"KES {paid} received from {response_data.get('payee')} "
+        f"({response_data.get('telephone')}) — M-Pesa ref "
+        f"{response_data.get('transaction_code')}, {response_data.get('paid_at')}"
+    )
+    frappe.db.set_value(
+        "iPay Request", request_name, {"status": status, "result_detail": result_detail}
+    )
+    deliver_callback(request_name, response_data)
+    frappe.db.commit()
+
+    result["request_status"] = status
+    result["response_data"] = response_data
+    return result
+
+
+def _resolve_status(result, paid, expected):
+    """Map a recorded payment to a request status.
+
+    Full expected amount actually allocated to an invoice → Success. Less than
+    expected → Underpaid (the balance stays outstanding and can be re-requested).
+    More than expected, or an exact amount that could not be allocated because
+    the invoices were already settled → Overpaid (the excess is customer credit).
+
+    Resolution is driven purely by ``allocated`` and the paid-vs-expected amounts,
+    both of which make_payment_entry reports identically for a fresh entry and a
+    duplicate (re-run) — so re-running finalisation is stable and never flips a
+    prior status.
+    """
+    allocated = frappe.utils.flt(result.get("allocated"))
+    if amounts_match(paid, expected) and allocated > 0:
+        return "Success"
+    if frappe.utils.flt(paid) < frappe.utils.flt(expected):
+        return "Underpaid"
+    return "Overpaid"

--- a/ipay/ipay/main/utils/get_sid.py
+++ b/ipay/ipay/main/utils/get_sid.py
@@ -1,19 +1,18 @@
-import re
 import requests
 import hmac
 import hashlib
 import logging
 import frappe
 
-logger = logging.getLogger(__name__)
+from ipay.ipay.main.utils.constants import clean_oid
 
-UNWANTED_OID_CHARACTERS = r"[-/;:~`!%^*<&_]"
+logger = logging.getLogger(__name__)
 
 def get_sid(vid: str, secret_key: str, amount: str, oid: str, phone: str, eml: str = "", sales_invoice: str = None) -> dict:
     try:
         # 'oid' is the iPay Request name (the search key). The iPay 'inv' field is
         # the (cleaned) Sales Invoice, kept as metadata for iPay's records.
-        inv = re.sub(UNWANTED_OID_CHARACTERS, "", sales_invoice) if sales_invoice else oid
+        inv = clean_oid(sales_invoice) if sales_invoice else oid
 
         # Customer email: prefer the value passed in; fall back to the invoice's
         # contact email looked up by the REAL invoice name (never the oid).

--- a/ipay/ipay/main/utils/get_sid.py
+++ b/ipay/ipay/main/utils/get_sid.py
@@ -5,7 +5,6 @@ import hashlib
 import logging
 import frappe
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 UNWANTED_OID_CHARACTERS = r"[-/;:~`!%^*<&_]"

--- a/ipay/ipay/main/utils/ipay_logs.py
+++ b/ipay/ipay/main/utils/ipay_logs.py
@@ -2,7 +2,6 @@ import frappe
 from datetime import datetime
 import logging
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 def create_log_entry(log_type, description):

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -263,7 +263,47 @@ def create_bundle(customer, invoices):
         }
     )
     request.insert(ignore_permissions=True)
-    return {"request": request.name, "amount": f"{total:.2f}", "count": len(rows)}
+    # `amount` has fetch_from the primary invoice's outstanding, which overrides
+    # the bundle sum on insert; write the true total back directly.
+    frappe.db.set_value("iPay Request", request.name, "amount", f"{total:.2f}")
+    token = _ensure_pay_token(request.name)
+    return {
+        "request": request.name,
+        "amount": f"{total:.2f}",
+        "count": len(rows),
+        "url": frappe.utils.get_url("/pay?token=" + token),
+    }
+
+
+@frappe.whitelist()
+def split_bundle(request):
+    """Split an unpaid bundle back into individual single-invoice requests and
+    cancel the bundle. Only allowed before any payment is recorded."""
+    _require_operator()
+    bundle = frappe.get_doc("iPay Request", request)
+    if bundle.status == "Success":
+        frappe.throw("This request has already been paid and cannot be split.")
+    invoice_names = [row.sales_invoice for row in (bundle.invoices or []) if row.sales_invoice]
+    if len(invoice_names) < 2:
+        frappe.throw("This is not a bundle (it covers fewer than two invoices).")
+
+    created = []
+    for name in invoice_names:
+        customer = frappe.db.get_value("Sales Invoice", name, "customer")
+        single = frappe.get_doc(
+            {
+                "doctype": "iPay Request",
+                "customer": customer,
+                "sales_invoice": name,
+                "docstatus": 1,
+            }
+        )
+        single.insert(ignore_permissions=True)
+        created.append(single.name)
+
+    bundle.flags.ignore_permissions = True
+    bundle.cancel()
+    return {"created": created}
 
 
 @frappe.whitelist()

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -6,11 +6,11 @@ import frappe
 
 from ipay.ipay.main.utils.reconcile_payments import reconcile_request
 from ipay.ipay.main.utils.ipay_logs import create_log_entry
+from ipay.ipay.main.utils.constants import clean_oid
 
 # Hosted checkout (HTML form POST). NB: this flow uses HMAC-SHA1 over the
 # documented field order — it is NOT the REST /transact SHA256 flow.
 CHECKOUT_URL = "https://payments.ipayafrica.com/v3/ke"
-UNWANTED_OID_CHARACTERS = r"[-/;:~`!%^*<&_]"
 HASH_FIELD_ORDER = [
     "live", "oid", "inv", "ttl", "tel", "eml", "vid",
     "curr", "p1", "p2", "p3", "p4", "cbk", "cst", "crl",
@@ -53,7 +53,7 @@ def build_checkout_form(request_name, phone=None):
     req = frappe.get_doc("iPay Request", request_name)
 
     # Order id is the iPay Request name (unique per request), not the invoice.
-    oid = re.sub(UNWANTED_OID_CHARACTERS, "", req.name)
+    oid = clean_oid(req.name)
     outstanding = frappe.db.get_value(
         "Sales Invoice", req.sales_invoice, "outstanding_amount"
     )
@@ -66,7 +66,7 @@ def build_checkout_form(request_name, phone=None):
     fields = {
         "live": "1" if settings.is_live else "0",
         "oid": oid,
-        "inv": re.sub(UNWANTED_OID_CHARACTERS, "", req.sales_invoice),
+        "inv": clean_oid(req.sales_invoice),
         "ttl": f"{amount:.2f}",
         "tel": normalize_phone(phone or req.customer_phone),
         "eml": req.customer_email or "",
@@ -156,7 +156,11 @@ def _payment_state(request_name, include_detail=False):
     state = {
         "status": status,
         "paid": status == "Success",
-        "failed": status in ("Error", "Failed to complete request"),
+        # A payment was received but did not match the expected amount (the
+        # balance stays outstanding, or the excess is credit). Terminal for
+        # polling, but distinct from a clean full payment.
+        "partial": status in ("Underpaid", "Overpaid"),
+        "failed": status in ("Failed", "Abandoned"),
     }
     # result_detail embeds payer name/phone/txn — only expose to authorised operators.
     if include_detail:
@@ -285,7 +289,7 @@ def split_bundle(request):
     cancel the bundle. Only allowed before any payment is recorded."""
     _require_operator()
     bundle = frappe.get_doc("iPay Request", request)
-    if bundle.status in ("Success", "Amount Mismatch") or bundle.payment_entry:
+    if bundle.status in ("Success", "Underpaid", "Overpaid") or bundle.payment_entry:
         frappe.throw("This request has a recorded payment and cannot be split.")
     invoice_names = [row.sales_invoice for row in (bundle.invoices or []) if row.sales_invoice]
     if len(invoice_names) < 2:

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -202,7 +202,7 @@ def start_checkout(invoice):
     frappe.local.response["location"] = f"/ipay_checkout?token={token}"
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def get_payment_link(invoice=None, request=None):
     """Return a shareable, tokenised payment link for an invoice or request."""
     _require_operator()
@@ -218,7 +218,7 @@ def get_payment_link(invoice=None, request=None):
     }
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def create_bundle(customer, invoices):
     """Create one submitted iPay Request covering several of a customer's
     invoices. amount = sum of their live outstanding; the oldest invoice is the
@@ -233,9 +233,10 @@ def create_bundle(customer, invoices):
 
     rows = []
     total = 0.0
+    companies = set()
     for name in invoices:
         si = frappe.db.get_value(
-            "Sales Invoice", name, ["customer", "outstanding_amount", "posting_date"], as_dict=True
+            "Sales Invoice", name, ["customer", "company", "outstanding_amount", "posting_date"], as_dict=True
         )
         if not si:
             continue
@@ -243,11 +244,14 @@ def create_bundle(customer, invoices):
             frappe.throw(f"Invoice {name} does not belong to {customer}.")
         if frappe.utils.flt(si.outstanding_amount) <= 0:
             continue
+        companies.add(si.company)
         rows.append((si.posting_date, name))
         total += frappe.utils.flt(si.outstanding_amount)
 
     if not rows:
         frappe.throw("None of the selected invoices have an outstanding balance.")
+    if len(companies) > 1:
+        frappe.throw("All invoices in a bundle must belong to the same company.")
 
     rows.sort()
     primary = rows[0][1]
@@ -275,14 +279,14 @@ def create_bundle(customer, invoices):
     }
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def split_bundle(request):
     """Split an unpaid bundle back into individual single-invoice requests and
     cancel the bundle. Only allowed before any payment is recorded."""
     _require_operator()
     bundle = frappe.get_doc("iPay Request", request)
-    if bundle.status == "Success":
-        frappe.throw("This request has already been paid and cannot be split.")
+    if bundle.status in ("Success", "Amount Mismatch") or bundle.payment_entry:
+        frappe.throw("This request has a recorded payment and cannot be split.")
     invoice_names = [row.sales_invoice for row in (bundle.invoices or []) if row.sales_invoice]
     if len(invoice_names) < 2:
         frappe.throw("This is not a bundle (it covers fewer than two invoices).")
@@ -306,7 +310,7 @@ def split_bundle(request):
     return {"created": created}
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def prompt_mpesa(invoice, phone=None):
     """Operator action (collection page): send an M-Pesa STK push for an invoice."""
     _require_operator()
@@ -323,7 +327,7 @@ def payment_state(request):
     return _payment_state(request, include_detail=True)
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True, methods=["POST"])
 def pay_prompt_mpesa(token, phone):
     """Customer action on the payment-link page: STK push, authorised by token.
     Guarded against already-paid requests and rate-limited per token to prevent

--- a/ipay/ipay/main/utils/log_cleanup.py
+++ b/ipay/ipay/main/utils/log_cleanup.py
@@ -17,16 +17,16 @@ def del_old_logs():
             pluck="name")
 
         # Delete INF logs
-        if inf_logs_to_delete:
-            for log_name in inf_logs_to_delete:
+        if inf_logs:
+            for log_name in inf_logs:
                 frappe.delete_doc("iPay Logs", log_name, ignore_permissions=True)
             frappe.db.commit()  # Commit changes after deletion
         else:
             frappe.logger().info("No old 'INF' logs to delete.")
-    
+
         # Delete ERR logs
-        if err_logs_to_delete:
-            for log_name in err_logs_to_delete:
+        if err_logs:
+            for log_name in err_logs:
                 frappe.delete_doc("iPay Logs", log_name, ignore_permissions=True)
             frappe.db.commit()  # Commit changes after deletion
         else:

--- a/ipay/ipay/main/utils/make_payment_entry.py
+++ b/ipay/ipay/main/utils/make_payment_entry.py
@@ -2,7 +2,6 @@ import frappe
 import logging
 import json
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
@@ -66,7 +65,7 @@ def make_payment_entry(user_id, customer_email, inv, response_data, ipay_request
                 frappe.db.get_value(
                     "Sales Invoice",
                     name,
-                    ["name", "outstanding_amount", "posting_date", "customer", "customer_name"],
+                    ["name", "outstanding_amount", "posting_date", "customer", "customer_name", "company"],
                     as_dict=True,
                 )
                 for name in invoice_names
@@ -136,11 +135,20 @@ def make_payment_entry(user_id, customer_email, inv, response_data, ipay_request
                 "iPay unallocated payment",
             )
 
-        cash_account = "Cash - TSL"
+        # Resolve the receiving account per the invoice's company: prefer the
+        # company's default cash account, then an iPay Settings override, then a
+        # legacy fallback. Setting company explicitly keeps multi-company correct.
+        company = primary.company
+        cash_account = (
+            frappe.get_cached_value("Company", company, "default_cash_account")
+            or frappe.db.get_single_value("iPay Settings", "cash_account")
+            or "Cash - TSL"
+        )
 
         # Create a new Payment Entry
         payment_entry = frappe.new_doc("Payment Entry")
         payment_entry.payment_type = "Receive"
+        payment_entry.company = company
         payment_entry.payment_order_status = "Initiated"
         payment_entry.posting_date = frappe.utils.today()
         payment_entry.mode_of_payment = "MPESA"

--- a/ipay/ipay/main/utils/make_payment_entry.py
+++ b/ipay/ipay/main/utils/make_payment_entry.py
@@ -122,6 +122,20 @@ def make_payment_entry(user_id, customer_email, inv, response_data, ipay_request
                 )
                 remaining = flt(remaining - allocated)
 
+        # If nothing could be allocated (every invoice was already settled
+        # elsewhere), the money is still real — record it as unallocated credit,
+        # but make it auditable instead of a silent full-credit Payment Entry.
+        if not references:
+            logger.warning(
+                f"No outstanding to allocate for {ipay_request or inv}; "
+                f"recording {transaction_amount} as unallocated customer credit"
+            )
+            frappe.log_error(
+                f"iPay payment {response_data.get('transaction_code')} recorded as unallocated "
+                f"credit — invoices already settled ({ipay_request or inv})",
+                "iPay unallocated payment",
+            )
+
         cash_account = "Cash - TSL"
 
         # Create a new Payment Entry
@@ -174,6 +188,7 @@ def make_payment_entry(user_id, customer_email, inv, response_data, ipay_request
         return {
             "status": "success",
             "payment_entry": payment_entry.name,
+            "allocated": float(transaction_amount - remaining),
             "message": "Payment Entry created",
         }
 

--- a/ipay/ipay/main/utils/make_payment_entry.py
+++ b/ipay/ipay/main/utils/make_payment_entry.py
@@ -34,9 +34,15 @@ def make_payment_entry(user_id, customer_email, inv, response_data, ipay_request
                 )
                 if ipay_request:
                     frappe.db.set_value("iPay Request", ipay_request, "payment_entry", existing)
+                # Report how much the existing entry allocated to invoices, so the
+                # caller resolves the same status on a re-run instead of assuming a
+                # duplicate was fully allocated.
                 return {
                     "status": "duplicate",
                     "payment_entry": existing,
+                    "allocated": frappe.utils.flt(
+                        frappe.db.get_value("Payment Entry", existing, "total_allocated_amount")
+                    ),
                     "message": "Payment Entry already exists",
                 }
 

--- a/ipay/ipay/main/utils/reconcile_payments.py
+++ b/ipay/ipay/main/utils/reconcile_payments.py
@@ -1,49 +1,36 @@
-import re
-import hmac
-import hashlib
 import requests
 import frappe
 
-from ipay.ipay.main.utils.make_payment_entry import make_payment_entry
-from ipay.ipay.main.utils.send_callback import deliver_callback
+from ipay.ipay.main.utils.finalize_payment import finalize_payment
 from ipay.ipay.main.utils.ipay_logs import create_log_entry
-
-# Order ids are derived from the iPay Request name exactly as the original
-# /transact request did (see main.py / ipay_redirect.py), so the search matches.
-UNWANTED_OID_CHARACTERS = r"[-/;:~`!%^*<&_]"
+from ipay.ipay.main.utils.constants import clean_oid, search_hash
 
 # Only reconcile requests created within this window; older unconfirmed requests
-# are assumed abandoned and are left alone (so we don't poll forever).
+# are assumed abandoned (marked terminal below) so we don't poll them forever.
 RECONCILE_WINDOW_HOURS = 24
 
 SEARCH_URL = "https://apis.ipayafrica.com/payments/v2/transaction/search"
 
+# Statuses that mean a payment was recorded — these are never abandoned and stay
+# eligible for callback retry. Everything else (Pending, blank legacy rows,
+# Failed) with no Payment Entry is fair game for the Abandoned sweep.
+PAID_STATUSES = ["Success", "Underpaid", "Overpaid"]
+
+REQUEST_FIELDS = ["name", "sales_invoice", "amount", "customer", "customer_email"]
+
 
 def reconcile_pending_payments():
     """Scheduled backstop that guarantees a payment is finalised and the n8n
-    callback is delivered even when the in-session flow never completed
-    (abandoned redirect, unattended Paybill, or a failed callback).
+    callback delivered even when the in-session flow never completed (abandoned
+    redirect, unattended Paybill, or a failed callback).
 
-    Polls iPay for every submitted iPay Request whose callback has not yet been
-    delivered, within the reconcile window. Idempotent and safe to re-run: the
-    Payment Entry is deduped on the transaction code and the callback on the
+    Within the reconcile window, every submitted request whose callback has not
+    been delivered is polled. Past the window, a final lookup is attempted and,
+    if still unpaid, the request is marked Abandoned so it reaches a terminal
+    state and is no longer polled. Idempotent and safe to re-run: the Payment
+    Entry is deduped on the transaction code and the callback on the
     callback_delivered flag.
     """
-    window_start = frappe.utils.add_to_date(
-        frappe.utils.now_datetime(), hours=-RECONCILE_WINDOW_HOURS
-    )
-    pending = frappe.get_all(
-        "iPay Request",
-        filters={
-            "docstatus": 1,
-            "callback_delivered": 0,
-            "creation": [">", window_start],
-        },
-        fields=["name", "sales_invoice", "amount", "customer", "customer_email"],
-    )
-    if not pending:
-        return
-
     settings = frappe.get_single("iPay Settings")
     vid = (settings.vendor_id or "").lower()
     secret_key = settings.api_key
@@ -51,24 +38,66 @@ def reconcile_pending_payments():
         create_log_entry("ERR", "Reconcile skipped: vendor id or api key not set")
         return
 
-    for req in pending:
+    window_start = frappe.utils.add_to_date(
+        frappe.utils.now_datetime(), hours=-RECONCILE_WINDOW_HOURS
+    )
+
+    # 1) Active window — poll every not-yet-delivered request. The flag covers
+    #    both "awaiting payment" and "paid but n8n not yet notified", and
+    #    _reconcile_one is idempotent, so this both finalises and (re)delivers.
+    active = frappe.get_all(
+        "iPay Request",
+        filters={
+            "docstatus": 1,
+            "callback_delivered": 0,
+            "creation": [">", window_start],
+        },
+        fields=REQUEST_FIELDS,
+    )
+    for req in active:
         try:
             _reconcile_one(req, vid, secret_key)
         except Exception as error:
             frappe.db.rollback()
             create_log_entry("ERR", f"Reconcile failed for {req.name}: {error}")
 
+    # 2) Past the window and still undelivered (but not already Abandoned): one
+    #    last lookup, then mark Abandoned UNLESS a payment was recorded. A paid
+    #    request (Success/Underpaid/Overpaid) keeps its status and stays eligible
+    #    for callback retry; an unpaid one (Pending or Failed, no Payment Entry)
+    #    becomes terminal so it is no longer polled.
+    stale = frappe.get_all(
+        "iPay Request",
+        filters={
+            "docstatus": 1,
+            "callback_delivered": 0,
+            "creation": ["<=", window_start],
+            "status": ["!=", "Abandoned"],
+        },
+        fields=REQUEST_FIELDS,
+    )
+    for req in stale:
+        try:
+            _reconcile_one(req, vid, secret_key)
+            # Re-read the live state set by _reconcile_one. Abandon only when no
+            # payment was recorded — so a payment whose callback merely failed
+            # (status paid, Payment Entry present) is never mislabelled Abandoned
+            # and keeps being retried for delivery.
+            current = frappe.db.get_value(
+                "iPay Request", req.name, ["status", "payment_entry"], as_dict=True
+            )
+            if current and not current.payment_entry and current.status not in PAID_STATUSES:
+                frappe.db.set_value("iPay Request", req.name, "status", "Abandoned")
+                frappe.db.commit()
+        except Exception as error:
+            frappe.db.rollback()
+            create_log_entry("ERR", f"Reconcile (stale) failed for {req.name}: {error}")
+
 
 def reconcile_request(request_name):
     """Finalise a single iPay Request on demand (used by the redirect return
-    handler). Verifies the payment, creates the Payment Entry and delivers the
-    n8n callback, reusing the same idempotent path as the scheduled poller."""
-    req = frappe.db.get_value(
-        "iPay Request",
-        request_name,
-        ["name", "sales_invoice", "amount", "customer", "customer_email"],
-        as_dict=True,
-    )
+    handler). Reuses the same idempotent path as the scheduled poller."""
+    req = frappe.db.get_value("iPay Request", request_name, REQUEST_FIELDS, as_dict=True)
     if not req:
         return
 
@@ -86,29 +115,19 @@ def _reconcile_one(req, vid, secret_key):
         return
 
     # Order id is the iPay Request name (matches what initiation sent to iPay).
-    oid = re.sub(UNWANTED_OID_CHARACTERS, "", req.name)
+    oid = clean_oid(req.name)
     data = _search_transaction(oid, vid, secret_key)
     if not data:
         # Not paid yet (or not found) — leave it to retry on the next run.
         return
 
-    response_data = {
-        "order_id": data.get("oid"),
-        "transaction_amount": data.get("transaction_amount"),
-        "transaction_code": data.get("transaction_code"),
-        "payee": data.get("firstname"),
-        "payment_mode": data.get("payment_mode"),
-        "paid_at": data.get("paid_at"),
-        "telephone": data.get("telephone"),
-    }
-
-    # A payment was found — record it. make_payment_entry allocates oldest-first
-    # against live outstanding, so a partial payment clears the oldest invoices and
-    # leaves the rest as a re-requestable balance, and an overpayment becomes
-    # customer credit. Mark Success when it covers the expected amount, otherwise
-    # Amount Mismatch (still recorded + notified, balance/credit handled).
-    result = make_payment_entry(
-        req.customer, req.customer_email, req.sales_invoice, response_data, ipay_request=req.name
+    # finalize_payment records the payment (allocating oldest-first against live
+    # outstanding so partials clear the oldest invoices and overpayments become
+    # credit), resolves the status, and delivers the callback exactly once.
+    result = finalize_payment(
+        req.name, data, req.amount,
+        sales_invoice=req.sales_invoice, customer=req.customer,
+        customer_email=req.customer_email,
     )
     if result.get("status") not in ("success", "duplicate"):
         # Payment Entry creation failed; leave undelivered to retry next run.
@@ -118,22 +137,14 @@ def _reconcile_one(req, vid, secret_key):
         )
         return
 
-    # Success only when the amount matches AND it was actually allocated to an
-    # invoice; otherwise flag for review (partial, overpayment, or nothing to
-    # allocate because the invoices were already settled).
-    if result.get("status") == "duplicate":
-        matched = True
-    else:
-        matched = _amount_matches(data.get("transaction_amount"), req.amount) and result.get("allocated")
-    frappe.db.set_value("iPay Request", req.name, "status", "Success" if matched else "Amount Mismatch")
-    deliver_callback(req.name, response_data)
+    request_status = result.get("request_status")
+    response_data = result.get("response_data", {})
     create_log_entry(
-        "INF" if matched else "ERR",
-        f"Reconciled {req.name} ({response_data['transaction_code']}): "
-        f"paid {response_data['transaction_amount']} vs expected {req.amount}",
+        "INF" if request_status == "Success" else "ERR",
+        f"Reconciled {req.name} ({response_data.get('transaction_code')}): "
+        f"status {request_status}, paid {response_data.get('transaction_amount')} "
+        f"vs expected {req.amount}",
     )
-
-    frappe.db.commit()
 
 
 def _search_transaction(oid, vid, secret_key):
@@ -144,12 +155,9 @@ def _search_transaction(oid, vid, secret_key):
     so a missing transaction is treated as a quiet None rather than an error;
     only genuine transport failures raise (caught and retried by the caller).
     """
-    hash_value = hmac.new(
-        secret_key.encode(), f"{oid}{vid}".encode(), hashlib.sha256
-    ).hexdigest()
     resp = requests.post(
         SEARCH_URL,
-        data={"vid": vid, "hash": hash_value, "oid": oid},
+        data={"vid": vid, "hash": search_hash(oid, vid, secret_key), "oid": oid},
         headers={"Content-Type": "application/x-www-form-urlencoded"},
         timeout=15,
     )
@@ -158,10 +166,3 @@ def _search_transaction(oid, vid, secret_key):
     except ValueError:
         return None
     return data if data.get("transaction_code") else None
-
-
-def _amount_matches(transaction_amount, expected_amount):
-    try:
-        return abs(float(transaction_amount) - float(expected_amount)) < 1e-2
-    except (TypeError, ValueError):
-        return False

--- a/ipay/ipay/main/utils/reconcile_payments.py
+++ b/ipay/ipay/main/utils/reconcile_payments.py
@@ -118,7 +118,13 @@ def _reconcile_one(req, vid, secret_key):
         )
         return
 
-    matched = _amount_matches(data.get("transaction_amount"), req.amount)
+    # Success only when the amount matches AND it was actually allocated to an
+    # invoice; otherwise flag for review (partial, overpayment, or nothing to
+    # allocate because the invoices were already settled).
+    if result.get("status") == "duplicate":
+        matched = True
+    else:
+        matched = _amount_matches(data.get("transaction_amount"), req.amount) and result.get("allocated")
     frappe.db.set_value("iPay Request", req.name, "status", "Success" if matched else "Amount Mismatch")
     deliver_callback(req.name, response_data)
     create_log_entry(

--- a/ipay/ipay/main/utils/trigger_stk_push.py
+++ b/ipay/ipay/main/utils/trigger_stk_push.py
@@ -4,7 +4,6 @@ import hashlib
 import logging
 import frappe  
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 def trigger_stk_push(phone: str, sid: str, vid: str, secret_key: str) -> dict:

--- a/ipay/ipay/main/utils/verify_mpesa_payment.py
+++ b/ipay/ipay/main/utils/verify_mpesa_payment.py
@@ -6,7 +6,6 @@ import logging
 import frappe 
 from requests.exceptions import RequestException 
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Helper function to delay execution

--- a/ipay/ipay/main/utils/verify_mpesa_payment.py
+++ b/ipay/ipay/main/utils/verify_mpesa_payment.py
@@ -1,21 +1,16 @@
-import requests
-import hmac
-import hashlib
 import time
 import logging
-import frappe 
-from requests.exceptions import RequestException 
+import requests
+import frappe
+from requests.exceptions import RequestException
+
+from ipay.ipay.main.utils.constants import search_hash
 
 logger = logging.getLogger(__name__)
 
 # Helper function to delay execution
 def delay(ms):
     time.sleep(ms / 1000.0)
-    
-# Helper function to create HMAC hash
-def create_hash(oid, vid, secret_key):
-    data_string = f'{oid}{vid}'
-    return hmac.new(secret_key.encode(), data_string.encode(), hashlib.sha256).hexdigest()
 
 # Isolate the API call to a separate function
 def make_verification_call(verification_payload):
@@ -38,7 +33,7 @@ def verify_mpesa_payment(oid, phone, vid, secret_key):
     # Initial delay before verification
     delay(initial_delay)
     
-    hash_value = create_hash(oid, vid, secret_key)
+    hash_value = search_hash(oid, vid, secret_key)
     verification_payload = {
         'vid': vid,
         'hash': hash_value,

--- a/ipay/patches.txt
+++ b/ipay/patches.txt
@@ -1,0 +1,4 @@
+[pre_model_sync]
+
+[post_model_sync]
+ipay.patches.v1_0.migrate_request_status

--- a/ipay/patches/v1_0/migrate_request_status.py
+++ b/ipay/patches/v1_0/migrate_request_status.py
@@ -1,0 +1,26 @@
+import frappe
+
+# Map the old, overloaded iPay Request statuses onto the refined taxonomy
+# (Pending / Success / Underpaid / Overpaid / Failed / Abandoned).
+#
+#   ""                          -> Pending   (no explicit pending state before)
+#   "Error"                     -> Failed    (merged failure states)
+#   "Failed to complete request"-> Failed
+#   "Amount Mismatch"           -> Overpaid  (legacy catch-all; treat the
+#                                             excess as customer credit. None
+#                                             exist in practice, but map it so
+#                                             no row keeps an out-of-list value)
+STATUS_MAP = {
+    "": "Pending",
+    "Error": "Failed",
+    "Failed to complete request": "Failed",
+    "Amount Mismatch": "Overpaid",
+}
+
+
+def execute():
+    for old, new in STATUS_MAP.items():
+        frappe.db.sql(
+            "UPDATE `tabiPay Request` SET status = %s WHERE IFNULL(status, '') = %s",
+            (new, old),
+        )

--- a/ipay/www/collect_payments.html
+++ b/ipay/www/collect_payments.html
@@ -65,11 +65,17 @@
                placeholder="Search invoice, customer or delivery note…" autocomplete="off">
       </div>
 
+      <button type="button" id="ipay-bundle-btn" class="btn btn-outline-primary btn-sm mb-2"
+              onclick="ipayBundleSelected()" style="display: none;">
+        Pay selected together
+      </button>
+
       {% if invoices %}
       <div class="table-responsive">
         <table class="table ipay-table" id="ipay-invoice-table">
           <thead>
             <tr>
+              <th style="width: 32px;"></th>
               <th>Invoice</th>
               <th>Customer</th>
               <th>Delivery Note</th>
@@ -79,7 +85,11 @@
           </thead>
           <tbody>
             {% for inv in invoices %}
-            <tr data-invoice="{{ inv.name }}">
+            <tr data-invoice="{{ inv.name }}" data-customer="{{ inv.customer }}">
+              <td>
+                <input type="checkbox" class="ipay-select"
+                       data-invoice="{{ inv.name }}" data-customer="{{ inv.customer }}">
+              </td>
               <td class="ipay-inv">{{ inv.name }}</td>
               <td>{{ inv.customer_name }}</td>
               <td class="ipay-dn">{{ inv.delivery_note or "—" }}</td>
@@ -184,6 +194,41 @@ function ipayPromptMpesa(invoice) {
     }
   });
 }
+
+function ipayBundleSelected() {
+  var checked = Array.prototype.slice.call(document.querySelectorAll(".ipay-select:checked"));
+  if (!checked.length) { ipayNotify("Select at least one invoice.", "warning"); return; }
+  var customers = {}, invoices = [];
+  checked.forEach(function (cb) { customers[cb.dataset.customer] = 1; invoices.push(cb.dataset.invoice); });
+  var custList = Object.keys(customers);
+  if (custList.length > 1) {
+    ipayNotify("All selected invoices must belong to the same customer to bundle.", "danger");
+    return;
+  }
+  frappe.call({
+    method: "ipay.ipay.main.utils.ipay_redirect.create_bundle",
+    args: { customer: custList[0], invoices: JSON.stringify(invoices) },
+    freeze: true,
+    callback: function (r) {
+      var res = r.message || {};
+      if (res.url) { window.location = res.url; }
+      else { ipayNotify("Could not create the bundle.", "danger"); }
+    }
+  });
+}
+
+(function () {
+  function refreshBundleBtn() {
+    var checked = document.querySelectorAll(".ipay-select:checked");
+    var btn = document.getElementById("ipay-bundle-btn");
+    if (!btn) { return; }
+    btn.style.display = checked.length ? "" : "none";
+    btn.textContent = "Pay " + checked.length + " selected together";
+  }
+  document.querySelectorAll(".ipay-select").forEach(function (cb) {
+    cb.addEventListener("change", refreshBundleBtn);
+  });
+})();
 
 (function () {
   var search = document.getElementById("ipay-search");

--- a/ipay/www/collect_payments.html
+++ b/ipay/www/collect_payments.html
@@ -25,6 +25,13 @@
   .ipay-amount { font-weight: 600; font-variant-numeric: tabular-nums; color: #1f2937; }
   .ipay-actions .btn { border-radius: 8px; font-weight: 500; }
   .ipay-empty { text-align: center; color: #94a3b8; padding: 48px 0; }
+  .ipay-stats { display: flex; flex-wrap: wrap; gap: 12px; margin: 4px 0 18px; }
+  .ipay-stat { flex: 1 1 0; min-width: 150px; border: 1px solid #edf2f7; border-radius: 12px; padding: 12px 14px; }
+  .ipay-stat .label { font-size: .72rem; text-transform: uppercase; letter-spacing: .04em; color: #94a3b8; }
+  .ipay-stat .value { font-size: 1.3rem; font-weight: 700; font-variant-numeric: tabular-nums; margin-top: 2px; }
+  .ipay-stat .sub { font-size: .8rem; color: #94a3b8; }
+  .ipay-stat.collected .value { color: #15803d; }
+  .ipay-stat.outstanding .value { color: #b45309; }
   #ipay-alerts:not(:empty) { margin-top: 16px; }
   @media (max-width: 576px) { .ipay-collect { margin: 16px; } .ipay-collect .card-body { padding: 1.25rem !important; } }
 </style>
@@ -34,6 +41,19 @@
     <div class="card-body p-4">
       <h3 class="mb-1">Collect Payment</h3>
       <p class="text-muted mb-2">Prompt a customer for payment. Pick the option that matches how they want to pay.</p>
+
+      <div class="ipay-stats">
+        <div class="ipay-stat collected">
+          <div class="label">Collected today</div>
+          <div class="value">KES {{ "{:,.2f}".format(collected_today or 0) }}</div>
+          <div class="sub">All time: KES {{ "{:,.2f}".format(collected_total or 0) }}</div>
+        </div>
+        <div class="ipay-stat outstanding">
+          <div class="label">Yet to collect &mdash; today's invoices</div>
+          <div class="value">KES {{ "{:,.2f}".format(outstanding_today or 0) }}</div>
+          <div class="sub">All outstanding: KES {{ "{:,.2f}".format(outstanding_total or 0) }}</div>
+        </div>
+      </div>
 
       <span class="ipay-help-toggle" onclick="ipayToggleHelp()">
         <span id="ipay-help-caret">&#9656;</span> Which option should I use?

--- a/ipay/www/collect_payments.html
+++ b/ipay/www/collect_payments.html
@@ -183,6 +183,9 @@ function ipayPoll(request, invoice) {
           clearInterval(iv);
           ipayNotify("<strong>Payment received</strong> &mdash; " + (s.detail ? ipayEsc(s.detail) : ipayEsc(invoice)), "success");
           ipayRemoveRow(invoice);
+        } else if (s.partial) {
+          clearInterval(iv);
+          ipayNotify("<strong>Payment received (" + ipayEsc(s.status) + ")</strong> for " + ipayEsc(invoice) + " &mdash; " + (s.detail ? ipayEsc(s.detail) : "amount differs from the balance; the balance is still outstanding"), "warning");
         } else if (s.failed) {
           clearInterval(iv);
           ipayNotify("<strong>Payment failed</strong> (" + ipayEsc(invoice) + ") &mdash; " + (s.detail ? ipayEsc(s.detail) : "no reason given"), "danger");

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -17,7 +17,7 @@ def get_context(context):
     invoices = frappe.get_all(
         "Sales Invoice",
         filters={"docstatus": 1, "is_return": 0, "outstanding_amount": [">", 0]},
-        fields=["name", "customer_name", "outstanding_amount", "posting_date"],
+        fields=["name", "customer", "customer_name", "outstanding_amount", "posting_date"],
         order_by="posting_date desc",
         limit_page_length=100,
     )

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -1,7 +1,35 @@
 import frappe
+from frappe.utils import flt, today
 
 # Roles allowed to use the collection page.
 ALLOWED_ROLES = {"System Manager", "iPay Manager", "iPay User"}
+
+
+def _sum_outstanding(extra_filters=None):
+    """Sum of outstanding on submitted, non-return, unpaid Sales Invoices."""
+    filters = {"docstatus": 1, "is_return": 0, "outstanding_amount": [">", 0]}
+    if extra_filters:
+        filters.update(extra_filters)
+    rows = frappe.get_all("Sales Invoice", filters=filters, fields=["sum(outstanding_amount) as total"])
+    return flt(rows[0].total) if rows else 0
+
+
+def _collected_totals(today_date):
+    """Collected via iPay = paid_amount of Payment Entries linked from iPay
+    Requests. Returns (overall, today)."""
+    row = frappe.db.sql(
+        """
+        select
+            coalesce(sum(pe.paid_amount), 0) as total,
+            coalesce(sum(case when pe.posting_date = %(today)s then pe.paid_amount else 0 end), 0) as today_total
+        from `tabPayment Entry` pe
+        inner join `tabiPay Request` ir on ir.payment_entry = pe.name
+        where pe.docstatus = 1
+        """,
+        {"today": today_date},
+        as_dict=True,
+    )
+    return (flt(row[0].total), flt(row[0].today_total)) if row else (0, 0)
 
 
 def get_context(context):
@@ -38,3 +66,9 @@ def get_context(context):
 
     context.invoices = invoices
     context.enable_redirect = frappe.db.get_single_value("iPay Settings", "enable_redirect")
+
+    # Collection totals: collected via iPay vs still outstanding, today and overall.
+    today_date = today()
+    context.collected_total, context.collected_today = _collected_totals(today_date)
+    context.outstanding_total = _sum_outstanding()
+    context.outstanding_today = _sum_outstanding({"posting_date": today_date})

--- a/ipay/www/pay.html
+++ b/ipay/www/pay.html
@@ -79,6 +79,9 @@ function ipayPayPoll() {
         if (s.paid) {
           clearInterval(iv);
           ipayPayNotify("<strong>Payment received.</strong> Thank you!", "success");
+        } else if (s.partial) {
+          clearInterval(iv);
+          ipayPayNotify("<strong>Payment received.</strong> The amount differs from the balance &mdash; our team will reconcile it shortly.", "info");
         } else if (s.failed) {
           clearInterval(iv);
           ipayPayNotify("<strong>Payment failed.</strong> Please try again.", "danger");

--- a/ipay/www/payment_status.py
+++ b/ipay/www/payment_status.py
@@ -10,4 +10,4 @@ def get_context(context):
         status = frappe.db.get_value("iPay Request", request_name, "status")
 
     context.confirmed = status == "Success"
-    context.mismatch = status == "Amount Mismatch"
+    context.mismatch = status in ("Underpaid", "Overpaid")


### PR DESCRIPTION
Part of #42. Stacked on PR-B #50 (base `feat/ipay-bundle-invoices`).

This PR began as **PR-C, the bundle/split UI**, but now also carries the
follow-on hardening, a finalisation refactor, the request status taxonomy, and
two small operational features built on top of it. Grouped by theme below.

## Bundling

- **Collect page:** a select checkbox per invoice + a **"Pay N selected together"** button that bundles the selected invoices (same customer, same company) via `create_bundle` and sends the operator to the bundle's **/pay** page (M-Pesa STK or hosted checkout).
- **`create_bundle`** returns the `/pay` link and writes the true bundle total back to `amount` (the field has `fetch_from` the primary invoice's outstanding, which otherwise overrode the sum on insert and would undercharge bundles).
- **`split_bundle`** + a **"Split into Individual Requests"** button on the iPay Request form (unpaid bundles only): turns a bundle into one request per invoice and cancels the bundle.
- **Desk-created bundles:** the iPay Request controller sums `amount` from the `invoices` table and validates that every invoice shares the request's customer and one company, so a multi-invoice request can be created directly from the desk.

## Collection page totals

- Stat cards on the collection page showing **collected today / overall** and **yet-to-collect today / overall**, derived from iPay Request → Payment Entry.

## Scheduler & account hardening

- **log-cleanup scheduler fixed:** `del_old_logs()` referenced variables that never existed and raised `NameError` — the daily job was silently dead. Now references the real `inf_logs`/`err_logs`.
- **Multi-company receiving account:** `make_payment_entry` derives the cash account from the invoice's company (Default Cash Account → iPay Settings *Cash Account (fallback)* → legacy string) and sets the Payment Entry `company` explicitly, instead of a hardcoded `Cash - TSL`.
- `iPay Logs.time` is now `Datetime` (was `Data`); `lipana_mpesa` is POST-only; redundant `logging.basicConfig()` calls removed from utility modules.

## Payment finalisation refactor + status taxonomy

- **One finalisation path** (`finalize_payment`) now used by all four finalisers — in-session STK, manual desk verify, hosted-checkout redirect return, and the reconcile poller — so the Payment Entry, request status, and n8n callback stay consistent regardless of which path runs. Shared order-id cleaning, the REST hash, and the amount comparison are extracted into `constants.py`.
- **Refined status taxonomy:** `Pending · Success · Underpaid · Overpaid · Failed · Abandoned`, replacing the overloaded `Amount Mismatch` / `Error` / `Failed to complete request`. Status is resolved purely from the allocated amount (reported identically for fresh and duplicate Payment Entries), so re-running finalisation is idempotent and never flips a prior status.
- **Reconcile poller** marks genuinely-unpaid requests `Abandoned` once past the window (after a final lookup) so dead requests stop being polled, never abandons a recorded payment, and keeps retrying the callback for a paid-but-undelivered request.
- A **migration patch** (`v1_0/migrate_request_status`) maps existing rows onto the new taxonomy.

## Operational features

- **Clickable payment link** on the iPay Request form: a read-only field renders the tokenised `/pay` link as a hyperlink (in addition to the existing "Copy Payment Link" popup).
- **Public `get_transaction` API** — `ipay.api.get_transaction(oid)`, path `/api/method/ipay.api.get_transaction`. An authenticated endpoint for other applications to confirm a payment and read its details in one call, returning `{oid, paid, data}`. Reuses the existing transaction lookup; verified live against a real paid oid and against pending/unknown oids.

## Verification

- Allocation verified on a real payment-term invoice (full / partial / over, rolled back).
- The finalisation refactor + status taxonomy went through two adversarial review passes; every confirmed finding (Abandoned-sweep corrupting paid requests, a status re-run flip, a hidden desk error, pollers spinning on partial payments, and an infinite-poll regression) was fixed before merge. `get_transaction` verified live.

## Follow-ups (not in this PR)

- Credentials (`api_key`) are still stored as `Data`, not `Password` — careful change (reads feed four HMAC sites).
- Optional: sign outbound callbacks (HMAC), redact PII from logs, token TTL on payment links, and surfacing iPay's `reason` code to distinguish "pending" from "unknown oid" in `get_transaction`.
