### PR TITLE
iPay Collect: /collect_payments parity + no-lost-invoices guarantee + review fixes

### DIFF
--- a/frontend/src/pages/RequestDetail.vue
+++ b/frontend/src/pages/RequestDetail.vue
@@ -135,13 +135,18 @@ async function copyLink() {
 // so we call it on every leave (and don't depend on `detail` having loaded yet).
 // Guarded so the explicit Back and the route-leave guard don't both run it.
 let discarded = false
+let discarding = false
 async function discardIfNeeded() {
-  if (discarded) return
-  discarded = true
+  if (discarded || discarding) return
+  discarding = true
   try {
     await discardBundle(name)
+    discarded = true // latch only on success, so a failed call can retry on the next leave
   } catch {
-    // Best-effort; the server keeps a bundle that has been paid.
+    // Best-effort; a paid bundle is kept by the server, and the 30-min stale
+    // window returns the invoices even if every discard attempt fails.
+  } finally {
+    discarding = false
   }
 }
 

--- a/ipay/ipay/doctype/ipay_request/ipay_request.js
+++ b/ipay/ipay/doctype/ipay_request/ipay_request.js
@@ -40,7 +40,7 @@ frappe.ui.form.on('iPay Request', {
                   });
                },
             });
-         });
+         }, __('iPay Menu'));
       }
 
       // Regenerate the link (new token + expiry) if the old one lapsed or was
@@ -64,7 +64,7 @@ frappe.ui.form.on('iPay Request', {
                   });
                }
             );
-         });
+         }, __('iPay Menu'));
       }
 
       // Split a bundle back into individual requests (only before payment)
@@ -87,7 +87,7 @@ frappe.ui.form.on('iPay Request', {
                   });
                }
             );
-         });
+         }, __('iPay Menu'));
       }
 
       // Add "Prompt iPay" button if submitted and status is not success

--- a/ipay/ipay/main/main.py
+++ b/ipay/ipay/main/main.py
@@ -30,6 +30,21 @@ def lipana_mpesa(
         f"OID: {oid}, Payment Request Type: {payment_request_type}"
     )
 
