### PR TITLE
feat(ipay): prepaid suppression, missing-contact UX, driver filter, and iPay Collector role

### DIFF
--- a/ipay/hooks.py
+++ b/ipay/hooks.py
@@ -100,13 +100,13 @@ app_include_js = 'sales_invoice.bundle.js'
 # -----------
 # Permissions evaluated in scripted ways
 
-# permission_query_conditions = {
-# 	"Event": "frappe.desk.doctype.event.event.get_permission_query_conditions",
-# }
-#
-# has_permission = {
-# 	"Event": "frappe.desk.doctype.event.event.has_permission",
-# }
+permission_query_conditions = {
+	"iPay Request": "ipay.ipay.main.utils.permissions.ipay_request_query_conditions",
+}
+
+has_permission = {
+	"iPay Request": "ipay.ipay.main.utils.permissions.ipay_request_has_permission",
+}
 
 # DocType Class
 # ---------------

--- a/ipay/ipay/doctype/ipay_request/ipay_request.js
+++ b/ipay/ipay/doctype/ipay_request/ipay_request.js
@@ -69,43 +69,39 @@ frappe.ui.form.on('iPay Request', {
       // Add "Prompt iPay" button if submitted and status is not success
       if (submitted && status !== 'Success') {
          frm.add_custom_button(__('Prompt iPay'), () => {
-            // Check if customer phone or email is missing
-            if (!frm.doc.customer_phone || !frm.doc.customer_email) {
+            // Block only on a missing PHONE (email is optional for iPay). Offer
+            // to enter a number now and save it to the Customer for next time.
+            if (!frm.doc.customer_phone) {
                frappe.msgprint({
-                  title: __('Customer Phone OR Email Missing'),
-                  message: __('The Phone and Email of the customer has to be provided in the Customer Doctype.'),
+                  title: __('Customer Phone Missing'),
+                  message: __('This customer has no phone number on file. Enter one to prompt for payment — it is saved to the Customer so future requests are pre-filled.'),
                   primary_action: {
-                     label: __('Go to Customer'),
+                     label: __('Enter & Save Number'),
                      action() {
-                        frappe.set_route('Form', 'Customer', frm.doc.customer);
+                        frappe.prompt(
+                           [
+                              { label: 'Customer Phone', fieldname: 'phone', fieldtype: 'Data', reqd: 1 },
+                              { label: 'Customer Email (optional)', fieldname: 'email', fieldtype: 'Data' },
+                           ],
+                           (v) => {
+                              frappe.call({
+                                 method: 'ipay.ipay.main.utils.ipay_redirect.save_customer_contact',
+                                 args: { request: frm.doc.name, phone: v.phone, email: v.email },
+                                 callback: () => {
+                                    frappe.hide_msgprint();
+                                    frappe.show_alert({ message: __('Saved. Click "Prompt iPay" again to continue.'), indicator: 'green' });
+                                    frm.reload_doc();
+                                 },
+                              });
+                           },
+                           __('Enter Customer Contact'), __('Save')
+                        );
                      },
                   },
                   secondary_action: {
-                     label: __('Fetch Customer Details'),
+                     label: __('Go to Customer'),
                      action() {
-                        // Fetch customer details via API call
-                        frappe.call({
-                           method: 'frappe.client.get',
-                           args: {
-                              doctype: 'Customer',
-                              name: frm.doc.customer,
-                           },
-                           callback: function (r) {
-                              if (r.message) {
-                                 const customer = r.message;
-                                 frm.set_value('customer_phone', customer.mobile_no || '');
-                                 frm.set_value('customer_email', customer.email_id || '');
-                                 frappe.msgprint(__('Customer details fetched successfully'));
-                                 frm.save(); // Save updated values
-                              } else {
-                                 frappe.msgprint(__('No customer details found'));
-                              }
-                           },
-                           error: function (err) {
-                              frappe.msgprint(__('Failed to fetch customer details.'));
-                              console.error('Fetch Customer Details Error:', err);
-                           },
-                        });
+                        frappe.set_route('Form', 'Customer', frm.doc.customer);
                      },
                   },
                });
@@ -146,7 +142,7 @@ frappe.ui.form.on('iPay Request', {
                         fieldname: 'customer_email',
                         fieldtype: 'Data',
                         default: frm.doc.customer_email,
-                        reqd: 1,
+                        reqd: 0,
                      },
                      {
                         label: 'Payment Method',
@@ -174,6 +170,14 @@ frappe.ui.form.on('iPay Request', {
                            if (frm.doc.prompted_number && customerPhoneLast8 === promptedPhoneLast8) {
                               frappe.db.set_value('iPay Request', frm.doc.name, 'prompted_number', null);
                            }
+
+                           // Persist any newly-entered contact to the Customer
+                           // (the server writes only blank fields), so future
+                           // requests are pre-filled and never error.
+                           frappe.call({
+                              method: 'ipay.ipay.main.utils.ipay_redirect.save_customer_contact',
+                              args: { request: frm.doc.name, phone: values.customer_phone, email: values.customer_email },
+                           });
 
                            // Display success alert
                            frappe.show_alert({ message: 'iPay Prompted', indicator: 'green' }, 7);

--- a/ipay/ipay/doctype/ipay_request/ipay_request.py
+++ b/ipay/ipay/doctype/ipay_request/ipay_request.py
@@ -5,14 +5,40 @@ import frappe
 from frappe.utils import flt
 from frappe.website.website_generator import WebsiteGenerator
 
+from ipay.ipay.main.utils.prepaid import is_sales_invoice_prepaid
+
 
 class iPayRequest(WebsiteGenerator):
 	def before_validate(self):
+		# Prepaid invoices are settled automatically (wave_sync creates their
+		# Payment Entry on submit), so they never need an iPay request. This is
+		# the one chokepoint every creation path funnels through. Only check on
+		# create — the classification never changes and later saves shouldn't pay
+		# the query cost. Drop prepaid invoices from a bundle; block a single one.
+		if self.is_new():
+			if self.invoices:
+				self.set("invoices", [
+					row for row in self.invoices
+					if not is_sales_invoice_prepaid(row.sales_invoice)
+				])
+				if not self.invoices:
+					frappe.throw(
+						"All selected invoices are prepaid and settle automatically; "
+						"no iPay payment request is needed."
+					)
+			elif self.sales_invoice and is_sales_invoice_prepaid(self.sales_invoice):
+				frappe.throw(
+					"This invoice is prepaid and settles automatically; "
+					"no iPay payment request is needed."
+				)
+
 		# For a bundle (the `invoices` table), default the primary Sales Invoice
-		# from the first row so the mandatory sales_invoice field is satisfied
+		# from a remaining row so the mandatory sales_invoice field is satisfied
 		# from the table alone (e.g. when created from the desk).
-		if self.invoices and not self.sales_invoice:
-			self.sales_invoice = self.invoices[0].sales_invoice
+		if self.invoices:
+			names = {row.sales_invoice for row in self.invoices}
+			if not self.sales_invoice or self.sales_invoice not in names:
+				self.sales_invoice = self.invoices[0].sales_invoice
 
 	def validate(self):
 		# A single-invoice request keeps the fetched amount; a bundle's amount is

--- a/ipay/ipay/doctype/ipay_request/ipay_request_list.js
+++ b/ipay/ipay/doctype/ipay_request/ipay_request_list.js
@@ -1,0 +1,10 @@
+// Passive alarm: flag iPay Requests that have no phone number, since M-Pesa
+// prompts cannot be sent without one. Pure list-view config, no backend.
+frappe.listview_settings['iPay Request'] = {
+   add_fields: ['customer_phone', 'status'],
+   get_indicator(doc) {
+      if (!doc.customer_phone && doc.status !== 'Success') {
+         return [__('Missing phone'), 'red', 'customer_phone,is,not set'];
+      }
+   },
+};

--- a/ipay/ipay/main/main.py
+++ b/ipay/ipay/main/main.py
@@ -14,6 +14,15 @@ logger = logging.getLogger(__name__)
 def lipana_mpesa(
     docid, user_id, phone, amount, oid, customer_email, payment_request_type
 ):
+    # Direct HTTP callers (the desk "Prompt iPay" button — or an attacker) must
+    # be an authorised operator acting on their own request. Background calls
+    # (enqueued by prompt_mpesa / pay_prompt_mpesa) have no HTTP request and were
+    # already authorised upstream, so they skip this gate.
+    if getattr(frappe.local, "request", None):
+        from ipay.ipay.main.utils.ipay_redirect import _require_operator, _require_request_access
+
+        _require_operator()
+        _require_request_access(docid)
 
     logger.info(
         f"Received doc name: {docid}, Customer Email: {customer_email}, "

--- a/ipay/ipay/main/utils/collector.py
+++ b/ipay/ipay/main/utils/collector.py
@@ -1,0 +1,110 @@
+"""Visibility scoping for the iPay Collector role.
+
+A collector is a delivery person who may prompt/collect payment only for their
+own work. "Their work" is the union of two signals (per product decision):
+
+  * Driver-based — invoices delivered by one of their drivers
+    (Delivery Note.driver -> Driver.user == the collector's login).
+  * Explicit assignment — iPay Requests assigned to them via Frappe's native
+    "Assign To" (the _assign field).
+
+Full operators (System Manager / iPay Manager / iPay User) are never scoped.
+Everything degrades safely: with no driver mapping and no assignment, a
+collector simply sees nothing rather than everything.
+"""
+
+import frappe
+
+COLLECTOR_ROLE = "iPay Collector"
+OPERATOR_ROLES = {"System Manager", "iPay Manager", "iPay User"}
+
+
+def is_collector_only(user=None):
+    """True when the user is a collector and NOT a full operator (so their view
+    must be scoped). Full operators short-circuit every check to unrestricted."""
+    user = user or frappe.session.user
+    roles = set(frappe.get_roles(user))
+    return COLLECTOR_ROLE in roles and not (OPERATOR_ROLES & roles)
+
+
+def my_driver_ids(user=None):
+    """Driver records mapped to this user via the Driver.user link."""
+    user = user or frappe.session.user
+    if not frappe.get_meta("Driver").has_field("user"):
+        return []
+    return frappe.get_all("Driver", filters={"user": user}, pluck="name")
+
+
+def _assign_like(user):
+    # _assign stores a JSON array of user ids, e.g. ["a@x.com"].
+    return ["like", f'%"{user}"%']
+
+
+def my_assigned_requests(user=None):
+    """iPay Requests explicitly assigned to this user (native _assign)."""
+    user = user or frappe.session.user
+    return frappe.get_all("iPay Request", filters={"_assign": _assign_like(user)}, pluck="name")
+
+
+def _invoices_delivered_by(drivers):
+    """Sales Invoices whose delivery note's driver is one of `drivers`."""
+    if not drivers:
+        return set()
+    dns = frappe.get_all(
+        "Delivery Note", filters={"driver": ["in", drivers], "docstatus": 1}, pluck="name"
+    )
+    if not dns:
+        return set()
+    return set(frappe.get_all(
+        "Sales Invoice Item", filters={"delivery_note": ["in", dns]}, pluck="parent"
+    ))
+
+
+def collector_scope(user=None):
+    """The set of Sales Invoices and iPay Requests a collector may see.
+
+    invoices = driver-delivered ∪ assigned-request invoices (single + bundle).
+    requests = explicitly-assigned ∪ requests covering a driver-delivered invoice.
+    """
+    user = user or frappe.session.user
+    invoices = _invoices_delivered_by(my_driver_ids(user))
+    requests = set(my_assigned_requests(user))
+
+    if requests:
+        invoices.update(frappe.get_all(
+            "iPay Request", filters={"name": ["in", list(requests)]}, pluck="sales_invoice"
+        ))
+        invoices.update(frappe.get_all(
+            "iPay Request Invoice", filters={"parent": ["in", list(requests)]}, pluck="sales_invoice"
+        ))
+
+    if invoices:
+        requests.update(frappe.get_all(
+            "iPay Request", filters={"sales_invoice": ["in", list(invoices)]}, pluck="name"
+        ))
+
+    invoices.discard(None)
+    requests.discard(None)
+    return {"invoices": invoices, "requests": requests}
+
+
+def can_access_invoice(sales_invoice, user=None):
+    """May this user prompt/collect for the given invoice? Always True for full
+    operators; for a collector, only their own work."""
+    user = user or frappe.session.user
+    if not is_collector_only(user):
+        return True
+    if not sales_invoice:
+        return False
+    return sales_invoice in collector_scope(user)["invoices"]
+
+
+def can_access_request(request_name, user=None):
+    """May this user act on the given iPay Request? Always True for full
+    operators; for a collector, only their assigned/driver-mapped requests."""
+    user = user or frappe.session.user
+    if not is_collector_only(user):
+        return True
+    if not request_name:
+        return False
+    return request_name in collector_scope(user)["requests"]

--- a/ipay/ipay/main/utils/confirm_payment.py
+++ b/ipay/ipay/main/utils/confirm_payment.py
@@ -18,6 +18,12 @@ def confirm_payment(docid, user_id, phone, amount, order, customer_email):
     if found, finalise it via the shared path — record the Payment Entry, set
     the request status and notify the callback. Returns the recorded result so
     the desk can show the Payment Entry link."""
+    # Authorised operators only, acting on their own request (this creates a
+    # Payment Entry, so it must not be callable by name for an arbitrary request).
+    from ipay.ipay.main.utils.ipay_redirect import _require_operator, _require_request_access
+
+    _require_operator()
+    _require_request_access(docid)
     vendor = frappe.get_doc("iPay Settings")
     vid = (vendor.vendor_id or "").lower()
     secret_key = vendor.api_key

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -7,6 +7,7 @@ import frappe
 from ipay.ipay.main.utils.reconcile_payments import reconcile_request
 from ipay.ipay.main.utils.ipay_logs import create_log_entry
 from ipay.ipay.main.utils.constants import clean_oid
+from ipay.ipay.main.utils.prepaid import is_sales_invoice_prepaid
 
 # Hosted checkout (HTML form POST). NB: this flow uses HMAC-SHA1 over the
 # documented field order — it is NOT the REST /transact SHA256 flow.
@@ -248,12 +249,15 @@ def create_bundle(customer, invoices):
             frappe.throw(f"Invoice {name} does not belong to {customer}.")
         if frappe.utils.flt(si.outstanding_amount) <= 0:
             continue
+        # Prepaid invoices settle automatically — never bundle them for collection.
+        if is_sales_invoice_prepaid(name):
+            continue
         companies.add(si.company)
         rows.append((si.posting_date, name))
         total += frappe.utils.flt(si.outstanding_amount)
 
     if not rows:
-        frappe.throw("None of the selected invoices have an outstanding balance.")
+        frappe.throw("None of the selected invoices need collection (paid, prepaid, or zero balance).")
     if len(companies) > 1:
         frappe.throw("All invoices in a bundle must belong to the same company.")
 
@@ -297,6 +301,10 @@ def split_bundle(request):
 
     created = []
     for name in invoice_names:
+        # A legacy bundle may contain a since-prepaid invoice; skip it rather
+        # than let the controller abort the whole split.
+        if is_sales_invoice_prepaid(name):
+            continue
         customer = frappe.db.get_value("Sales Invoice", name, "customer")
         single = frappe.get_doc(
             {

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -360,6 +360,11 @@ def split_bundle(request):
         single.insert(ignore_permissions=True)
         created.append(single.name)
 
+    # Don't cancel the bundle if nothing was re-created (e.g. every remaining
+    # invoice is prepaid) — that would silently drop the bundle.
+    if not created:
+        frappe.throw("All invoices in this bundle are prepaid; there is nothing to split.")
+
     bundle.flags.ignore_permissions = True
     bundle.cancel()
     return {"created": created}

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -18,13 +18,41 @@ HASH_FIELD_ORDER = [
 ]
 
 OPERATOR_ROLES = {"System Manager", "iPay Manager", "iPay User"}
+# Collectors may prompt/collect, but only for their own work — guarded per
+# invoice/request by the access checks below.
+ALL_OPERATOR_ROLES = OPERATOR_ROLES | {"iPay Collector"}
+
+
+def _require_full_operator():
+    """Guard supervisor-only endpoints (bundling): full operators, not collectors."""
+    if frappe.session.user == "Guest" or not (OPERATOR_ROLES & set(frappe.get_roles())):
+        frappe.throw("Not permitted.", frappe.PermissionError)
 
 
 def _require_operator():
-    """Guard operator-only endpoints. The page role-gate (collect_payments) does
-    not protect the underlying whitelisted methods, so enforce it here too."""
-    if frappe.session.user == "Guest" or not (OPERATOR_ROLES & set(frappe.get_roles())):
+    """Guard operator endpoints, allowing collectors. The page role-gate
+    (collect_payments) does not protect the underlying whitelisted methods, so
+    enforce it here too. Row-level ownership is enforced separately by
+    _require_invoice_access / _require_request_access."""
+    if frappe.session.user == "Guest" or not (ALL_OPERATOR_ROLES & set(frappe.get_roles())):
         frappe.throw("Not permitted.", frappe.PermissionError)
+
+
+def _require_invoice_access(invoice):
+    """A collector may only act on invoices that are their own work."""
+    from ipay.ipay.main.utils.collector import can_access_invoice
+
+    if not can_access_invoice(invoice):
+        frappe.throw("You are not assigned to this invoice.", frappe.PermissionError)
+
+
+def _require_request_access(request_name):
+    """A collector may only act on requests that are their own work — closes the
+    hole where any operator could poll/act on another's request by name."""
+    from ipay.ipay.main.utils.collector import can_access_request
+
+    if not can_access_request(request_name):
+        frappe.throw("You are not assigned to this request.", frappe.PermissionError)
 
 
 def normalize_phone(phone):
@@ -206,6 +234,7 @@ def start_checkout(invoice):
     """Operator action from the collection page: ensure a submitted iPay Request
     (and its token) exist, then send the browser to the hosted checkout."""
     _require_operator()
+    _require_invoice_access(invoice)
     request_name = _ensure_request(invoice)
     token = _ensure_pay_token(request_name)
     frappe.local.response["type"] = "redirect"
@@ -216,6 +245,10 @@ def start_checkout(invoice):
 def get_payment_link(invoice=None, request=None):
     """Return a shareable, tokenised payment link for an invoice or request."""
     _require_operator()
+    if request:
+        _require_request_access(request)
+    elif invoice:
+        _require_invoice_access(invoice)
     request_name = request or (_ensure_request(invoice) if invoice else None)
     if not request_name:
         frappe.throw("An invoice or iPay Request is required.")
@@ -233,7 +266,7 @@ def create_bundle(customer, invoices):
     """Create one submitted iPay Request covering several of a customer's
     invoices. amount = sum of their live outstanding; the oldest invoice is the
     primary. Payment is allocated oldest-first across them by make_payment_entry."""
-    _require_operator()
+    _require_full_operator()
 
     if isinstance(invoices, str):
         invoices = frappe.parse_json(invoices)
@@ -296,7 +329,7 @@ def create_bundle(customer, invoices):
 def split_bundle(request):
     """Split an unpaid bundle back into individual single-invoice requests and
     cancel the bundle. Only allowed before any payment is recorded."""
-    _require_operator()
+    _require_full_operator()
     bundle = frappe.get_doc("iPay Request", request)
     if bundle.status in ("Success", "Underpaid", "Overpaid") or bundle.payment_entry:
         frappe.throw("This request has a recorded payment and cannot be split.")
@@ -331,6 +364,7 @@ def split_bundle(request):
 def prompt_mpesa(invoice, phone=None):
     """Operator action (collection page): send an M-Pesa STK push for an invoice."""
     _require_operator()
+    _require_invoice_access(invoice)
     request_name = _ensure_request(invoice)
     result = _enqueue_stk(request_name, phone)
     result["request"] = request_name
@@ -341,6 +375,7 @@ def prompt_mpesa(invoice, phone=None):
 def payment_state(request):
     """Poll target for the collection page (operator, by request name)."""
     _require_operator()
+    _require_request_access(request)
     return _payment_state(request, include_detail=True)
 
 
@@ -353,6 +388,7 @@ def save_customer_contact(request, phone=None, email=None):
     Uses a low-level db.set_value because iPay operator/collector roles do not
     have Customer write permission; values are validated first."""
     _require_operator()
+    _require_request_access(request)
     customer = frappe.db.get_value("iPay Request", request, "customer")
     if not customer:
         frappe.throw("Unknown request.")

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -237,6 +237,11 @@ def start_checkout(invoice):
     _require_invoice_access(invoice)
     request_name = _ensure_request(invoice)
     token = _ensure_pay_token(request_name)
+    # This endpoint is reached by a GET (an <a> link), which Frappe treats as
+    # read-only and does NOT auto-commit — so the just-created request and token
+    # would be rolled back, and the checkout page would not find the token.
+    # Persist them explicitly before redirecting.
+    frappe.db.commit()
     frappe.local.response["type"] = "redirect"
     frappe.local.response["location"] = f"/ipay_checkout?token={token}"
 

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -180,7 +180,12 @@ def _enqueue_stk(request_name, phone):
     )
     phone = normalize_phone(phone or req.customer_phone)
     if not phone:
-        return {"status": "error", "message": "No phone number provided."}
+        # Structured signal so the caller can prompt for a number and save it
+        # back, rather than surfacing a dead-end error.
+        return {
+            "status": "missing_phone",
+            "message": "No M-Pesa phone number on file. Enter a number to charge.",
+        }
 
     frappe.enqueue(
         "ipay.ipay.main.main.lipana_mpesa",
@@ -337,6 +342,43 @@ def payment_state(request):
     """Poll target for the collection page (operator, by request name)."""
     _require_operator()
     return _payment_state(request, include_detail=True)
+
+
+@frappe.whitelist(methods=["POST"])
+def save_customer_contact(request, phone=None, email=None):
+    """Persist an operator-entered phone/email so future requests never error for
+    missing contact. Writes to the Customer master ONLY when that field is blank
+    (never overwrites an ad-hoc number), and refreshes the in-flight request.
+
+    Uses a low-level db.set_value because iPay operator/collector roles do not
+    have Customer write permission; values are validated first."""
+    _require_operator()
+    customer = frappe.db.get_value("iPay Request", request, "customer")
+    if not customer:
+        frappe.throw("Unknown request.")
+
+    customer_updates, request_updates, saved = {}, {}, []
+    if phone:
+        norm = normalize_phone(phone)
+        if not re.fullmatch(r"254(7|1)\d{8}", norm):
+            frappe.throw("Enter a valid Kenyan phone number (e.g. 0712345678).")
+        request_updates["customer_phone"] = norm
+        if not frappe.db.get_value("Customer", customer, "mobile_no"):
+            customer_updates["mobile_no"] = norm
+            saved.append("phone")
+    if email:
+        if not frappe.utils.validate_email_address(email):
+            frappe.throw("Enter a valid email address.")
+        request_updates["customer_email"] = email
+        if not frappe.db.get_value("Customer", customer, "email_id"):
+            customer_updates["email_id"] = email
+            saved.append("email")
+
+    if customer_updates:
+        frappe.db.set_value("Customer", customer, customer_updates)
+    if request_updates:
+        frappe.db.set_value("iPay Request", request, request_updates)
+    return {"status": "ok", "saved_to_customer": saved}
 
 
 @frappe.whitelist(allow_guest=True, methods=["POST"])

--- a/ipay/ipay/main/utils/permissions.py
+++ b/ipay/ipay/main/utils/permissions.py
@@ -1,0 +1,47 @@
+"""Desk row-level scoping for iPay Request (collectors see only their own).
+
+These hooks apply to frappe.get_list, list views and reports. They do NOT apply
+to the collect_payments page (it builds its own query and scopes itself) nor to
+frappe.get_all.
+"""
+
+import frappe
+
+from ipay.ipay.main.utils.collector import is_collector_only, my_driver_ids
+
+
+def ipay_request_query_conditions(user=None):
+    """SQL WHERE fragment limiting the iPay Request list to a collector's work:
+    requests assigned to them (_assign) OR delivered by one of their drivers."""
+    user = user or frappe.session.user
+    if not is_collector_only(user):
+        return ""
+
+    conditions = [
+        "`tabiPay Request`._assign like {0}".format(frappe.db.escape('%"' + user + '"%'))
+    ]
+    drivers = my_driver_ids(user)
+    if drivers:
+        driver_list = ", ".join(frappe.db.escape(d) for d in drivers)
+        conditions.append(
+            "`tabiPay Request`.sales_invoice in ("
+            "select sii.parent from `tabSales Invoice Item` sii "
+            "join `tabDelivery Note` dn on dn.name = sii.delivery_note "
+            "where dn.driver in ({0}))".format(driver_list)
+        )
+    return "(" + " or ".join(conditions) + ")"
+
+
+def ipay_request_has_permission(doc, ptype=None, user=None, **kwargs):
+    """Single-document check mirroring the list scoping above. Frappe also calls
+    this at the doctype level (doc is None / a string) and passes extra kwargs
+    (e.g. debug); allow those — row scoping is handled per-doc and by the query
+    conditions."""
+    user = user or frappe.session.user
+    if not is_collector_only(user):
+        return True
+    if not doc or isinstance(doc, str):
+        return True
+    from ipay.ipay.main.utils.collector import can_access_request
+
+    return can_access_request(doc.name, user)

--- a/ipay/ipay/main/utils/prepaid.py
+++ b/ipay/ipay/main/utils/prepaid.py
@@ -1,0 +1,36 @@
+"""Detect prepaid invoices so iPay never raises a payment request for them.
+
+A prepaid order is settled automatically by the wave_sync_hypa app (it creates
+the Payment Entry on Sales Invoice submit), so an iPay request, link or prompt
+for such an invoice is redundant and confusing. "Prepaid" is authoritative on
+the Sales Order via the wave_sync custom field `wave_payment_classification`.
+
+This replicates wave_sync's SI -> Sales Order trace with a couple of cheap
+reads rather than importing wave_sync (which already imports ipay — importing
+back would be circular). It degrades to "not prepaid" when the custom field is
+absent, so the iPay app still works standalone.
+"""
+
+import frappe
+
+PREPAID_CLASSIFICATION = "prepaid"
+
+
+def is_sales_invoice_prepaid(sales_invoice):
+    """True when any Sales Order behind this Sales Invoice is classified prepaid."""
+    if not sales_invoice:
+        return False
+    if not frappe.get_meta("Sales Order").has_field("wave_payment_classification"):
+        return False
+
+    sales_orders = frappe.get_all(
+        "Sales Invoice Item",
+        filters={"parent": sales_invoice, "sales_order": ["is", "set"]},
+        pluck="sales_order",
+        distinct=True,
+    )
+    for so in set(sales_orders):
+        classification = frappe.db.get_value("Sales Order", so, "wave_payment_classification")
+        if (classification or "").strip() == PREPAID_CLASSIFICATION:
+            return True
+    return False

--- a/ipay/ipay/main/utils/prepaid.py
+++ b/ipay/ipay/main/utils/prepaid.py
@@ -34,3 +34,29 @@ def is_sales_invoice_prepaid(sales_invoice):
         if (classification or "").strip() == PREPAID_CLASSIFICATION:
             return True
     return False
+
+
+def prepaid_invoice_names(sales_invoices):
+    """Subset of the given Sales Invoices that are prepaid (two batched queries).
+
+    Use this instead of calling is_sales_invoice_prepaid in a loop when checking
+    many invoices at once (e.g. the collection page list)."""
+    names = [n for n in (sales_invoices or []) if n]
+    if not names or not frappe.get_meta("Sales Order").has_field("wave_payment_classification"):
+        return set()
+
+    items = frappe.get_all(
+        "Sales Invoice Item",
+        filters={"parent": ["in", names], "sales_order": ["is", "set"]},
+        fields=["parent", "sales_order"],
+    )
+    sales_orders = {it.sales_order for it in items}
+    if not sales_orders:
+        return set()
+
+    prepaid_orders = set(frappe.get_all(
+        "Sales Order",
+        filters={"name": ["in", list(sales_orders)], "wave_payment_classification": PREPAID_CLASSIFICATION},
+        pluck="name",
+    ))
+    return {it.parent for it in items if it.sales_order in prepaid_orders}

--- a/ipay/patches.txt
+++ b/ipay/patches.txt
@@ -1,4 +1,5 @@
 [pre_model_sync]
+ipay.patches.v1_0.setup_collector
 
 [post_model_sync]
 ipay.patches.v1_0.migrate_request_status

--- a/ipay/patches/v1_0/setup_collector.py
+++ b/ipay/patches/v1_0/setup_collector.py
@@ -1,0 +1,35 @@
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+from frappe.permissions import add_permission, update_permission_property
+
+
+def execute():
+    if not frappe.db.exists("Role", "iPay Collector"):
+        frappe.get_doc(
+            {"doctype": "Role", "role_name": "iPay Collector", "desk_access": 1}
+        ).insert(ignore_permissions=True)
+
+    # iPay Request's permissions are customized (Custom DocPerm), so a DocPerm
+    # row in the doctype JSON is ignored. Grant the collector read/report via
+    # the permissions API, which writes the correct (Custom) DocPerm. Row-level
+    # narrowing is layered on by the permission hooks.
+    add_permission("iPay Request", "iPay Collector", 0)
+    for ptype in ("read", "report", "print", "email", "export"):
+        update_permission_property("iPay Request", "iPay Collector", 0, ptype, 1)
+
+    # Map a collector's login to their Driver record, for driver-based scoping.
+    create_custom_fields(
+        {
+            "Driver": [
+                {
+                    "fieldname": "user",
+                    "label": "User",
+                    "fieldtype": "Link",
+                    "options": "User",
+                    "insert_after": "employee",
+                    "description": "Login mapped to this driver, for iPay Collector visibility scoping.",
+                }
+            ]
+        },
+        ignore_validate=True,
+    )

--- a/ipay/www/collect_payments.html
+++ b/ipay/www/collect_payments.html
@@ -200,14 +200,26 @@ function ipayPoll(request, invoice) {
   iv = setInterval(check, 3000);
 }
 
-function ipayPromptMpesa(invoice) {
-  var phone = prompt("Customer phone for M-Pesa (leave blank to use the number on file):", "");
-  if (phone === null) { return; }
+function ipayPromptMpesa(invoice, phone) {
+  if (phone === undefined) {
+    phone = prompt("Customer phone for M-Pesa (leave blank to use the number on file):", "");
+    if (phone === null) { return; }
+  }
   frappe.call({
     method: "ipay.ipay.main.utils.ipay_redirect.prompt_mpesa",
     args: { invoice: invoice, phone: phone },
     callback: function (r) {
       var res = r.message || {};
+      if (res.status === "missing_phone") {
+        var entered = prompt("No phone on file for this customer. Enter an M-Pesa number to charge (saved for next time):", "");
+        if (!entered) { ipayNotify("A phone number is required to prompt " + invoice + ".", "warning"); return; }
+        frappe.call({
+          method: "ipay.ipay.main.utils.ipay_redirect.save_customer_contact",
+          args: { request: res.request, phone: entered },
+          callback: function () { ipayPromptMpesa(invoice, entered); }
+        });
+        return;
+      }
       if (res.status === "error") {
         ipayNotify("Cannot prompt " + invoice + ": " + (res.message || "unknown error"), "danger");
         return;

--- a/ipay/www/collect_payments.html
+++ b/ipay/www/collect_payments.html
@@ -113,7 +113,7 @@
           </thead>
           <tbody>
             {% for inv in invoices %}
-            <tr data-invoice="{{ inv.name }}" data-customer="{{ inv.customer }}" data-driver="{{ inv.driver_name or '' }}">
+            <tr data-invoice="{{ inv.name }}" data-customer="{{ inv.customer }}" data-driver="{{ inv.driver_filter or '' }}">
               <td>
                 <input type="checkbox" class="ipay-select"
                        data-invoice="{{ inv.name }}" data-customer="{{ inv.customer }}">
@@ -286,7 +286,8 @@ function ipayBundleSelected() {
     var shown = 0;
     rows.forEach(function (row) {
       var textMatch = row.textContent.toLowerCase().indexOf(q) > -1;
-      var driverMatch = !driver || (row.dataset.driver || "") === driver;
+      var rowDrivers = (row.dataset.driver || "").split("|");
+      var driverMatch = !driver || rowDrivers.indexOf(driver) > -1;
       var match = textMatch && driverMatch;
       row.style.display = match ? "" : "none";
       if (match) { shown++; }

--- a/ipay/www/collect_payments.html
+++ b/ipay/www/collect_payments.html
@@ -85,6 +85,13 @@
                placeholder="Search invoice, customer or delivery note…" autocomplete="off">
       </div>
 
+      {% if drivers %}
+      <select id="ipay-driver-filter" class="form-control mt-2" style="max-width: 280px;">
+        <option value="">All drivers</option>
+        {% for d in drivers %}<option value="{{ d }}">{{ d }}</option>{% endfor %}
+      </select>
+      {% endif %}
+
       <button type="button" id="ipay-bundle-btn" class="btn btn-outline-primary btn-sm mb-2"
               onclick="ipayBundleSelected()" style="display: none;">
         Pay selected together
@@ -99,13 +106,14 @@
               <th>Invoice</th>
               <th>Customer</th>
               <th>Delivery Note</th>
+              <th>Driver</th>
               <th class="text-right">Outstanding</th>
               <th class="text-right">Action</th>
             </tr>
           </thead>
           <tbody>
             {% for inv in invoices %}
-            <tr data-invoice="{{ inv.name }}" data-customer="{{ inv.customer }}">
+            <tr data-invoice="{{ inv.name }}" data-customer="{{ inv.customer }}" data-driver="{{ inv.driver_name or '' }}">
               <td>
                 <input type="checkbox" class="ipay-select"
                        data-invoice="{{ inv.name }}" data-customer="{{ inv.customer }}">
@@ -113,6 +121,7 @@
               <td class="ipay-inv">{{ inv.name }}</td>
               <td>{{ inv.customer_name }}</td>
               <td class="ipay-dn">{{ inv.delivery_note or "—" }}</td>
+              <td>{{ inv.driver_name or "—" }}</td>
               <td class="text-right ipay-amount">{{ "{:,.2f}".format(inv.outstanding_amount) }}</td>
               <td class="text-right ipay-actions" style="white-space: nowrap;">
                 <button type="button" class="btn btn-success btn-sm"
@@ -267,19 +276,27 @@ function ipayBundleSelected() {
 
 (function () {
   var search = document.getElementById("ipay-search");
-  if (!search) { return; }
-  search.addEventListener("keyup", function () {
-    var q = this.value.toLowerCase();
+  var driverFilter = document.getElementById("ipay-driver-filter");
+  if (!search && !driverFilter) { return; }
+
+  function applyFilters() {
+    var q = (search ? search.value : "").toLowerCase();
+    var driver = driverFilter ? driverFilter.value : "";
     var rows = document.querySelectorAll("#ipay-invoice-table tbody tr");
     var shown = 0;
     rows.forEach(function (row) {
-      var match = row.textContent.toLowerCase().indexOf(q) > -1;
+      var textMatch = row.textContent.toLowerCase().indexOf(q) > -1;
+      var driverMatch = !driver || (row.dataset.driver || "") === driver;
+      var match = textMatch && driverMatch;
       row.style.display = match ? "" : "none";
       if (match) { shown++; }
     });
     var none = document.getElementById("ipay-no-match");
     if (none) { none.style.display = shown ? "none" : ""; }
-  });
+  }
+
+  if (search) { search.addEventListener("keyup", applyFilters); }
+  if (driverFilter) { driverFilter.addEventListener("change", applyFilters); }
 })();
 </script>
 {% endblock %}

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -105,10 +105,14 @@ def get_context(context):
         for inv in invoices:
             dns = sorted(dn_map.get(inv.name, []))
             inv.delivery_note = ", ".join(dns)
-            inv.driver_name = next((driver_by_dn[n] for n in dns if driver_by_dn.get(n)), "")
+            # An invoice may span delivery notes with different drivers; keep all
+            # of them so the filter and the dropdown don't drop any.
+            inv.drivers = sorted({driver_by_dn[n] for n in dns if driver_by_dn.get(n)})
+            inv.driver_name = ", ".join(inv.drivers)
+            inv.driver_filter = "|".join(inv.drivers)
 
     context.invoices = invoices
-    context.drivers = sorted({inv.driver_name for inv in invoices if getattr(inv, "driver_name", "")})
+    context.drivers = sorted({d for inv in invoices for d in getattr(inv, "drivers", [])})
     context.enable_redirect = frappe.db.get_single_value("iPay Settings", "enable_redirect")
 
     # Collection totals: collected via iPay vs still outstanding, today and

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -1,6 +1,8 @@
 import frappe
 from frappe.utils import flt, today
 
+from ipay.ipay.main.utils.prepaid import prepaid_invoice_names
+
 # Roles allowed to use the collection page.
 ALLOWED_ROLES = {"System Manager", "iPay Manager", "iPay User"}
 
@@ -49,6 +51,12 @@ def get_context(context):
         order_by="posting_date desc",
         limit_page_length=100,
     )
+
+    # Prepaid invoices settle automatically and must never be collected here, so
+    # drop them from the list (no row, no link, no prompt).
+    prepaid = prepaid_invoice_names([inv.name for inv in invoices])
+    if prepaid:
+        invoices = [inv for inv in invoices if inv.name not in prepaid]
 
     # Attach the delivery note(s) linked to each invoice (one batched query).
     if invoices:

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -61,10 +61,27 @@ def get_context(context):
         dn_map = {}
         for link in links:
             dn_map.setdefault(link.parent, set()).add(link.delivery_note)
+
+        # Resolve each delivery note's driver (one batched query) so invoices can
+        # be filtered by driver on the page. The driver lives on the Delivery
+        # Note, not the Sales Invoice.
+        dn_names = {n for names_set in dn_map.values() for n in names_set}
+        driver_by_dn = {}
+        if dn_names:
+            for dn in frappe.get_all(
+                "Delivery Note",
+                filters={"name": ["in", list(dn_names)]},
+                fields=["name", "driver_name"],
+            ):
+                driver_by_dn[dn.name] = dn.driver_name or ""
+
         for inv in invoices:
-            inv.delivery_note = ", ".join(sorted(dn_map.get(inv.name, [])))
+            dns = sorted(dn_map.get(inv.name, []))
+            inv.delivery_note = ", ".join(dns)
+            inv.driver_name = next((driver_by_dn[n] for n in dns if driver_by_dn.get(n)), "")
 
     context.invoices = invoices
+    context.drivers = sorted({inv.driver_name for inv in invoices if getattr(inv, "driver_name", "")})
     context.enable_redirect = frappe.db.get_single_value("iPay Settings", "enable_redirect")
 
     # Collection totals: collected via iPay vs still outstanding, today and overall.

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -2,9 +2,10 @@ import frappe
 from frappe.utils import flt, today
 
 from ipay.ipay.main.utils.prepaid import prepaid_invoice_names
+from ipay.ipay.main.utils.collector import is_collector_only, collector_scope
 
 # Roles allowed to use the collection page.
-ALLOWED_ROLES = {"System Manager", "iPay Manager", "iPay User"}
+ALLOWED_ROLES = {"System Manager", "iPay Manager", "iPay User", "iPay Collector"}
 
 
 def _sum_outstanding(extra_filters=None):
@@ -16,19 +17,27 @@ def _sum_outstanding(extra_filters=None):
     return flt(rows[0].total) if rows else 0
 
 
-def _collected_totals(today_date):
+def _collected_totals(today_date, request_names=None):
     """Collected via iPay = paid_amount of Payment Entries linked from iPay
-    Requests. Returns (overall, today)."""
+    Requests. Returns (overall, today). When request_names is given (collector
+    view), restrict to those requests."""
+    scope_clause = ""
+    params = {"today": today_date}
+    if request_names is not None:
+        if not request_names:
+            return (0, 0)
+        scope_clause = "and ir.name in %(reqs)s"
+        params["reqs"] = tuple(request_names)
     row = frappe.db.sql(
-        """
+        f"""
         select
             coalesce(sum(pe.paid_amount), 0) as total,
             coalesce(sum(case when pe.posting_date = %(today)s then pe.paid_amount else 0 end), 0) as today_total
         from `tabPayment Entry` pe
         inner join `tabiPay Request` ir on ir.payment_entry = pe.name
-        where pe.docstatus = 1
+        where pe.docstatus = 1 {scope_clause}
         """,
-        {"today": today_date},
+        params,
         as_dict=True,
     )
     return (flt(row[0].total), flt(row[0].today_total)) if row else (0, 0)
@@ -44,9 +53,19 @@ def get_context(context):
     if not (ALLOWED_ROLES & set(frappe.get_roles())):
         frappe.throw("You are not permitted to collect payments.", frappe.PermissionError)
 
+    # A collector sees only their own work (driver-delivered + assigned); full
+    # operators see everything. Scope is computed once and reused for the list
+    # and the stat cards.
+    collector = is_collector_only(frappe.session.user)
+    scope = collector_scope(frappe.session.user) if collector else None
+
+    si_filters = {"docstatus": 1, "is_return": 0, "outstanding_amount": [">", 0]}
+    if collector:
+        si_filters["name"] = ["in", list(scope["invoices"]) or ["__none__"]]
+
     invoices = frappe.get_all(
         "Sales Invoice",
-        filters={"docstatus": 1, "is_return": 0, "outstanding_amount": [">", 0]},
+        filters=si_filters,
         fields=["name", "customer", "customer_name", "outstanding_amount", "posting_date"],
         order_by="posting_date desc",
         limit_page_length=100,
@@ -92,8 +111,17 @@ def get_context(context):
     context.drivers = sorted({inv.driver_name for inv in invoices if getattr(inv, "driver_name", "")})
     context.enable_redirect = frappe.db.get_single_value("iPay Settings", "enable_redirect")
 
-    # Collection totals: collected via iPay vs still outstanding, today and overall.
+    # Collection totals: collected via iPay vs still outstanding, today and
+    # overall — scoped to the collector's own book when applicable.
     today_date = today()
-    context.collected_total, context.collected_today = _collected_totals(today_date)
-    context.outstanding_total = _sum_outstanding()
-    context.outstanding_today = _sum_outstanding({"posting_date": today_date})
+    if collector:
+        inv_filter = {"name": ["in", list(scope["invoices"]) or ["__none__"]]}
+        context.collected_total, context.collected_today = _collected_totals(
+            today_date, list(scope["requests"])
+        )
+        context.outstanding_total = _sum_outstanding(inv_filter)
+        context.outstanding_today = _sum_outstanding({**inv_filter, "posting_date": today_date})
+    else:
+        context.collected_total, context.collected_today = _collected_totals(today_date)
+        context.outstanding_total = _sum_outstanding()
+        context.outstanding_today = _sum_outstanding({"posting_date": today_date})

--- a/ipay/www/pay.html
+++ b/ipay/www/pay.html
@@ -104,7 +104,9 @@ function ipayPaySubmitMpesa() {
     args: { token: IPAY_TOKEN, phone: phone },
     callback: function (r) {
       var res = r.message || {};
-      if (res.status === "error") { ipayPayNotify(res.message || "Could not start the payment.", "danger"); return; }
+      if (res.status === "error" || res.status === "missing_phone") {
+        ipayPayNotify(res.message || "Please enter a valid M-Pesa number.", "danger"); return;
+      }
       ipayPayNotify("M-Pesa prompt sent to " + phone + ". Enter your PIN on your phone&hellip;", "info");
       ipayPayPoll();
     }


### PR DESCRIPTION
Stacked on `feat/ipay-bundle-ui` (PR #51). Four operational features for the
delivery/collection workflow, plus security hardening surfaced by review.

## ① Prepaid orders never get an iPay request
Prepaid orders (Sales Order `wave_payment_classification == "prepaid"`) are
settled automatically by `wave_sync_hypa` on Sales Invoice submit, so an iPay
request/link/prompt for them is redundant. New `prepaid.py` traces SI Item →
Sales Order (guarded by `get_meta`, so iPay still works standalone). Enforced at
the single controller chokepoint (`iPayRequest.before_validate`, covering all
five creation paths): a single prepaid invoice is blocked; prepaid rows are
dropped from a bundle; `create_bundle`/`split_bundle` skip them; and the
collection page hides them.

## ② Missing email/phone — alarm, prompt, save-back
- Passive alarm: a "Missing phone" list-view indicator on iPay Request.
- Block-and-prompt: `_enqueue_stk` returns a structured `missing_phone` signal;
  the collect page and desk prompt for a number instead of erroring.
- Save-back: `save_customer_contact` writes an entered phone/email to the
  Customer **only when that field is blank** (never overwrites an ad-hoc
  number), validates it, and uses a low-level write (iPay roles lack Customer
  permission). Future requests then auto-fill. Phone is the real requirement, so
  the desk gate is relaxed to phone-only.

## ③ Filter the collection page by driver
The driver lives on the Delivery Note (not the SI), so each invoice is enriched
with its DN driver(s) via one batched query, shown in a Driver column, and
filterable by a client-side dropdown that ANDs with the search.

## ④ iPay Collector role with assigned-only visibility
A new `iPay Collector` role for delivery staff who may prompt/collect only their
own work, on both the desk list and the collection page. "Their work" is the
union of two signals: **driver-based** (Delivery Note driver → a new
`Driver.user` link) and **explicit assignment** (native Assign To / `_assign`).
Full operators (System Manager / iPay Manager / iPay User) are **never** scoped
— they always see everything; only pure collectors are auto-filtered.

- `collector.py`: scope resolution + per-invoice/per-request access checks.
- `permissions.py` + hooks: `permission_query_conditions` + `has_permission`
  scope the desk list/reports.
- `collect_payments.py`: self-scopes the list and the stat cards (the page
  builds its own query, which the permission hooks do not touch).
- `setup_collector` patch: creates the role, grants read/report via the
  permissions API (the doctype uses **Custom DocPerm**, so a JSON row is
  ignored), and adds the `Driver.user` field.

> **Activation:** set the **User** field on each Driver record to the
> collector's login. Until then, collectors see only explicitly-assigned
> requests (graceful).

## Security hardening (from adversarial review)
- **IDOR on by-name/by-invoice endpoints:** every operator endpoint
  (`prompt_mpesa`, `start_checkout`, `get_payment_link`, `payment_state`,
  `save_customer_contact`) now enforces ownership for collectors; bundling stays
  full-operator-only.
- **`lipana_mpesa`** (legacy STK endpoint) was whitelisted with no gate — any
  authenticated user could POST another team's request + an arbitrary phone.
  Direct HTTP callers now require operator + ownership; background (enqueued,
  pre-authorised) calls are unaffected.
- **`confirm_payment`** (creates a Payment Entry by request name) now requires
  operator + ownership.
- **GET-commit bug:** "Pay via iPay" reaches `start_checkout` by a GET, which
  Frappe does not auto-commit, so the on-the-fly request + token were rolled
  back ("Payment request not found"). Now commits before redirecting.

## Verified live
Prepaid block (prepaid SI blocked, normal passes, hidden from collect page);
save-back (invalid phone rejected, existing value not overwritten); driver
enrichment; collector scoping (`get_list` scoped & error-free, own invoice
allowed, **another's blocked**, page scoped); both auth guards block a non-owner
collector; the GET-commit fix resolves the token.

## Known interactions (by design / follow-ups)
- A Sales Invoice drawing from **multiple** prepaid Sales Orders is flagged by
  `wave_sync` for **manual** PE creation (it won't auto-settle); iPay still
  suppresses it (classified prepaid) to avoid double-charging — manual
  settlement remains wave_sync's domain.
- `cod_create_request` stays ungated so Sales Users can auto-create the COD
  request on SI submit; minting a request grants no ability to collect it (the
  action endpoints are access-checked).
- Stat-card outstanding totals still include prepaid invoices (minor
  over-count); the per-bundle prepaid check is a small N+1 (bundles are tiny).
