### PR TITLE
iPay Collect: extract shared list/detail UI + a11y polish (refactor)

### DIFF
--- a/frontend/src/components/CollectBar.vue
+++ b/frontend/src/components/CollectBar.vue
@@ -1,0 +1,56 @@
+<script setup>
+import { formatKES } from '@/utils/format'
+
+// The collect action for a customer detail: one "Collect all"/"Collect N" button plus the
+// per-state hints. Rendered as sibling roots so it drops straight into the page's flex
+// column (the hints' -mt-2 tightens them against the button, matching the standalone markup).
+defineProps({
+  showBar: Boolean, // whether the collect button row is shown at all
+  selectedCount: { type: Number, default: 0 },
+  selectedTotal: { type: Number, default: 0 },
+  total: { type: Number, default: 0 },
+  creatingBundle: Boolean,
+  bundleBlocked: Boolean,
+  mpesaMax: { type: Number, default: 0 },
+  collectError: Boolean,
+  showTickHint: Boolean,
+})
+defineEmits(['collect', 'clear'])
+</script>
+
+<template>
+  <div v-if="showBar" class="flex gap-2">
+    <button
+      type="button"
+      class="h-14 flex-1 rounded-xl bg-mpesa text-lg font-semibold text-white transition active:scale-[.98] disabled:opacity-50"
+      :disabled="creatingBundle || bundleBlocked"
+      :aria-busy="creatingBundle"
+      @click="$emit('collect')"
+    >
+      {{
+        creatingBundle
+          ? 'Collecting…'
+          : selectedCount
+            ? `Collect ${selectedCount} — ${formatKES(selectedTotal)}`
+            : `Collect all — ${formatKES(total)}`
+      }}
+    </button>
+    <button
+      v-if="selectedCount"
+      type="button"
+      class="h-14 shrink-0 rounded-xl border border-hairline px-5 font-medium text-ink/70"
+      @click="$emit('clear')"
+    >
+      Clear
+    </button>
+  </div>
+  <p v-if="bundleBlocked" class="-mt-2 px-1 text-xs text-owed">
+    This exceeds the M-Pesa limit ({{ formatKES(mpesaMax) }}) and card checkout is off — collect the invoices individually below.
+  </p>
+  <p v-if="collectError" class="-mt-2 px-1 text-sm text-danger">
+    Couldn't start the collection — try again.
+  </p>
+  <p v-if="showTickHint" class="-mt-2 px-1 text-xs text-ink/60">
+    Tick invoices to collect only some.
+  </p>
+</template>

--- a/frontend/src/components/CustomerListShell.vue
+++ b/frontend/src/components/CustomerListShell.vue
@@ -1,0 +1,73 @@
+<script setup>
+import RoundHeader from '@/components/RoundHeader.vue'
+import CustomerCard from '@/components/CustomerCard.vue'
+import ErrorRetry from '@/components/ErrorRetry.vue'
+
+// The shared customer-list screen (field /collect and internal /collect/internal): title,
+// today's-round header, a filters row (slotted, since each mode's filters differ), and the
+// loading / not-permitted / error / empty / grid states. Each page owns its data + filters
+// and passes the rest as props, so behaviour stays per-page.
+defineProps({
+  containerClass: { type: String, default: '' }, // per-mode max width
+  title: { type: String, default: 'Collect' },
+  collectedToday: { type: Number, default: 0 },
+  outstandingToday: { type: Number, default: 0 },
+  remaining: { type: Number, default: 0 },
+  countLabel: { type: String, default: 'to collect' },
+  statsLoading: Boolean,
+  listLoading: Boolean,
+  loadError: Boolean,
+  notPermitted: Boolean, // internal mode only — a collector reached operator-only mode
+  customers: { type: Array, default: () => [] },
+  emptyMessage: { type: String, default: '' },
+  cardRouteName: { type: String, default: 'Customer' },
+  cardDriver: { type: String, default: '' },
+  cardPaymentTerm: { type: String, default: '' },
+})
+defineEmits(['retry'])
+</script>
+
+<template>
+  <main class="mx-auto flex min-h-full w-full flex-col gap-4 p-4 pb-10" :class="containerClass">
+    <h1 class="pt-1 font-display text-2xl font-bold tracking-tight text-ink">{{ title }}</h1>
+
+    <RoundHeader
+      :collected-today="collectedToday"
+      :outstanding-today="outstandingToday"
+      :remaining="remaining"
+      :count-label="countLabel"
+      :loading="statsLoading"
+    />
+
+    <div class="flex flex-col gap-2 sm:flex-row">
+      <slot name="filters" />
+    </div>
+
+    <div v-if="listLoading" class="grid grid-cols-1 gap-3 md:grid-cols-2">
+      <div v-for="n in 6" :key="n" class="h-20 animate-pulse rounded-xl bg-ink/5" />
+    </div>
+    <div v-else-if="notPermitted" class="py-16 text-center">
+      <p class="font-display text-ink/70">Internal collection is for operators only.</p>
+      <a
+        href="/collect"
+        class="mt-3 inline-flex h-11 items-center rounded-xl bg-mpesa px-5 font-semibold text-white"
+      >
+        Go to Collect
+      </a>
+    </div>
+    <ErrorRetry v-else-if="loadError" @retry="$emit('retry')" />
+    <p v-else-if="!customers.length" class="py-16 text-center font-display text-ink/70">
+      {{ emptyMessage }}
+    </p>
+    <div v-else class="grid grid-cols-1 gap-3 md:grid-cols-2">
+      <CustomerCard
+        v-for="c in customers"
+        :key="c.customer"
+        :customer="c"
+        :route-name="cardRouteName"
+        :driver="cardDriver"
+        :payment-term="cardPaymentTerm"
+      />
+    </div>
+  </main>
+</template>