+    # Re-validate at execution time: the request may have been cancelled
+    # (split/discarded — docstatus 2) or already settled between enqueue and
+    # pickup. Never push an STK in that case. The token paths already refuse a
+    # cancelled request; this closes the operator/worker path too.
+    state = frappe.db.get_value(
+        "iPay Request", docid, ["docstatus", "status"], as_dict=True
+    ) or {}
+    if state.get("docstatus") == 2 or state.get("status") in ("Success", "Underpaid", "Overpaid"):
+        create_log_entry(
+            "INF",
+            f"Skipping STK for {docid}: no longer chargeable "
+            f"(docstatus={state.get('docstatus')}, status={state.get('status')})",
+        )
+        return {"status": "skipped", "message": "This request is no longer chargeable."}
+
     # set payment request type
     frappe.db.set_value(
         "iPay Request", docid, "payment_request_type", payment_request_type

--- a/ipay/ipay/main/utils/constants.py
+++ b/ipay/ipay/main/utils/constants.py
@@ -15,6 +15,14 @@ import hashlib
 # /transaction/search lookup will not match what /transact was sent.
 UNWANTED_OID_CHARACTERS = r"[-/;:~`!%^*<&_]"
 
+# How long a freshly-created, unpaid bundle is treated as "actively collecting":
+# its member invoices are hidden from the collection list and a member can't spin
+# up a duplicate single request. After this, the bundle is treated as abandoned —
+# its invoices return to the list and can be collected individually (the bundle's
+# own link still works; live-amount charging keeps that safe). Shared by
+# collect_payments._drop_bundled and ipay_redirect._active_bundle_for_invoice.
+ACTIVE_BUNDLE_WINDOW_MIN = 30
+
 
 def clean_oid(name):
     """Derive an iPay-safe order id (or `inv`) from a document name."""

--- a/ipay/ipay/main/utils/finalize_payment.py
+++ b/ipay/ipay/main/utils/finalize_payment.py
@@ -55,10 +55,21 @@ def finalize_payment(
     defaults = frappe.db.get_value(
         "iPay Request",
         request_name,
-        ["sales_invoice", "amount", "customer", "customer_email"],
+        ["sales_invoice", "amount", "customer", "customer_email", "docstatus"],
         as_dict=True,
         for_update=True,
     ) or {}
+    # A payment can land on a cancelled (split/discarded) request if it was already
+    # in flight when the bundle was cancelled. The money must still be recorded, so
+    # we proceed — make_payment_entry allocates against LIVE outstanding, so an
+    # invoice already collected elsewhere takes nothing here (the excess becomes
+    # customer credit) and can't be double-charged. Flag it for an operator to eye.
+    if defaults.get("docstatus") == 2:
+        frappe.log_error(
+            f"Payment finalised on cancelled iPay Request {request_name} — likely a "
+            f"post-discard race. Recorded against live outstanding (excess = credit).",
+            "iPay: payment on cancelled request",
+        )
     sales_invoice = sales_invoice or defaults.get("sales_invoice")
     customer = customer or defaults.get("customer")
     customer_email = customer_email or defaults.get("customer_email")

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -6,7 +6,7 @@ import frappe
 
 from ipay.ipay.main.utils.reconcile_payments import reconcile_request
 from ipay.ipay.main.utils.ipay_logs import create_log_entry
-from ipay.ipay.main.utils.constants import clean_oid
+from ipay.ipay.main.utils.constants import clean_oid, ACTIVE_BUNDLE_WINDOW_MIN
 from ipay.ipay.main.utils.prepaid import is_sales_invoice_prepaid
 
 # Hosted checkout (HTML form POST). NB: this flow uses HMAC-SHA1 over the
@@ -90,10 +90,11 @@ def build_checkout_form(request_name, phone=None, email=None):
 
     # Order id is the iPay Request name (unique per request), not the invoice.
     oid = clean_oid(req.name)
-    outstanding = frappe.db.get_value(
-        "Sales Invoice", req.sales_invoice, "outstanding_amount"
-    )
-    amount = frappe.utils.flt(req.amount) or frappe.utils.flt(outstanding)
+    # Charge the LIVE outstanding of the request's invoices — the same total the STK
+    # and the /pay page use, so all three surfaces agree (a member invoice may have
+    # settled since the bundle was created). Fall back to the stored amount only if
+    # the live read is empty.
+    amount = _live_request_amount(req.name, req.sales_invoice) or frappe.utils.flt(req.amount)
 
     cbk = frappe.utils.get_url(
         "/api/method/ipay.ipay.main.utils.ipay_redirect.ipay_return"
@@ -152,19 +153,56 @@ def ipay_return(**kwargs):
     frappe.local.response["location"] = f"/payment_status?request={request_name or ''}"
 
 
+def _active_bundle_for_invoice(invoice):
+    """The name of an ACTIVE bundle (submitted, still-Pending, created within the
+    window) this invoice is a member of, if any. Used so a bundled invoice is
+    collected THROUGH its bundle rather than via a duplicate single request — which
+    would let the same invoice be charged twice. Mirrors _drop_bundled's window: a
+    stale/abandoned bundle no longer 'owns' the invoice, so None is returned and the
+    invoice is collected individually."""
+    parents = frappe.get_all(
+        "iPay Request Invoice", filters={"sales_invoice": invoice}, pluck="parent"
+    )
+    if not parents:
+        return None
+    cutoff = frappe.utils.add_to_date(
+        frappe.utils.now_datetime(), minutes=-ACTIVE_BUNDLE_WINDOW_MIN
+    )
+    return frappe.db.get_value(
+        "iPay Request",
+        {
+            "name": ["in", list(set(parents))],
+            "docstatus": 1,
+            "status": "Pending",
+            "creation": [">=", cutoff],
+        },
+        "name",
+    )
+
+
 def _ensure_request(invoice):
-    """Return the name of a submitted iPay Request for the invoice, creating one
-    if none exists yet. Serialised per invoice so two concurrent operator actions
-    (e.g. start_checkout + get_payment_link) can't both insert a duplicate."""
+    """Return the name of a submitted iPay Request to collect this invoice, creating
+    a single one if none exists yet. Serialised per invoice so two concurrent
+    operator actions (e.g. start_checkout + get_payment_link) can't both insert a
+    duplicate."""
     # Lock the invoice row for the rest of this transaction; a concurrent
     # _ensure_request for the same invoice blocks here until we commit, then sees
     # the request we created and reuses it instead of inserting a second one.
     frappe.db.get_value("Sales Invoice", invoice, "name", for_update=True)
-    request_name = frappe.db.get_value(
-        "iPay Request", {"sales_invoice": invoice, "docstatus": 1}, "name"
-    )
-    if request_name:
-        return request_name
+    # If this invoice is a member of an active bundle, collect through that bundle —
+    # never spin up a duplicate request for a bundled invoice (it would double-charge
+    # it). A non-primary member's lookup below would otherwise miss the bundle.
+    active_bundle = _active_bundle_for_invoice(invoice)
+    if active_bundle:
+        return active_bundle
+    # Reuse an existing SINGLE request for this invoice. Skip bundles (which carry
+    # iPay Request Invoice child rows) so collecting a released invoice individually
+    # charges only that invoice, not the whole old bundle.
+    for name in frappe.get_all(
+        "iPay Request", filters={"sales_invoice": invoice, "docstatus": 1}, pluck="name"
+    ):
+        if not frappe.db.exists("iPay Request Invoice", {"parent": name}):
+            return name
 
     invoice_doc = frappe.get_doc("Sales Invoice", invoice)
     request = frappe.get_doc(

--- a/ipay/www/collect.py
+++ b/ipay/www/collect.py
@@ -22,6 +22,14 @@ def get_context():
         frappe.local.flags.redirect_location = f"/login?redirect-to={quote(target)}"
         raise frappe.Redirect
 
+    # Operator/collector-only: a logged-in user without a collection role gets a
+    # clear 403 instead of the empty SPA shell (the APIs already scope; this gates
+    # the page itself, matching /collect_payments).
+    from ipay.www.collect_payments import ALLOWED_ROLES
+
+    if not set(frappe.get_roles()) & ALLOWED_ROLES:
+        raise frappe.PermissionError("You do not have access to iPay Collect.")
+
     frappe.db.commit()
     context = frappe._dict()
     context.boot = get_boot()

--- a/ipay/www/collect_payments.html
+++ b/ipay/www/collect_payments.html
@@ -90,6 +90,7 @@
       </select>
       {% endif %}
 
+      {% if can_bundle %}
       <button type="button" id="ipay-bundle-btn" class="btn btn-primary btn-sm mb-2"
               onclick="ipayBundleSelected()" style="display: none;">
         Pay selected together
@@ -97,51 +98,14 @@
       <p id="ipay-bundle-warning" class="text-danger small mb-2" style="display: none;">
         Selected invoices belong to different customers — bundle one customer at a time.
       </p>
-
-      <!-- Inline bundle panel: shown after bundling so the operator never leaves
-           this page (its invoices can't get "lost"). Prompt the full amount, copy
-           the link to share, pay via iPay, or cancel to return the invoices. -->
-      <div id="ipay-bundle-panel" class="card mb-3" style="display: none; border: 1px solid #bcdffb;">
-        <div class="card-body">
-          <div class="d-flex justify-content-between align-items-start">
-            <h6 class="mb-1" id="ipay-bundle-title">Bundle</h6>
-            <button type="button" class="close" aria-label="Cancel bundle"
-                    onclick="ipayCancelBundle()">&times;</button>
-          </div>
-          <p class="text-muted small mb-2">
-            Prompt the full amount, share the link, or pay via iPay.
-            Cancelling returns the invoices to the list.
-          </p>
-          <div class="input-group input-group-sm mb-2">
-            <input type="text" id="ipay-bundle-link" class="form-control" readonly>
-            <div class="input-group-append">
-              <button class="btn btn-outline-secondary" type="button" onclick="ipayCopyBundleLink()">
-                Copy link
-              </button>
-            </div>
-          </div>
-          <div class="d-flex flex-wrap" style="gap: 8px;">
-            <button type="button" class="btn btn-success btn-sm" onclick="ipayPromptBundle()">
-              Prompt M-Pesa
-            </button>
-            {% if enable_redirect %}
-            <button type="button" class="btn btn-primary btn-sm" onclick="ipayBundleViaIpay()">
-              Pay via iPay
-            </button>
-            {% endif %}
-            <button type="button" class="btn btn-outline-danger btn-sm" onclick="ipayCancelBundle()">
-              Cancel bundle
-            </button>
-          </div>
-        </div>
-      </div>
+      {% endif %}
 
       {% if invoices %}
       <div class="table-responsive">
         <table class="table ipay-table" id="ipay-invoice-table">
           <thead>
             <tr>
-              <th style="width: 32px;"></th>
+              {% if can_bundle %}<th style="width: 32px;"></th>{% endif %}
               <th>Invoice</th>
               <th>Customer</th>
               <th>Delivery Note</th>
@@ -153,10 +117,12 @@
           <tbody>
             {% for inv in invoices %}
             <tr data-invoice="{{ inv.name }}" data-customer="{{ inv.customer }}" data-driver="{{ inv.driver_filter or '' }}">
+              {% if can_bundle %}
               <td>
                 <input type="checkbox" class="ipay-select"
                        data-invoice="{{ inv.name }}" data-customer="{{ inv.customer }}">
               </td>
+              {% endif %}
               <td class="ipay-inv">{{ inv.name }}</td>
               <td>{{ inv.customer_name }}</td>
               <td class="ipay-dn">{{ inv.delivery_note or "—" }}</td>
@@ -298,13 +264,8 @@ function ipayBundleSelected() {
       return row && row.style.display !== "none";
     });
   if (!checked.length) { ipayNotify("Select at least one visible invoice.", "warning"); return; }
-  var customers = {}, invoices = [], total = 0;
-  checked.forEach(function (cb) {
-    customers[cb.dataset.customer] = 1;
-    invoices.push(cb.dataset.invoice);
-    var amt = cb.closest("tr").querySelector(".ipay-amount");
-    if (amt) { total += parseFloat(amt.textContent.replace(/,/g, "")) || 0; }
-  });
+  var customers = {}, invoices = [];
+  checked.forEach(function (cb) { customers[cb.dataset.customer] = 1; invoices.push(cb.dataset.invoice); });
   var custList = Object.keys(customers);
   if (custList.length > 1) {
     ipayNotify("All selected invoices must belong to the same customer to bundle.", "danger");
@@ -316,127 +277,11 @@ function ipayBundleSelected() {
     freeze: true,
     callback: function (r) {
       var res = r.message || {};
-      // Open the bundle panel in place (no navigation) so the invoices can't get
-      // lost; the operator prompts, copies the link, pays via iPay, or cancels.
-      if (res.request) { ipayShowBundlePanel(res, invoices, total); }
+      // Take the operator to the bundle's payment page — it lists the invoices and
+      // total, a copyable link, Prompt M-Pesa, and Pay via iPay.
+      if (res.url) { window.location = res.url; }
       else { ipayNotify("Could not create the bundle.", "danger"); }
     }
-  });
-}
-
-// ---- Inline bundle panel: keeps the operator on this page so a bundle's invoices
-//      can't get "lost"; cancelling returns them to the list. ----
-var ipayBundle = null;            // { request, url, invoices }
-var ipayBundlePollTimer = null;
-
-function ipayShowBundlePanel(res, invoices, total) {
-  ipayBundle = { request: res.request, url: res.url, invoices: invoices };
-  document.getElementById("ipay-bundle-title").textContent =
-    "Bundle · " + invoices.length + " invoice" + (invoices.length > 1 ? "s" : "") + " · " + ipayFmtKES(total);
-  document.getElementById("ipay-bundle-link").value = res.url || "";
-  document.getElementById("ipay-bundle-panel").style.display = "";
-  // The bundled invoices are now collected via the bundle — drop their rows; they
-  // return (page reload) if the bundle is cancelled.
-  invoices.forEach(ipayRemoveRow);
-  ipayRefreshBundleSelection();
-  ipayStartBundlePoll();
-  document.getElementById("ipay-bundle-panel").scrollIntoView({ behavior: "smooth", block: "nearest" });
-}
-
-function ipayStartBundlePoll() {
-  // One poller while the panel is open — reflects payment from the prompt OR the
-  // hosted checkout (which opens in another tab).
-  ipayStopBundlePoll();
-  ipayBundlePollTimer = setInterval(function () {
-    if (!ipayBundle) { ipayStopBundlePoll(); return; }
-    frappe.call({
-      method: "ipay.ipay.main.utils.ipay_redirect.payment_state",
-      args: { request: ipayBundle.request },
-      callback: function (r) {
-        var s = r.message || {};
-        if (s.paid) {
-          ipayNotify("<strong>Payment received</strong> &mdash; bundle paid. " + (s.detail ? ipayEsc(s.detail) : ""), "success");
-          var df = document.getElementById("ipay-driver-filter");
-          ipayRefreshStats(df ? df.value : "");
-          ipayHideBundlePanel();
-        } else if (s.partial) {
-          ipayNotify("<strong>Payment received (" + ipayEsc(s.status) + ")</strong> &mdash; " + (s.detail ? ipayEsc(s.detail) : "amount differs; the balance is still outstanding"), "warning");
-        }
-      }
-    });
-  }, 3000);
-}
-
-function ipayStopBundlePoll() {
-  if (ipayBundlePollTimer) { clearInterval(ipayBundlePollTimer); ipayBundlePollTimer = null; }
-}
-
-function ipayHideBundlePanel() {
-  ipayStopBundlePoll();
-  ipayBundle = null;
-  document.getElementById("ipay-bundle-panel").style.display = "none";
-}
-
-function ipayCopyBundleLink() {
-  var inp = document.getElementById("ipay-bundle-link");
-  if (!inp || !inp.value) { return; }
-  inp.select();
-  inp.setSelectionRange(0, 99999);
-  function ok() { ipayNotify("Payment link copied.", "success"); }
-  if (navigator.clipboard && navigator.clipboard.writeText) {
-    navigator.clipboard.writeText(inp.value).then(ok, function () { try { document.execCommand("copy"); ok(); } catch (e) {} });
-  } else {
-    try { document.execCommand("copy"); ok(); } catch (e) {}
-  }
-}
-
-function ipayBundleViaIpay() {
-  if (!ipayBundle || !ipayBundle.url) { return; }
-  var token = (ipayBundle.url.split("token=")[1] || "");
-  // New tab so the operator stays here; the panel poll picks up the payment.
-  window.open("/ipay_checkout?token=" + encodeURIComponent(token), "_blank");
-}
-
-function ipayPromptBundle(phone) {
-  if (!ipayBundle) { return; }
-  var request = ipayBundle.request, invoices = ipayBundle.invoices;
-  if (phone === undefined) {
-    phone = prompt("Customer phone for the M-Pesa prompt (leave blank to use the number on file):", "");
-    if (phone === null) { return; }
-  }
-  frappe.call({
-    method: "ipay.ipay.main.utils.ipay_redirect.prompt_request_mpesa",
-    args: { request: request, phone: phone },
-    freeze: true,
-    callback: function (r) {
-      var res = r.message || {};
-      if (res.status === "missing_phone") {
-        var entered = prompt("No phone on file. Enter an M-Pesa number to charge (saved for next time):", "");
-        if (!entered) { ipayNotify("A phone number is required to prompt the bundle.", "warning"); return; }
-        frappe.call({
-          method: "ipay.ipay.main.utils.ipay_redirect.save_customer_contact",
-          args: { request: request, phone: entered },
-          callback: function () { ipayPromptBundle(entered); }
-        });
-        return;
-      }
-      if (res.status === "error") {
-        ipayNotify("Cannot prompt the bundle: " + (res.message || "unknown error"), "danger");
-        return;
-      }
-      ipayNotify("M-Pesa prompt sent for " + invoices.length + " invoices. Waiting for the customer to pay&hellip;", "info");
-      ipayStartBundlePoll();
-    }
-  });
-}
-
-function ipayCancelBundle() {
-  if (!ipayBundle) { ipayHideBundlePanel(); return; }
-  frappe.call({
-    method: "ipay.ipay.main.utils.ipay_redirect.discard_bundle",
-    args: { request: ipayBundle.request },
-    freeze: true,
-    callback: function () { location.reload(); }   // invoices return to the list
   });
 }
 

--- a/ipay/www/collect_payments.html
+++ b/ipay/www/collect_payments.html
@@ -90,10 +90,51 @@
       </select>
       {% endif %}
 
-      <button type="button" id="ipay-bundle-btn" class="btn btn-outline-primary btn-sm mb-2"
+      <button type="button" id="ipay-bundle-btn" class="btn btn-primary btn-sm mb-2"
               onclick="ipayBundleSelected()" style="display: none;">
         Pay selected together
       </button>
+      <p id="ipay-bundle-warning" class="text-danger small mb-2" style="display: none;">
+        Selected invoices belong to different customers — bundle one customer at a time.
+      </p>
+
+      <!-- Inline bundle panel: shown after bundling so the operator never leaves
+           this page (its invoices can't get "lost"). Prompt the full amount, copy
+           the link to share, pay via iPay, or cancel to return the invoices. -->
+      <div id="ipay-bundle-panel" class="card mb-3" style="display: none; border: 1px solid #bcdffb;">
+        <div class="card-body">
+          <div class="d-flex justify-content-between align-items-start">
+            <h6 class="mb-1" id="ipay-bundle-title">Bundle</h6>
+            <button type="button" class="close" aria-label="Cancel bundle"
+                    onclick="ipayCancelBundle()">&times;</button>
+          </div>
+          <p class="text-muted small mb-2">
+            Prompt the full amount, share the link, or pay via iPay.
+            Cancelling returns the invoices to the list.
+          </p>
+          <div class="input-group input-group-sm mb-2">
+            <input type="text" id="ipay-bundle-link" class="form-control" readonly>
+            <div class="input-group-append">
+              <button class="btn btn-outline-secondary" type="button" onclick="ipayCopyBundleLink()">
+                Copy link
+              </button>
+            </div>
+          </div>
+          <div class="d-flex flex-wrap" style="gap: 8px;">
+            <button type="button" class="btn btn-success btn-sm" onclick="ipayPromptBundle()">
+              Prompt M-Pesa
+            </button>
+            {% if enable_redirect %}
+            <button type="button" class="btn btn-primary btn-sm" onclick="ipayBundleViaIpay()">
+              Pay via iPay
+            </button>
+            {% endif %}
+            <button type="button" class="btn btn-outline-danger btn-sm" onclick="ipayCancelBundle()">
+              Cancel bundle
+            </button>
+          </div>
+        </div>
+      </div>
 
       {% if invoices %}
       <div class="table-responsive">
@@ -198,7 +239,7 @@ function ipayPoll(request, invoice) {
           ipayNotify("<strong>Payment failed</strong> (" + ipayEsc(invoice) + ") &mdash; " + (s.detail ? ipayEsc(s.detail) : "no reason given"), "danger");
         } else if (tries >= max) {
           clearInterval(iv);
-          ipayNotify("Still awaiting payment for " + invoice + ". It will confirm automatically if the customer pays.", "warning");
+          ipayNotify("Still awaiting payment for " + ipayEsc(invoice) + ". It will confirm automatically if the customer pays.", "warning");
         }
       }
     });
@@ -257,8 +298,13 @@ function ipayBundleSelected() {
       return row && row.style.display !== "none";
     });
   if (!checked.length) { ipayNotify("Select at least one visible invoice.", "warning"); return; }
