### PR TITLE
feat(ipay): show the payment term on each invoice in the collect drill-down

### DIFF
--- a/frontend/src/components/InvoiceCard.vue
+++ b/frontend/src/components/InvoiceCard.vue
@@ -57,6 +57,12 @@ async function payViaIpay() {
 
       <div class="min-w-0 flex-1">
         <p class="truncate font-display text-base font-semibold text-ink">{{ invoice.name }}</p>
+        <span
+          v-if="invoice.payment_terms_template"
+          class="mt-1 inline-block rounded-md bg-ink/10 px-2 py-0.5 text-[11px] font-semibold text-ink/80"
+        >
+          {{ invoice.payment_terms_template }}
+        </span>
         <p v-if="invoice.due_date" class="mt-0.5 text-xs text-ink/60">
           Due {{ formatDate(invoice.due_date) }}
         </p>

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -152,7 +152,7 @@ def _outstanding_invoices(user, customer=None):
     invoices = frappe.get_all(
         "Sales Invoice",
         filters=si_filters,
-        fields=["name", "customer", "customer_name", "outstanding_amount", "posting_date", "due_date"],
+        fields=["name", "customer", "customer_name", "outstanding_amount", "posting_date", "due_date", "payment_terms_template"],
         order_by="posting_date asc",
         limit_page_length=0,
     )
@@ -377,7 +377,7 @@ def _internal_outstanding(customer=None, payment_term=None):
     invoices = frappe.get_all(
         "Sales Invoice",
         filters=filters,
-        fields=["name", "customer", "customer_name", "outstanding_amount", "posting_date", "due_date"],
+        fields=["name", "customer", "customer_name", "outstanding_amount", "posting_date", "due_date", "payment_terms_template"],
         order_by="posting_date desc",
         limit_page_length=0,
     )


### PR DESCRIPTION
Returns `payment_terms_template` with the collect invoices (field + internal queries) and renders it as a small pill under the invoice number on `InvoiceCard`, so operators see whether each invoice is Cash on Delivery / End of Day (or, in internal mode, its actual term). Only renders when a term is set. Verified on dev; SPA rebuilt. Follows the merged #72.