--- a/frontend/src/components/CustomerMoneyHeader.vue
+++ b/frontend/src/components/CustomerMoneyHeader.vue
@@ -1,0 +1,20 @@
+<script setup>
+import { formatKES } from '@/utils/format'
+
+defineProps({
+  name: { type: String, default: '' },
+  total: { type: Number, default: 0 },
+  count: { type: Number, default: 0 },
+  term: { type: String, default: '' }, // internal mode appends the payment term
+})
+</script>
+
+<template>
+  <section class="rounded-2xl bg-ink px-5 py-4 text-paper">
+    <p class="truncate font-display text-lg font-bold">{{ name }}</p>
+    <p class="mt-1 font-mono text-3xl font-semibold tabular-nums">{{ formatKES(total) }}</p>
+    <p class="text-sm text-paper/60">
+      {{ count }} invoice{{ count === 1 ? '' : 's' }} outstanding<span v-if="term"> · {{ term }}</span>
+    </p>
+  </section>
+</template>

--- a/frontend/src/components/ErrorRetry.vue
+++ b/frontend/src/components/ErrorRetry.vue
@@ -1,0 +1,16 @@
+<script setup>
+defineEmits(['retry'])
+</script>
+
+<template>
+  <div class="py-16 text-center">
+    <p class="font-display text-ink/70">Couldn't load — check your connection.</p>
+    <button
+      type="button"
+      class="mt-3 h-11 rounded-xl bg-mpesa px-5 font-semibold text-white"
+      @click="$emit('retry')"
+    >
+      Retry
+    </button>
+  </div>
+</template>