-  var customers = {}, invoices = [];
-  checked.forEach(function (cb) { customers[cb.dataset.customer] = 1; invoices.push(cb.dataset.invoice); });
+  var customers = {}, invoices = [], total = 0;
+  checked.forEach(function (cb) {
+    customers[cb.dataset.customer] = 1;
+    invoices.push(cb.dataset.invoice);
+    var amt = cb.closest("tr").querySelector(".ipay-amount");
+    if (amt) { total += parseFloat(amt.textContent.replace(/,/g, "")) || 0; }
+  });
   var custList = Object.keys(customers);
   if (custList.length > 1) {
     ipayNotify("All selected invoices must belong to the same customer to bundle.", "danger");
@@ -270,22 +316,165 @@ function ipayBundleSelected() {
     freeze: true,
     callback: function (r) {
       var res = r.message || {};
-      if (res.url) { window.location = res.url; }
+      // Open the bundle panel in place (no navigation) so the invoices can't get
+      // lost; the operator prompts, copies the link, pays via iPay, or cancels.
+      if (res.request) { ipayShowBundlePanel(res, invoices, total); }
       else { ipayNotify("Could not create the bundle.", "danger"); }
     }
   });
 }
 
-(function () {
-  function refreshBundleBtn() {
-    var checked = document.querySelectorAll(".ipay-select:checked");
-    var btn = document.getElementById("ipay-bundle-btn");
-    if (!btn) { return; }
-    btn.style.display = checked.length ? "" : "none";
-    btn.textContent = "Pay " + checked.length + " selected together";
+// ---- Inline bundle panel: keeps the operator on this page so a bundle's invoices
+//      can't get "lost"; cancelling returns them to the list. ----
+var ipayBundle = null;            // { request, url, invoices }
+var ipayBundlePollTimer = null;
+
+function ipayShowBundlePanel(res, invoices, total) {
+  ipayBundle = { request: res.request, url: res.url, invoices: invoices };
+  document.getElementById("ipay-bundle-title").textContent =
+    "Bundle · " + invoices.length + " invoice" + (invoices.length > 1 ? "s" : "") + " · " + ipayFmtKES(total);
+  document.getElementById("ipay-bundle-link").value = res.url || "";
+  document.getElementById("ipay-bundle-panel").style.display = "";
+  // The bundled invoices are now collected via the bundle — drop their rows; they
+  // return (page reload) if the bundle is cancelled.
+  invoices.forEach(ipayRemoveRow);
+  ipayRefreshBundleSelection();
+  ipayStartBundlePoll();
+  document.getElementById("ipay-bundle-panel").scrollIntoView({ behavior: "smooth", block: "nearest" });
+}
+
+function ipayStartBundlePoll() {
+  // One poller while the panel is open — reflects payment from the prompt OR the
+  // hosted checkout (which opens in another tab).
+  ipayStopBundlePoll();
+  ipayBundlePollTimer = setInterval(function () {
+    if (!ipayBundle) { ipayStopBundlePoll(); return; }
+    frappe.call({
+      method: "ipay.ipay.main.utils.ipay_redirect.payment_state",
+      args: { request: ipayBundle.request },
+      callback: function (r) {
+        var s = r.message || {};
+        if (s.paid) {
+          ipayNotify("<strong>Payment received</strong> &mdash; bundle paid. " + (s.detail ? ipayEsc(s.detail) : ""), "success");
+          var df = document.getElementById("ipay-driver-filter");
+          ipayRefreshStats(df ? df.value : "");
+          ipayHideBundlePanel();
+        } else if (s.partial) {
+          ipayNotify("<strong>Payment received (" + ipayEsc(s.status) + ")</strong> &mdash; " + (s.detail ? ipayEsc(s.detail) : "amount differs; the balance is still outstanding"), "warning");
+        }
+      }
+    });
+  }, 3000);
+}
+
+function ipayStopBundlePoll() {
+  if (ipayBundlePollTimer) { clearInterval(ipayBundlePollTimer); ipayBundlePollTimer = null; }
+}
+
+function ipayHideBundlePanel() {
+  ipayStopBundlePoll();
+  ipayBundle = null;
+  document.getElementById("ipay-bundle-panel").style.display = "none";
+}
+
+function ipayCopyBundleLink() {
+  var inp = document.getElementById("ipay-bundle-link");
+  if (!inp || !inp.value) { return; }
+  inp.select();
+  inp.setSelectionRange(0, 99999);
+  function ok() { ipayNotify("Payment link copied.", "success"); }
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(inp.value).then(ok, function () { try { document.execCommand("copy"); ok(); } catch (e) {} });
+  } else {
+    try { document.execCommand("copy"); ok(); } catch (e) {}
   }
+}
+
+function ipayBundleViaIpay() {
+  if (!ipayBundle || !ipayBundle.url) { return; }
+  var token = (ipayBundle.url.split("token=")[1] || "");
+  // New tab so the operator stays here; the panel poll picks up the payment.
+  window.open("/ipay_checkout?token=" + encodeURIComponent(token), "_blank");
+}
+
+function ipayPromptBundle(phone) {
+  if (!ipayBundle) { return; }
+  var request = ipayBundle.request, invoices = ipayBundle.invoices;
+  if (phone === undefined) {
+    phone = prompt("Customer phone for the M-Pesa prompt (leave blank to use the number on file):", "");
+    if (phone === null) { return; }
+  }
+  frappe.call({
+    method: "ipay.ipay.main.utils.ipay_redirect.prompt_request_mpesa",
+    args: { request: request, phone: phone },
+    freeze: true,
+    callback: function (r) {
+      var res = r.message || {};
+      if (res.status === "missing_phone") {
+        var entered = prompt("No phone on file. Enter an M-Pesa number to charge (saved for next time):", "");
+        if (!entered) { ipayNotify("A phone number is required to prompt the bundle.", "warning"); return; }
+        frappe.call({
+          method: "ipay.ipay.main.utils.ipay_redirect.save_customer_contact",
+          args: { request: request, phone: entered },
+          callback: function () { ipayPromptBundle(entered); }
+        });
+        return;
+      }
+      if (res.status === "error") {
+        ipayNotify("Cannot prompt the bundle: " + (res.message || "unknown error"), "danger");
+        return;
+      }
+      ipayNotify("M-Pesa prompt sent for " + invoices.length + " invoices. Waiting for the customer to pay&hellip;", "info");
+      ipayStartBundlePoll();
+    }
+  });
+}
+
+function ipayCancelBundle() {
+  if (!ipayBundle) { ipayHideBundlePanel(); return; }
+  frappe.call({
+    method: "ipay.ipay.main.utils.ipay_redirect.discard_bundle",
+    args: { request: ipayBundle.request },
+    freeze: true,
+    callback: function () { location.reload(); }   // invoices return to the list
+  });
+}
+
+// While building a bundle: disable per-invoice actions, hide the bundle button
+// for a mixed-customer selection (with a warning), and show the count + total.
+function ipayRefreshBundleSelection() {
+  var checked = Array.prototype.slice.call(document.querySelectorAll(".ipay-select:checked"));
+  var btn = document.getElementById("ipay-bundle-btn");
+  var warn = document.getElementById("ipay-bundle-warning");
+  var selecting = checked.length > 0;
+  // You either act on one invoice or bundle several — never both at once.
+  document.querySelectorAll(".ipay-actions button").forEach(function (b) { b.disabled = selecting; });
+  if (!btn) { return; }
+  if (!selecting) {
+    btn.style.display = "none";
+    if (warn) { warn.style.display = "none"; }
+    return;
+  }
+  var customers = {}, total = 0;
+  checked.forEach(function (cb) {
+    customers[cb.dataset.customer] = 1;
+    var amt = cb.closest("tr").querySelector(".ipay-amount");
+    if (amt) { total += parseFloat(amt.textContent.replace(/,/g, "")) || 0; }
+  });
+  if (Object.keys(customers).length > 1) {
+    // A bundle is one customer's invoices — a mixed selection can't be prompted.
+    btn.style.display = "none";
+    if (warn) { warn.style.display = ""; }
+  } else {
+    btn.style.display = "";
+    btn.textContent = "Pay " + checked.length + " together · " + ipayFmtKES(total);
+    if (warn) { warn.style.display = "none"; }
+  }
+}
+
+(function () {
   document.querySelectorAll(".ipay-select").forEach(function (cb) {
-    cb.addEventListener("change", refreshBundleBtn);
+    cb.addEventListener("change", ipayRefreshBundleSelection);
   });
 })();
 

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -1,5 +1,5 @@
 import frappe
-from frappe.utils import flt, today
+from frappe.utils import add_to_date, flt, now_datetime, today
 
 from ipay.ipay.main.utils.prepaid import prepaid_invoice_names
 from ipay.ipay.main.utils.collector import is_collector_only, collector_scope
@@ -7,12 +7,21 @@ from ipay.ipay.main.utils.collector import is_collector_only, collector_scope
 # Roles allowed to use the collection page.
 ALLOWED_ROLES = {"System Manager", "iPay Manager", "iPay User", "iPay Collector"}
 
+# How long a freshly-created, unpaid bundle keeps its invoices off the list. After
+# this it is treated as abandoned and the invoices return, so nothing can be "lost"
+# for more than this window even if the operator never explicitly cancels. The
+# bundle itself stays valid (its link can still be paid); live-amount charging keeps
+# concurrent collection safe.
+ACTIVE_BUNDLE_WINDOW_MIN = 30
+
 
 def _drop_bundled(invoices):
-    """Remove invoices that are members of an ACTIVE submitted bundle (a docstatus=1
-    iPay Request, not Abandoned) — they're collected via the bundle. A cancelled
-    (split/discarded) or Abandoned bundle no longer collects them, so its invoices
-    return to the list."""
+    """Hide an invoice from the collection list ONLY while it is actively being
+    collected via a bundle — a submitted (docstatus=1), still-Pending iPay Request
+    created within the last ACTIVE_BUNDLE_WINDOW_MIN minutes. The instant a bundle is
+    cancelled (docstatus 2 — split/discarded), abandoned, settles short
+    (Underpaid/Overpaid/Failed), or just goes stale unpaid, its member invoices
+    return to the list, so a bundle can never strand them."""
     if not invoices:
         return invoices
     rows = frappe.get_all(
@@ -22,16 +31,18 @@ def _drop_bundled(invoices):
     )
     if not rows:
         return invoices
-    submitted = set(frappe.get_all(
+    cutoff = add_to_date(now_datetime(), minutes=-ACTIVE_BUNDLE_WINDOW_MIN)
+    active = set(frappe.get_all(
         "iPay Request",
         filters={
             "name": ["in", list({r.parent for r in rows})],
             "docstatus": 1,
-            "status": ["!=", "Abandoned"],
+            "status": "Pending",
+            "creation": [">=", cutoff],
         },
         pluck="name",
     ))
-    bundled = {r.sales_invoice for r in rows if r.parent in submitted}
+    bundled = {r.sales_invoice for r in rows if r.parent in active}
     return [inv for inv in invoices if inv.name not in bundled]
 
 
@@ -167,6 +178,9 @@ def get_context(context):
     context.invoices = invoices
     context.drivers = drivers
     context.enable_redirect = frappe.db.get_single_value("iPay Settings", "enable_redirect")
+    # Collectors can't bundle (create_bundle rejects them) — hide the bundle UI so
+    # it isn't a dead end, matching the SPA.
+    context.can_bundle = not is_collector_only(frappe.session.user)
 
     stats = collection_stats()
     context.collected_today = stats["collected_today"]

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -3,16 +3,10 @@ from frappe.utils import add_to_date, flt, now_datetime, today
 
 from ipay.ipay.main.utils.prepaid import prepaid_invoice_names
 from ipay.ipay.main.utils.collector import is_collector_only, collector_scope
+from ipay.ipay.main.utils.constants import ACTIVE_BUNDLE_WINDOW_MIN
 
 # Roles allowed to use the collection page.
 ALLOWED_ROLES = {"System Manager", "iPay Manager", "iPay User", "iPay Collector"}
-
-# How long a freshly-created, unpaid bundle keeps its invoices off the list. After
-# this it is treated as abandoned and the invoices return, so nothing can be "lost"
-# for more than this window even if the operator never explicitly cancels. The
-# bundle itself stays valid (its link can still be paid); live-amount charging keeps
-# concurrent collection safe.
-ACTIVE_BUNDLE_WINDOW_MIN = 30
 
 
 def _drop_bundled(invoices):

--- a/ipay/www/ipay_checkout.html
+++ b/ipay/www/ipay_checkout.html
@@ -32,7 +32,7 @@
     <p>Redirecting you to iPay&hellip;</p>
     <form id="ipay-checkout-form" method="POST" action="{{ action }}">
       {% for key, value in fields.items() %}
-      <input type="hidden" name="{{ key }}" value="{{ value }}">
+      <input type="hidden" name="{{ key | e }}" value="{{ value | e }}">
       {% endfor %}
       <noscript>
         <button type="submit" class="btn btn-primary">Continue to iPay</button>

--- a/ipay/www/pay.html
+++ b/ipay/www/pay.html
@@ -34,6 +34,19 @@
         <p class="muted">Invoice {{ invoice | e }} has already been paid. Thank you!</p>
         {% endif %}
       {% else %}
+        {% if is_operator %}
+        <div class="ipay-op-bar text-left mb-3">
+          <div class="input-group input-group-sm mb-2">
+            <input type="text" id="ipay-pay-link" class="form-control" readonly value="{{ pay_link | e }}">
+            <div class="input-group-append">
+              <button class="btn btn-outline-secondary" type="button" onclick="ipayCopyPayLink()">Copy link</button>
+            </div>
+          </div>
+          <button type="button" class="btn btn-link btn-sm p-0" onclick="ipayBackToCollection()">
+            &larr; Back to collection
+          </button>
+        </div>
+        {% endif %}
         {% if invoices | length > 1 %}
         <p class="muted mb-1">Payment for {{ invoices | length }} invoices</p>
         <ul class="ipay-inv-list">
@@ -76,6 +89,31 @@
 {% if not invalid and not paid %}
 <script>
 var IPAY_TOKEN = "{{ token }}";
+var IPAY_REQUEST = "{{ request_name }}";
+
+// Operator-only: copy the link to share.
+function ipayCopyPayLink() {
+  var inp = document.getElementById("ipay-pay-link");
+  if (!inp || !inp.value) { return; }
+  inp.select();
+  inp.setSelectionRange(0, 99999);
+  function ok() { ipayPayNotify("Payment link copied.", "success"); }
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(inp.value).then(ok, function () { try { document.execCommand("copy"); ok(); } catch (e) {} });
+  } else {
+    try { document.execCommand("copy"); ok(); } catch (e) {}
+  }
+}
+
+// Operator-only: discard an unpaid bundle (so its invoices return) then go back.
+function ipayBackToCollection() {
+  if (!IPAY_REQUEST) { window.location = "/collect_payments"; return; }
+  frappe.call({
+    method: "ipay.ipay.main.utils.ipay_redirect.discard_bundle",
+    args: { request: IPAY_REQUEST },
+    always: function () { window.location = "/collect_payments"; }
+  });
+}
 
 function ipayPayNotify(message, type) {
   var c = document.getElementById("ipay-pay-alerts");

--- a/ipay/www/pay.py
+++ b/ipay/www/pay.py
@@ -1,6 +1,7 @@
 import frappe
 
 from ipay.ipay.main.utils.ipay_redirect import resolve_pay_token
+from ipay.www.collect_payments import ALLOWED_ROLES
 
 
 def get_context(context):
@@ -47,3 +48,13 @@ def get_context(context):
     context.enable_redirect = frappe.db.get_single_value(
         "iPay Settings", "enable_redirect"
     )
+
+    # Operator-only toolbar: copy the link to share, and a "back to collection" that
+    # discards an unpaid bundle so its invoices return to the list. A guest paying a
+    # shared link never sees these.
+    is_operator = frappe.session.user != "Guest" and bool(
+        set(frappe.get_roles(frappe.session.user)) & ALLOWED_ROLES
+    )
+    context.is_operator = is_operator
+    context.pay_link = frappe.utils.get_url("/pay?token=" + token)
+    context.request_name = request_name if is_operator else ""


### PR DESCRIPTION
## Summary

Brings the legacy server-rendered **`/collect_payments`** page to parity with the Collect SPA, makes the **bundle payment link** fully usable, and lands the **final adversarial review** fixes — most importantly a hard guarantee that **a bundle can never strand ("lose") its invoices**.

Stacked on #63 (base = `feat/ipay-collect-frontend`); retarget to `main` once #63 merges.

## Stranding guarantee — "no lost invoices, ever"

`_drop_bundled` now hides an invoice **only while its bundle is actively collecting** — submitted, still `Pending`, created within `ACTIVE_BUNDLE_WINDOW_MIN` (30 min). The instant a bundle is **cancelled** (split/discarded → docstatus 2), **abandoned**, settles short (**Underpaid/Overpaid/Failed**), or simply **goes stale unpaid**, its member invoices return to the list. Verified end-to-end: *fresh hides · stale releases · cancelled releases*. The bundle's link stays valid (live-amount charging keeps concurrent collection safe), so nothing breaks if a customer pays late.

## `/collect_payments` parity

- Selecting invoices **disables the per-row Prompt / Pay actions** (bundle *or* act on one, never both).
- A **mixed-customer selection is blocked** with an inline warning; the bundle button shows **count + total**.
- Bundling **redirects to the bundle's `/pay` page** (which lists every invoice + amount + total).
- The bundle UI is **hidden from collectors** (who can't bundle) — no dead end.

## `/pay` operator toolbar

- **Copy link** — the shareable payment link.
- **Back to collection** — discards an unpaid bundle (invoices return) and returns to the list.

## Final review fixes (21 confirmed: 5 high / 5 med / 11 low)

Money-movement:
- hosted checkout charges the **live** outstanding like STK and `/pay` — the three surfaces agree (#3).
- a bundled invoice is collected **through its active bundle**, never a duplicate single request (#4).
- the STK worker **re-checks docstatus/status at execution** and refuses a cancelled/settled request (#7).
- a payment landing on a cancelled request (post-discard race) is recorded against live outstanding (excess = credit, never an over-allocation) and **Error-Logged** for review (#6).

Polish: discard retries on transient failure (#11) · hosted-checkout form values escaped (#17) · SPA shell gated by collection role (#20) · collectors no longer see a dead-end bundle UI (#10/#16).

## Also

- **iPay Request form**: actions grouped under an **"iPay Menu"** dropdown; **Prompt iPay** and **Verify Payment** stay top-level.
