### PR TITLE
test(ipay): unit tests for the money-path core

### DIFF
--- a/ipay/tests/README.md
+++ b/ipay/tests/README.md
@@ -1,0 +1,18 @@
+# iPay tests
+
+Money-path unit tests for the functions behind the money-safety fixes: phone
+normalisation (charge the right number), amount matching + status resolution
+(classify a payment), and the reconcile search (never abandon a paid request).
+
+## Running
+
+The bench-wide `run-tests` is currently broken by an unrelated app (`hrms`'s
+`before_tests` hook imports a symbol not present in this Frappe version), so run
+the module directly:
+
+```bash
+cd frappe-bench
+printf 'import unittest\nunittest.TextTestRunner(verbosity=2).run(unittest.TestLoader().loadTestsFromName("ipay.tests.test_payment_core"))\n' | bench --site <site> console
+```
+
+These tests are pure/mock (no DB writes), so they are fast and deterministic.

--- a/ipay/tests/test_payment_core.py
+++ b/ipay/tests/test_payment_core.py
@@ -1,0 +1,132 @@
+from unittest.mock import MagicMock, patch
+
+import requests
+from frappe.tests.utils import FrappeTestCase
+
+from ipay.ipay.main.utils import reconcile_payments
+from ipay.ipay.main.utils.constants import amounts_match, clean_oid
+from ipay.ipay.main.utils.finalize_payment import _resolve_status
+from ipay.ipay.main.utils.ipay_redirect import normalize_phone
+
+
+class TestNormalizePhone(FrappeTestCase):
+    """A wrong number charges the wrong phone, so normalisation is money-critical."""
+
+    def test_local_zero_prefix_becomes_msisdn(self):
+        self.assertEqual(normalize_phone("0712345678"), "254712345678")
+        self.assertEqual(normalize_phone("0112345678"), "254112345678")
+
+    def test_bare_nine_digit_gets_country_code(self):
+        self.assertEqual(normalize_phone("712345678"), "254712345678")
+        self.assertEqual(normalize_phone("112345678"), "254112345678")
+
+    def test_already_msisdn_is_unchanged(self):
+        self.assertEqual(normalize_phone("254712345678"), "254712345678")
+
+    def test_separators_and_plus_are_stripped(self):
+        self.assertEqual(normalize_phone("+254 712 345 678"), "254712345678")
+        self.assertEqual(normalize_phone("0712-345-678"), "254712345678")
+
+    def test_junk_returns_empty_so_caller_prompts(self):
+        self.assertEqual(normalize_phone("0812345678"), "")  # 08 is not a mobile prefix
+        self.assertEqual(normalize_phone("0712"), "")  # too short
+        self.assertEqual(normalize_phone("254712345678999"), "")  # too long
+        self.assertEqual(normalize_phone("not a phone"), "")
+        self.assertEqual(normalize_phone(""), "")
+        self.assertEqual(normalize_phone(None), "")
+
+
+class TestAmountsMatch(FrappeTestCase):
+    """Amount matching decides Success vs Under/Overpaid — it must be cent-exact."""
+
+    def test_equal_amounts_match(self):
+        self.assertTrue(amounts_match(100, 100))
+        self.assertTrue(amounts_match("100", 100))
+
+    def test_within_a_cent_matches(self):
+        self.assertTrue(amounts_match(100.00, 100.005))
+
+    def test_over_a_cent_does_not_match(self):
+        self.assertFalse(amounts_match(100, 101))
+        self.assertFalse(amounts_match(99.98, 100))
+
+    def test_non_numeric_is_not_a_match(self):
+        self.assertFalse(amounts_match(None, 100))
+        self.assertFalse(amounts_match("abc", 100))
+
+
+class TestResolveStatus(FrappeTestCase):
+    """Classifying a recorded payment: Success / Underpaid / Overpaid."""
+
+    def test_full_amount_allocated_is_success(self):
+        self.assertEqual(_resolve_status({"allocated": 100}, 100, 100), "Success")
+
+    def test_less_than_expected_is_underpaid(self):
+        self.assertEqual(_resolve_status({"allocated": 70}, 70, 100), "Underpaid")
+
+    def test_more_than_expected_is_overpaid(self):
+        self.assertEqual(_resolve_status({"allocated": 100}, 120, 100), "Overpaid")
+
+    def test_exact_amount_but_nothing_allocated_is_overpaid(self):
+        self.assertEqual(_resolve_status({"allocated": 0}, 100, 100), "Overpaid")
+
+
+class TestCleanOid(FrappeTestCase):
+    """The iPay order id must drop characters iPay rejects."""
+
+    def test_unwanted_characters_are_stripped(self):
+        self.assertEqual(clean_oid("ACC-SINV-2024-00001"), "ACCSINV202400001")
+
+    def test_empty_name_is_empty(self):
+        self.assertEqual(clean_oid(None), "")
+
+
+def _fake_response(status_code, json_value=None, json_error=False):
+    resp = MagicMock()
+    resp.status_code = status_code
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = requests.HTTPError(str(status_code))
+    else:
+        resp.raise_for_status.return_value = None
+    if json_error:
+        resp.json.side_effect = ValueError("not json")
+    else:
+        resp.json.return_value = json_value or {}
+    return resp
+
+
+class TestSearchTransaction(FrappeTestCase):
+    """A transient iPay error must never read as 'not paid' — that would abandon a
+    genuinely-paid request and lose the money."""
+
+    def _search(self):
+        return reconcile_payments._search_transaction("OID", "vid", "key")
+
+    def test_404_is_the_only_not_paid_signal(self):
+        with patch.object(reconcile_payments.requests, "post", return_value=_fake_response(404)):
+            self.assertIsNone(self._search())
+
+    def test_server_error_raises_not_abandons(self):
+        with patch.object(reconcile_payments.requests, "post", return_value=_fake_response(502)):
+            with self.assertRaises(requests.RequestException):
+                self._search()
+
+    def test_non_json_body_raises_not_abandons(self):
+        with patch.object(
+            reconcile_payments.requests, "post", return_value=_fake_response(200, json_error=True)
+        ):
+            with self.assertRaises(requests.RequestException):
+                self._search()
+
+    def test_paid_transaction_returns_data(self):
+        paid = {"data": {"transaction_code": "ABC123", "transaction_amount": "100"}}
+        with patch.object(
+            reconcile_payments.requests, "post", return_value=_fake_response(200, paid)
+        ):
+            self.assertEqual(self._search()["transaction_code"], "ABC123")
+
+    def test_record_without_code_is_not_paid(self):
+        with patch.object(
+            reconcile_payments.requests, "post", return_value=_fake_response(200, {"data": {}})
+        ):
+            self.assertIsNone(self._search())


### PR DESCRIPTION
First item of the post-#72 hardening backlog: **automated tests**.

Focused, pure/mockable unit tests for the functions behind the money-safety fixes — no flaky ERPNext fixtures, so they're fast and deterministic.

## Covered
- `normalize_phone` — junk/invalid numbers normalise to `""` so a malformed number is never charged; local `07`/`01`, bare 9-digit, and already-MSISDN forms.
- `amounts_match` — cent-exact matching (drives Success vs Under/Overpaid).
- `_resolve_status` — Success / Underpaid / Overpaid, including the exact-amount-but-nothing-allocated → Overpaid case.
- `_search_transaction` — the reconcile regression: 404 is the only "not paid" signal; a 5xx or non-JSON body **raises** rather than abandoning a genuinely-paid request.
- `clean_oid` — strips characters iPay rejects.

20 tests, all passing.

## Running
The bench-wide `run-tests` is currently broken by an unrelated app (`hrms`'s `before_tests` imports `IntegrationTestCase`, absent in this Frappe version). Run the module directly — see `ipay/tests/README.md`.