--- a/frontend/src/components/InvoiceCard.vue
+++ b/frontend/src/components/InvoiceCard.vue
@@ -88,9 +88,10 @@ async function payViaIpay() {
         type="button"
         class="h-12 flex-1 rounded-xl border border-hairline px-4 font-medium text-ink transition active:scale-[.98] disabled:opacity-40"
         :disabled="actionsDisabled || checkoutBusy"
+        :aria-busy="checkoutBusy"
         @click="payViaIpay"
       >
-        {{ checkoutBusy ? '…' : 'Card / other' }}
+        {{ checkoutBusy ? 'Opening…' : 'Card / other' }}
       </button>
     </div>
     <p v-if="mpesaBlocked" class="mt-2 text-xs text-owed">

--- a/frontend/src/components/PromptDialog.vue
+++ b/frontend/src/components/PromptDialog.vue
@@ -29,7 +29,25 @@ const toneBox = {
 }
 const waiting = computed(() => busy.value && message.value?.tone === 'info')
 
-const onKeydown = (e) => e.key === 'Escape' && emit('close')
+// Close on Escape and trap Tab within the dialog (keyboard/AT users can't wander to the
+// page behind the modal).
+function onKeydown(e) {
+  if (e.key === 'Escape') return emit('close')
+  if (e.key !== 'Tab') return
+  const items = Array.from(
+    dialogRef.value?.querySelectorAll('input, button, [href], [tabindex]:not([tabindex="-1"])') || [],
+  ).filter((el) => !el.disabled)
+  if (!items.length) return
+  const first = items[0]
+  const last = items[items.length - 1]
+  if (e.shiftKey && document.activeElement === first) {
+    e.preventDefault()
+    last.focus()
+  } else if (!e.shiftKey && document.activeElement === last) {
+    e.preventDefault()
+    first.focus()
+  }
+}
 
 watch(
   () => props.target,
@@ -171,6 +189,7 @@ onUnmounted(() => {
           type="button"
           class="h-12 flex-1 rounded-xl bg-mpesa font-semibold text-white transition active:scale-[.98] disabled:opacity-40"
           :disabled="busy"
+          :aria-busy="busy"
           @click="send"
         >
           {{ busy ? 'Waiting…' : 'Send prompt' }}

--- a/frontend/src/composables/useInvoiceSelection.js
+++ b/frontend/src/composables/useInvoiceSelection.js
@@ -1,0 +1,23 @@
+import { computed, ref } from 'vue'
+
+// Shared invoice-selection state for the customer detail pages: tick a subset to bundle
+// only those; nothing ticked = collect the whole balance.
+export function useInvoiceSelection() {
+  const selected = ref([])
+  const isSelected = (inv) => selected.value.some((i) => i.name === inv.name)
+
+  function toggleSelect(inv) {
+    selected.value = isSelected(inv)
+      ? selected.value.filter((i) => i.name !== inv.name)
+      : [...selected.value, inv]
+  }
+
+  const clearSelection = () => (selected.value = [])
+  const dropSelected = (name) => (selected.value = selected.value.filter((i) => i.name !== name))
+
+  const selectedTotal = computed(() =>
+    selected.value.reduce((sum, inv) => sum + Number(inv.outstanding_amount || 0), 0),
+  )
+
+  return { selected, isSelected, toggleSelect, clearSelection, dropSelected, selectedTotal }
+}

--- a/frontend/src/pages/Collect.vue
+++ b/frontend/src/pages/Collect.vue
@@ -3,8 +3,7 @@ import { computed, onMounted, ref } from 'vue'
 import { useRoute } from 'vue-router'
 import { fetchCollectionCustomers, fetchCollectionStats } from '@/data/collection'
 import { useResumeRefresh } from '@/composables/useResumeRefresh'
-import RoundHeader from '@/components/RoundHeader.vue'
-import CustomerCard from '@/components/CustomerCard.vue'
+import CustomerListShell from '@/components/CustomerListShell.vue'
 
 const route = useRoute()
 
@@ -19,8 +18,8 @@ const statsLoading = ref(false)
 const search = ref('')
 const driver = ref(route.query.driver || '') // restored when returning from a detail page
 
-// The driver filter is applied server-side (it scopes each customer's total), so this
-// only narrows the loaded list — by customer name, invoice number, or delivery note.
+// The driver filter is server-side (it scopes each customer's total); this only narrows the
+// loaded list — by customer name, invoice number, or delivery note.
 const filtered = computed(() => {
   const query = search.value.trim().toLowerCase()
   if (!query) return customers.value
@@ -33,6 +32,10 @@ const filtered = computed(() => {
 
 const invoiceCount = computed(() =>
   filtered.value.reduce((sum, c) => sum + (c.invoice_count || 0), 0),
+)
+
+const emptyMessage = computed(() =>
+  search.value.trim() ? 'No customers match your search.' : 'All collected — no customers owe you.',
 )
 
 async function loadCustomers() {
@@ -58,11 +61,6 @@ async function loadStats() {
   }
 }
 
-function onDriverChange() {
-  loadCustomers()
-  loadStats()
-}
-
 function refreshAll() {
   loadCustomers()
   loadStats()
@@ -73,17 +71,21 @@ onMounted(refreshAll)
 </script>
 
 <template>
-  <main class="mx-auto flex min-h-full w-full max-w-xl flex-col gap-4 p-4 pb-10 md:max-w-4xl">
-    <h1 class="pt-1 font-display text-2xl font-bold tracking-tight text-ink">Collect</h1>
-
-    <RoundHeader
-      :collected-today="stats.collected_today"
-      :outstanding-today="stats.outstanding_today"
-      :remaining="invoiceCount"
-      :loading="statsLoading"
-    />
-
-    <div class="flex flex-col gap-2 sm:flex-row">
+  <CustomerListShell
+    container-class="max-w-xl md:max-w-4xl"
+    title="Collect"
+    :collected-today="stats.collected_today"
+    :outstanding-today="stats.outstanding_today"
+    :remaining="invoiceCount"
+    :stats-loading="statsLoading"
+    :list-loading="listLoading"
+    :load-error="loadError"
+    :customers="filtered"
+    :empty-message="emptyMessage"
+    :card-driver="driver"
+    @retry="loadCustomers"
+  >
+    <template #filters>
       <input
         v-model="search"
         type="search"
@@ -96,31 +98,11 @@ onMounted(refreshAll)
         v-model="driver"
         aria-label="Filter by driver"
         class="h-11 w-full rounded-xl border border-hairline bg-white px-3 text-sm text-ink focus:border-mpesa focus:outline-none focus:ring-2 focus:ring-mpesa/40 sm:w-48"
-        @change="onDriverChange"
+        @change="refreshAll"
       >
         <option value="">All drivers</option>
         <option v-for="d in drivers" :key="d" :value="d">{{ d }}</option>
       </select>
-    </div>
-
-    <div v-if="listLoading" class="grid grid-cols-1 gap-3 pt-1 md:grid-cols-2">
-      <div v-for="n in 6" :key="n" class="h-20 animate-pulse rounded-xl bg-ink/5" />
-    </div>
-    <div v-else-if="loadError" class="py-16 text-center">
-      <p class="font-display text-ink/70">Couldn't load — check your connection.</p>
-      <button
-        type="button"
-        class="mt-3 h-11 rounded-xl bg-mpesa px-5 font-semibold text-white"
-        @click="loadCustomers"
-      >
-        Retry
-      </button>
-    </div>
-    <p v-else-if="!filtered.length" class="py-16 text-center font-display text-ink/70">
-      {{ search.trim() ? 'No customers match your search.' : 'All collected — no customers owe you.' }}
-    </p>
-    <div v-else class="grid grid-cols-1 gap-3 md:grid-cols-2">
-      <CustomerCard v-for="c in filtered" :key="c.customer" :customer="c" :driver="driver" />
-    </div>
-  </main>
+    </template>
+  </CustomerListShell>
 </template>

--- a/frontend/src/pages/CustomerDetail.vue
+++ b/frontend/src/pages/CustomerDetail.vue
@@ -3,9 +3,12 @@ import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { createBundle, fetchCustomerCollection } from '@/data/collection'
 import { useResumeRefresh } from '@/composables/useResumeRefresh'
-import { formatKES } from '@/utils/format'
+import { useInvoiceSelection } from '@/composables/useInvoiceSelection'
 import InvoiceCard from '@/components/InvoiceCard.vue'
 import PromptDialog from '@/components/PromptDialog.vue'
+import CustomerMoneyHeader from '@/components/CustomerMoneyHeader.vue'
+import CollectBar from '@/components/CollectBar.vue'
+import ErrorRetry from '@/components/ErrorRetry.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -23,15 +26,12 @@ const creatingBundle = ref(false)
 const collectError = ref(false)
 const prompting = ref(null)
 
-// Operators may tick a subset to collect only some invoices; nothing ticked = collect all.
-const selected = ref([])
+const { selected, isSelected, toggleSelect, clearSelection, dropSelected, selectedTotal } =
+  useInvoiceSelection()
 const selectable = computed(() => canBundle.value && invoices.value.length > 1)
 
 const total = computed(() =>
   invoices.value.reduce((sum, inv) => sum + Number(inv.outstanding_amount || 0), 0),
-)
-const selectedTotal = computed(() =>
-  selected.value.reduce((sum, inv) => sum + Number(inv.outstanding_amount || 0), 0),
 )
 
 // A bundle is charged as one M-Pesa STK (or hosted checkout). Over the cap with no card
@@ -49,16 +49,6 @@ const filtered = computed(() => {
   if (!query) return invoices.value
   return invoices.value.filter((inv) => inv.name.toLowerCase().includes(query))
 })
-
-const isSelected = (inv) => selected.value.some((i) => i.name === inv.name)
-
-function toggleSelect(inv) {
-  selected.value = isSelected(inv)
-    ? selected.value.filter((i) => i.name !== inv.name)
-    : [...selected.value, inv]
-}
-
-const clearSelection = () => (selected.value = [])
 
 async function load() {
   loading.value = true
@@ -116,7 +106,7 @@ const toList = () => router.push({ name: 'Collect', query: driver ? { driver } :
 
 function onPaid(name) {
   invoices.value = invoices.value.filter((inv) => inv.name !== name)
-  selected.value = selected.value.filter((inv) => inv.name !== name)
+  dropSelected(name)
   if (!invoices.value.length) toList()
 }
 
@@ -134,89 +124,54 @@ onMounted(load)
       ‹ All customers
     </button>
 
-    <div v-if="loadError" class="py-16 text-center">
-      <p class="font-display text-ink/70">Couldn't load — check your connection.</p>
-      <button
-        type="button"
-        class="mt-3 h-11 rounded-xl bg-mpesa px-5 font-semibold text-white"
-        @click="load"
-      >
-        Retry
-      </button>
-    </div>
+    <ErrorRetry v-if="loadError" @retry="load" />
 
     <template v-else>
-    <section class="rounded-2xl bg-ink px-5 py-4 text-paper">
-      <p class="truncate font-display text-lg font-bold">{{ customerName }}</p>
-      <p class="mt-1 font-mono text-3xl font-semibold tabular-nums">{{ formatKES(total) }}</p>
-      <p class="text-sm text-paper/60">
-        {{ invoices.length }} invoice{{ invoices.length === 1 ? '' : 's' }} outstanding
-      </p>
-    </section>
+      <CustomerMoneyHeader :name="customerName" :total="total" :count="invoices.length" />
 
-    <div v-if="canBundle && invoices.length > 1" class="flex gap-2">
-      <button
-        type="button"
-        class="h-14 flex-1 rounded-xl bg-mpesa text-lg font-semibold text-white transition active:scale-[.98] disabled:opacity-50"
-        :disabled="creatingBundle || bundleBlocked"
-        @click="collectNow"
-      >
-        {{
-          creatingBundle
-            ? '…'
-            : selected.length
-              ? `Collect ${selected.length} — ${formatKES(selectedTotal)}`
-              : `Collect all — ${formatKES(total)}`
-        }}
-      </button>
-      <button
-        v-if="selected.length"
-        type="button"
-        class="h-14 shrink-0 rounded-xl border border-hairline px-5 font-medium text-ink/70"
-        @click="clearSelection"
-      >
-        Clear
-      </button>
-    </div>
-    <p v-if="bundleBlocked" class="-mt-2 px-1 text-xs text-owed">
-      This exceeds the M-Pesa limit ({{ formatKES(mpesaMax) }}) and card checkout is off — collect the invoices individually below.
-    </p>
-    <p v-if="collectError" class="-mt-2 px-1 text-sm text-danger">
-      Couldn't start the collection — try again.
-    </p>
-    <p v-if="selectable && !selected.length" class="-mt-2 px-1 text-xs text-ink/60">
-      Tick invoices to collect only some.
-    </p>
-
-    <input
-      v-if="invoices.length > 1"
-      v-model="search"
-      type="search"
-      aria-label="Search this customer's invoices"
-      placeholder="Search invoice number…"
-      class="h-11 w-full rounded-xl border border-hairline bg-white px-4 text-sm text-ink placeholder:text-ink/50 focus:border-mpesa focus:outline-none focus:ring-2 focus:ring-mpesa/40"
-    />
-
-    <div v-if="loading" class="grid grid-cols-1 gap-3 md:grid-cols-2">
-      <div v-for="n in 3" :key="n" class="h-28 animate-pulse rounded-xl bg-ink/5" />
-    </div>
-    <p v-else-if="!filtered.length" class="py-16 text-center font-display text-ink/70">
-      No invoices match.
-    </p>
-    <div v-else class="grid grid-cols-1 gap-3 md:grid-cols-2">
-      <InvoiceCard
-        v-for="inv in filtered"
-        :key="inv.name"
-        :invoice="inv"
-        :enable-redirect="enableRedirect"
+      <CollectBar
+        :show-bar="canBundle && invoices.length > 1"
+        :selected-count="selected.length"
+        :selected-total="selectedTotal"
+        :total="total"
+        :creating-bundle="creatingBundle"
+        :bundle-blocked="bundleBlocked"
         :mpesa-max="mpesaMax"
-        :selectable="selectable"
-        :selected="isSelected(inv)"
-        :actions-disabled="selected.length > 0"
-        @prompt="promptInvoice(inv)"
-        @toggle-select="toggleSelect(inv)"
+        :collect-error="collectError"
+        :show-tick-hint="selectable && !selected.length"
+        @collect="collectNow"
+        @clear="clearSelection"
       />
-    </div>
+
+      <input
+        v-if="invoices.length > 1"
+        v-model="search"
+        type="search"
+        aria-label="Search this customer's invoices"
+        placeholder="Search invoice number…"
+        class="h-11 w-full rounded-xl border border-hairline bg-white px-4 text-sm text-ink placeholder:text-ink/50 focus:border-mpesa focus:outline-none focus:ring-2 focus:ring-mpesa/40"
+      />
+
+      <div v-if="loading" class="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <div v-for="n in 3" :key="n" class="h-28 animate-pulse rounded-xl bg-ink/5" />
+      </div>
+      <p v-else-if="!filtered.length" class="py-16 text-center font-display text-ink/70">
+        No invoices match.
+      </p>
+      <div v-else class="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <InvoiceCard
+          v-for="inv in filtered"
+          :key="inv.name"
+          :invoice="inv"
+          :enable-redirect="enableRedirect"
+          :mpesa-max="mpesaMax"
+          :selectable="selectable"
+          :selected="isSelected(inv)"
+          :actions-disabled="selected.length > 0"
+          @prompt="promptInvoice(inv)"
+          @toggle-select="toggleSelect(inv)"
+        />
+      </div>
     </template>
 
     <PromptDialog :target="prompting" @close="prompting = null" @paid="onPaid" @changed="load" />

--- a/frontend/src/pages/InternalCollect.vue
+++ b/frontend/src/pages/InternalCollect.vue
@@ -3,14 +3,13 @@ import { computed, onMounted, ref } from 'vue'
 import { useRoute } from 'vue-router'
 import { fetchCollectionStats, fetchInternalCustomers } from '@/data/collection'
 import { useResumeRefresh } from '@/composables/useResumeRefresh'
-import RoundHeader from '@/components/RoundHeader.vue'
-import CustomerCard from '@/components/CustomerCard.vue'
+import CustomerListShell from '@/components/CustomerListShell.vue'
 
 const route = useRoute()
 
 // Internal (operator) mode: every customer who owes, all payment terms, newest-invoice
-// customer first. The list is loaded once (one aggregate call); a customer's invoices
-// are fetched only when opened.
+// customer first. The list is loaded once (one aggregate call); a customer's invoices are
+// fetched only when opened.
 const customers = ref([])
 const listLoading = ref(true)
 const loadError = ref(false)
@@ -30,6 +29,12 @@ const filtered = computed(() => {
   if (!query) return customers.value
   return customers.value.filter((c) => c.customer_name.toLowerCase().includes(query))
 })
+
+const emptyMessage = computed(() =>
+  search.value.trim()
+    ? 'No customers match your search.'
+    : 'No customers with an outstanding balance.',
+)
 
 async function loadCustomers() {
   listLoading.value = true
@@ -58,11 +63,6 @@ async function loadStats() {
 }
 
 // The driver/term filters are server-side (they scope each customer's balance), so re-fetch.
-function onFilterChange() {
-  loadCustomers()
-  loadStats()
-}
-
 function refreshAll() {
   loadCustomers()
   loadStats()
@@ -73,18 +73,25 @@ onMounted(refreshAll)
 </script>
 
 <template>
-  <main class="mx-auto flex min-h-full w-full max-w-5xl flex-col gap-4 p-4 pb-10">
-    <h1 class="pt-1 font-display text-2xl font-bold tracking-tight text-ink">Collect Payments</h1>
-
-    <RoundHeader
-      :collected-today="stats.collected_today"
-      :outstanding-today="stats.outstanding_today"
-      :remaining="filtered.length"
-      count-label="customers"
-      :loading="statsLoading"
-    />
-
-    <div class="flex flex-col gap-2 sm:flex-row">
+  <CustomerListShell
+    container-class="max-w-5xl"
+    title="Collect Payments"
+    :collected-today="stats.collected_today"
+    :outstanding-today="stats.outstanding_today"
+    :remaining="filtered.length"
+    count-label="customers"
+    :stats-loading="statsLoading"
+    :list-loading="listLoading"
+    :load-error="loadError"
+    :not-permitted="notPermitted"
+    :customers="filtered"
+    :empty-message="emptyMessage"
+    card-route-name="InternalCustomer"
+    :card-driver="driver"
+    :card-payment-term="paymentTerm"
+    @retry="loadCustomers"
+  >
+    <template #filters>
       <input
         v-model="search"
         type="search"
@@ -97,7 +104,7 @@ onMounted(refreshAll)
         v-model="driver"
         aria-label="Filter by driver"
         class="h-11 w-full rounded-xl border border-hairline bg-white px-3 text-sm text-ink focus:border-mpesa focus:outline-none focus:ring-2 focus:ring-mpesa/40 sm:w-56"
-        @change="onFilterChange"
+        @change="refreshAll"
       >
         <option value="">All drivers</option>
         <option v-for="d in drivers" :key="d" :value="d">{{ d }}</option>
@@ -107,47 +114,11 @@ onMounted(refreshAll)
         v-model="paymentTerm"
         aria-label="Filter by payment term"
         class="h-11 w-full rounded-xl border border-hairline bg-white px-3 text-sm text-ink focus:border-mpesa focus:outline-none focus:ring-2 focus:ring-mpesa/40 sm:w-48"
-        @change="onFilterChange"
+        @change="refreshAll"
       >
         <option value="">All terms</option>
         <option v-for="t in paymentTerms" :key="t" :value="t">{{ t }}</option>
       </select>
-    </div>
-
-    <div v-if="listLoading" class="grid grid-cols-1 gap-3 md:grid-cols-2">
-      <div v-for="n in 6" :key="n" class="h-20 animate-pulse rounded-xl bg-ink/5" />
-    </div>
-    <div v-else-if="notPermitted" class="py-16 text-center">
-      <p class="font-display text-ink/70">Internal collection is for operators only.</p>
-      <a
-        href="/collect"
-        class="mt-3 inline-flex h-11 items-center rounded-xl bg-mpesa px-5 font-semibold text-white"
-      >
-        Go to Collect
-      </a>
-    </div>
-    <div v-else-if="loadError" class="py-16 text-center">
-      <p class="font-display text-ink/70">Couldn't load — check your connection.</p>
-      <button
-        type="button"
-        class="mt-3 h-11 rounded-xl bg-mpesa px-5 font-semibold text-white"
-        @click="loadCustomers"
-      >
-        Retry
-      </button>
-    </div>
-    <p v-else-if="!filtered.length" class="py-16 text-center font-display text-ink/70">
-      {{ search.trim() ? 'No customers match your search.' : 'No customers with an outstanding balance.' }}
-    </p>
-    <div v-else class="grid grid-cols-1 gap-3 md:grid-cols-2">
-      <CustomerCard
-        v-for="c in filtered"
-        :key="c.customer"
-        :customer="c"
-        route-name="InternalCustomer"
-        :driver="driver"
-        :payment-term="paymentTerm"
-      />
-    </div>
-  </main>
+    </template>
+  </CustomerListShell>
 </template>

--- a/frontend/src/pages/InternalCustomerDetail.vue
+++ b/frontend/src/pages/InternalCustomerDetail.vue
@@ -3,9 +3,12 @@ import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { createBundle, fetchInternalCustomerInvoices } from '@/data/collection'
 import { useResumeRefresh } from '@/composables/useResumeRefresh'
-import { formatKES } from '@/utils/format'
+import { useInvoiceSelection } from '@/composables/useInvoiceSelection'
 import InvoiceCard from '@/components/InvoiceCard.vue'
 import PromptDialog from '@/components/PromptDialog.vue'
+import CustomerMoneyHeader from '@/components/CustomerMoneyHeader.vue'
+import CollectBar from '@/components/CollectBar.vue'
+import ErrorRetry from '@/components/ErrorRetry.vue'
 
 const PAGE = 50
 
@@ -35,11 +38,9 @@ let searchTimer = null
 let loadSeq = 0 // guards against out-of-order load/search/load-more responses
 
 // Operators may tick a subset (across pages) to collect just those; per-invoice prompt
-// stays for one-offs. No blanket "collect all" — a big account holds thousands.
-const selected = ref([])
-const selectedTotal = computed(() =>
-  selected.value.reduce((sum, inv) => sum + Number(inv.outstanding_amount || 0), 0),
-)
+// stays for one-offs.
+const { selected, isSelected, toggleSelect, clearSelection, dropSelected, selectedTotal } =
+  useInvoiceSelection()
 
 // Over the M-Pesa cap with no card fallback a bundle can't be paid (and hides its invoices
 // ~30 min) — block it and let the operator collect invoices individually.
@@ -47,14 +48,6 @@ const bundleAmount = computed(() => (selected.value.length ? selectedTotal.value
 const bundleBlocked = computed(
   () => !enableRedirect.value && mpesaMax.value > 0 && bundleAmount.value > mpesaMax.value,
 )
-
-const isSelected = (inv) => selected.value.some((i) => i.name === inv.name)
-function toggleSelect(inv) {
-  selected.value = isSelected(inv)
-    ? selected.value.filter((i) => i.name !== inv.name)
-    : [...selected.value, inv]
-}
-const clearSelection = () => (selected.value = [])
 
 async function load(reset = true) {
   const seq = ++loadSeq
@@ -129,8 +122,9 @@ async function collect(names) {
     creatingBundle.value = false
   }
 }
-const collectSelected = () => collect(selected.value.map((inv) => inv.name))
-const collectAll = () => collect(invoices.value.map((inv) => inv.name))
+// Ticked a subset → collect those; nothing ticked → the whole loaded balance.
+const collectNow = () =>
+  collect((selected.value.length ? selected.value : invoices.value).map((inv) => inv.name))
 
 // "Collect all" only when the whole balance is on screen: no more pages AND no active
 // search (a search narrows the loaded rows, so "all" would bundle just the matches).
@@ -147,7 +141,7 @@ const toList = () =>
 function onPaid(name) {
   const paid = invoices.value.find((inv) => inv.name === name)
   invoices.value = invoices.value.filter((inv) => inv.name !== name)
-  selected.value = selected.value.filter((inv) => inv.name !== name)
+  dropSelected(name)
   // Keep the header in step with the balance and only leave when the WHOLE customer is
   // settled — not merely when the loaded page emptied (a big account holds thousands).
   count.value = Math.max(0, count.value - 1)
@@ -170,59 +164,29 @@ onMounted(() => load(true))
       ‹ All customers
     </button>
 
-    <div v-if="loadError" class="py-16 text-center">
-      <p class="font-display text-ink/70">Couldn't load — check your connection.</p>
-      <button
-        type="button"
-        class="mt-3 h-11 rounded-xl bg-mpesa px-5 font-semibold text-white"
-        @click="load(true)"
-      >
-        Retry
-      </button>
-    </div>
+    <ErrorRetry v-if="loadError" @retry="load(true)" />
 
     <template v-else>
-      <section class="rounded-2xl bg-ink px-5 py-4 text-paper">
-        <p class="truncate font-display text-lg font-bold">{{ customerName }}</p>
-        <p class="mt-1 font-mono text-3xl font-semibold tabular-nums">{{ formatKES(total) }}</p>
-        <p class="text-sm text-paper/60">
-          {{ count }} invoice{{ count === 1 ? '' : 's' }} outstanding · {{ paymentTerm || 'all terms' }}
-        </p>
-      </section>
+      <CustomerMoneyHeader
+        :name="customerName"
+        :total="total"
+        :count="count"
+        :term="paymentTerm || 'all terms'"
+      />
 
-      <div v-if="selected.length || canCollectAll" class="flex gap-2">
-        <button
-          type="button"
-          class="h-14 flex-1 rounded-xl bg-mpesa text-lg font-semibold text-white transition active:scale-[.98] disabled:opacity-50"
-          :disabled="creatingBundle || bundleBlocked"
-          @click="selected.length ? collectSelected() : collectAll()"
-        >
-          {{
-            creatingBundle
-              ? '…'
-              : selected.length
-                ? `Collect ${selected.length} — ${formatKES(selectedTotal)}`
-                : `Collect all — ${formatKES(total)}`
-          }}
-        </button>
-        <button
-          v-if="selected.length"
-          type="button"
-          class="h-14 shrink-0 rounded-xl border border-hairline px-5 font-medium text-ink/70"
-          @click="clearSelection"
-        >
-          Clear
-        </button>
-      </div>
-      <p v-if="bundleBlocked" class="-mt-2 px-1 text-xs text-owed">
-        This exceeds the M-Pesa limit ({{ formatKES(mpesaMax) }}) and card checkout is off — collect the invoices individually below.
-      </p>
-      <p v-if="collectError" class="-mt-2 px-1 text-sm text-danger">
-        Couldn't start the collection — try again.
-      </p>
-      <p v-if="invoices.length > 1 && !selected.length" class="-mt-2 px-1 text-xs text-ink/60">
-        Tick invoices to collect only some.
-      </p>
+      <CollectBar
+        :show-bar="selected.length > 0 || canCollectAll"
+        :selected-count="selected.length"
+        :selected-total="selectedTotal"
+        :total="total"
+        :creating-bundle="creatingBundle"
+        :bundle-blocked="bundleBlocked"
+        :mpesa-max="mpesaMax"
+        :collect-error="collectError"
+        :show-tick-hint="invoices.length > 1 && !selected.length"
+        @collect="collectNow"
+        @clear="clearSelection"
+      />
 
       <input
         v-model="search"
@@ -259,9 +223,10 @@ onMounted(() => load(true))
           type="button"
           class="mx-auto h-11 rounded-xl border border-hairline px-6 font-medium text-ink disabled:opacity-50"
           :disabled="loadingMore"
+          :aria-busy="loadingMore"
           @click="load(false)"
         >
-          {{ loadingMore ? '…' : 'Load more' }}
+          {{ loadingMore ? 'Loading…' : 'Load more' }}
         </button>
       </template>
 

--- a/frontend/src/pages/RequestDetail.vue
+++ b/frontend/src/pages/RequestDetail.vue
@@ -11,6 +11,7 @@ import {
 } from '@/data/collection'
 import { formatKES } from '@/utils/format'
 import PromptDialog from '@/components/PromptDialog.vue'
+import ErrorRetry from '@/components/ErrorRetry.vue'
 
 // The transient home for a request or bundle: live status, the invoices it
 // covers, prompt the full amount, and share/regenerate the link. An unpaid bundle
@@ -214,16 +215,7 @@ onMounted(load)
 
     <p v-if="loading" class="py-10 text-center text-sm text-ink/50">Loading…</p>
 
-    <div v-else-if="loadError" class="py-16 text-center">
-      <p class="font-display text-ink/70">Couldn't load — check your connection.</p>
-      <button
-        type="button"
-        class="mt-3 h-11 rounded-xl bg-mpesa px-5 font-semibold text-white"
-        @click="load"
-      >
-        Retry
-      </button>
-    </div>
+    <ErrorRetry v-else-if="loadError" @retry="load" />
 
     <template v-else-if="detail">
       <section class="rounded-2xl bg-ink px-5 py-4 text-paper">
@@ -284,9 +276,10 @@ onMounted(load)
           type="button"
           class="h-14 rounded-xl border-2 border-mpesa text-lg font-semibold text-mpesa transition active:scale-[.98] disabled:opacity-50"
           :disabled="checkoutBusy"
+          :aria-busy="checkoutBusy"
           @click="payViaIpay"
         >
-          {{ checkoutBusy ? '…' : `Pay via iPay — ${formatKES(detail.amount)}` }}
+          {{ checkoutBusy ? 'Opening…' : `Pay via iPay — ${formatKES(detail.amount)}` }}
         </button>
 
         <div v-if="detail.enable_redirect" class="rounded-2xl border border-hairline bg-white p-4">
@@ -295,14 +288,16 @@ onMounted(load)
               type="button"
               class="h-11 flex-1 rounded-xl border border-hairline font-medium text-ink disabled:opacity-50"
               :disabled="linkBusy"
+              :aria-busy="linkBusy"
               @click="showLink"
             >
-              {{ linkBusy ? '…' : 'Payment link' }}
+              {{ linkBusy ? 'Loading…' : 'Payment link' }}
             </button>
             <button
               type="button"
               class="h-11 flex-1 rounded-xl border border-hairline font-medium text-ink disabled:opacity-50"
               :disabled="linkBusy"
+              :aria-busy="linkBusy"
               @click="regenerate"
             >
               Regenerate


### PR DESCRIPTION
Extracts the shared UI between the field (`/collect`) and internal (`/collect/internal`) Collect pages so common markup/logic is changed in **one place**, while each page keeps its own behavior. Addresses review findings **#14, #15** (duplication) and the polish items **#19, #20**.

> **Stacked on #70.** Base is `feat/ipay-collect-payments-internal` so this diff shows only the refactor. It will retarget to `main` automatically once #70 merges.

## New shared modules
| Module | Replaces duplication in |
|---|---|
| `components/CustomerListShell.vue` | the whole list screen — `Collect.vue` + `InternalCollect.vue` |
| `components/CollectBar.vue` | the "Collect all/N" button + hints — both detail pages |
| `components/CustomerMoneyHeader.vue` | the ink money header — both detail pages |
| `components/ErrorRetry.vue` | the "couldn't load / retry" block — **5** pages |
| `composables/useInvoiceSelection.js` | the tick-to-select state — both detail pages |

Each page passes its data + a filters slot into the shared pieces, so behavior stays per-page:
- **Field**: load-all + client-side search, driver filter, `max-w-xl md:max-w-4xl`.
- **Internal**: paginated + debounced server search, driver + payment-term filters, "load more", `max-w-5xl`.

## Polish
- **#19** — busy buttons show a word + `aria-busy` ("Collecting…", "Loading…", "Opening…") instead of a bare "…", across CollectBar, load-more, PromptDialog, RequestDetail and InvoiceCard.
- **#20** — the M-Pesa prompt dialog now **traps Tab focus** within the modal and autofocuses the phone field.

## Behavior preservation
An adversarial equivalence review (5 lenses, each finding independently refuted) found **no functional divergence**. The one cosmetic change: the field loading skeleton's stray `pt-1` (4px) is dropped — the field's *loaded* grid and the internal page never had it, so it was a pre-existing inconsistency; normalizing it makes the loading state consistent.

Verified: all script blocks pass `node --check`, the SPA builds clean (2070 modules), and `/collect` + `/collect/internal` serve on dev.
