### PR TITLE
feat(ipay): observability — declines, reconcile heartbeat, money-at-risk alerts

### DIFF
--- a/ipay/ipay/doctype/ipay_settings/ipay_settings.json
+++ b/ipay/ipay/doctype/ipay_settings/ipay_settings.json
@@ -16,7 +16,9 @@
   "enable_redirect",
   "mpesa_max_amount",
   "payment_link_ttl_days",
-  "cash_account"
+  "cash_account",
+  "alert_email",
+  "last_reconcile_run"
  ],
  "fields": [
   {
@@ -89,6 +91,20 @@
    "fieldtype": "Link",
    "label": "Cash Account (fallback)",
    "options": "Account"
+  },
+  {
+   "description": "Where money-at-risk alerts (a payment confirmed at iPay but not recorded) are emailed. Leave blank to log to Error Log only.",
+   "fieldname": "alert_email",
+   "fieldtype": "Data",
+   "label": "Alert Email",
+   "options": "Email"
+  },
+  {
+   "description": "When the reconcile backstop last ran. A stale value (see reconcile_heartbeat) means it has stopped and payments may be unrecovered.",
+   "fieldname": "last_reconcile_run",
+   "fieldtype": "Datetime",
+   "label": "Last Reconcile Run",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,

--- a/ipay/ipay/main/main.py
+++ b/ipay/ipay/main/main.py
@@ -6,6 +6,7 @@ from ipay.ipay.main.utils.verify_mpesa_payment import verify_mpesa_payment
 from ipay.ipay.main.utils.finalize_payment import finalize_payment
 from ipay.ipay.main.utils.ipay_logs import create_log_entry
 from ipay.ipay.main.utils.constants import clean_oid
+from ipay.ipay.main.utils.alerts import iPayDeclined
 
 logger = logging.getLogger(__name__)
 
@@ -218,6 +219,15 @@ def lipana_mpesa(
                 frappe.db.set_value("iPay Request", docid, "status", "Failed")
                 frappe.db.commit()
                 frappe.throw("Failed to initiate Payment")
+
+        except iPayDeclined as decline:
+            # The payer cancelled / entered a wrong PIN / had no balance — expected,
+            # not an error. Record the reason for the operator, log it at INF.
+            create_log_entry("INF", f"STK declined for {docid}: {decline}")
+            frappe.db.set_value(
+                "iPay Request", docid, {"status": "Failed", "result_detail": str(decline)}
+            )
+            frappe.db.commit()
 
         except Exception as error:
             logger.error("An error occurred during the payment process: %s", error)

--- a/ipay/ipay/main/utils/alerts.py
+++ b/ipay/ipay/main/utils/alerts.py
@@ -1,0 +1,24 @@
+import frappe
+
+
+class iPayDeclined(frappe.ValidationError):
+    """An STK prompt the payer declined (cancelled / wrong PIN / insufficient funds).
+    A business outcome, not a system fault — logged at INF so real errors stand out."""
+
+
+def notify_money_at_risk(subject, message):
+    """Surface a money-at-risk event (a payment confirmed at iPay but not recorded)
+    where a human will see it: always an Error Log, plus an email to the configured
+    operations address. Best-effort — alerting must never break the payment path."""
+    try:
+        frappe.log_error(message, f"iPay money-at-risk: {subject}"[:140])
+    except Exception:
+        pass
+
+    recipient = frappe.db.get_single_value("iPay Settings", "alert_email")
+    if not recipient:
+        return
+    try:
+        frappe.sendmail(recipients=[recipient], subject=f"[iPay] {subject}", message=message)
+    except Exception:
+        pass

--- a/ipay/ipay/main/utils/reconcile_payments.py
+++ b/ipay/ipay/main/utils/reconcile_payments.py
@@ -5,10 +5,15 @@ from ipay.ipay.main.utils.finalize_payment import finalize_payment
 from ipay.ipay.main.utils.send_callback import deliver_callback
 from ipay.ipay.main.utils.ipay_logs import create_log_entry
 from ipay.ipay.main.utils.constants import clean_oid, search_hash
+from ipay.ipay.main.utils.alerts import notify_money_at_risk
 
 # Only reconcile requests created within this window; older unconfirmed requests
 # are assumed abandoned (marked terminal below) so we don't poll them forever.
 RECONCILE_WINDOW_HOURS = 24
+
+# The backstop runs every 5 minutes; a heartbeat older than this means it has
+# stopped (dead scheduler / erroring job) and payments may be piling up unrecovered.
+HEARTBEAT_STALE_SECONDS = 900
 
 SEARCH_URL = "https://apis.ipayafrica.com/payments/v2/transaction/search"
 
@@ -102,6 +107,29 @@ def reconcile_pending_payments():
             frappe.db.rollback()
             create_log_entry("ERR", f"Reconcile (stale) failed for {req.name}: {error}")
 
+    # Stamp liveness even on an empty run, so a stopped backstop is detectable
+    # externally (reconcile_heartbeat) rather than failing silently.
+    frappe.db.set_value(
+        "iPay Settings", "iPay Settings", "last_reconcile_run", frappe.utils.now_datetime()
+    )
+    frappe.db.commit()
+
+
+@frappe.whitelist()
+def reconcile_heartbeat():
+    """Liveness of the reconcile backstop, for an external monitor: when it last ran
+    and whether that is stale. A stale heartbeat means payments may be piling up
+    unrecovered, so an operator should check the scheduler."""
+    last = frappe.db.get_single_value("iPay Settings", "last_reconcile_run")
+    seconds_since = (
+        frappe.utils.time_diff_in_seconds(frappe.utils.now_datetime(), last) if last else None
+    )
+    return {
+        "last_run": last,
+        "seconds_since": seconds_since,
+        "stale": seconds_since is None or seconds_since > HEARTBEAT_STALE_SECONDS,
+    }
+
 
 def reconcile_request(request_name):
     """Finalise a single iPay Request on demand (used by the redirect return
@@ -149,11 +177,13 @@ def _reconcile_one(req, vid, secret_key):
         customer_email=req.customer_email,
     )
     if result.get("status") not in ("success", "duplicate"):
-        # Payment Entry creation failed; leave undelivered to retry next run.
-        create_log_entry(
-            "ERR",
-            f"Reconcile could not create Payment Entry for {req.name}: {result.get('message')}",
+        # Payment confirmed at iPay but the Payment Entry would not save — money is
+        # collected yet unrecorded. Alert a human; leave undelivered to retry next run.
+        message = (
+            f"Reconcile could not create Payment Entry for {req.name}: {result.get('message')}"
         )
+        create_log_entry("ERR", message)
+        notify_money_at_risk(f"Payment Entry failed for {req.name}", message)
         return
 
     request_status = result.get("request_status")

--- a/ipay/ipay/main/utils/verify_mpesa_payment.py
+++ b/ipay/ipay/main/utils/verify_mpesa_payment.py
@@ -5,6 +5,7 @@ import frappe
 from requests.exceptions import RequestException
 
 from ipay.ipay.main.utils.constants import search_hash
+from ipay.ipay.main.utils.alerts import iPayDeclined
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +106,9 @@ def verify_mpesa_payment(oid, phone, vid, secret_key):
 
             terminal = _terminal_error_message(error.response)
             if terminal:
-                frappe.throw(terminal)
+                # A decline is the payer's choice, not a system error — raise a
+                # typed exception so the caller logs it at INF, not ERR.
+                frappe.throw(terminal, exc=iPayDeclined)
             # Otherwise transient (e.g. "no payment record found", timeout) — keep polling.
             delay(retry_delay)
     


### PR DESCRIPTION
Second item of the post-#72 hardening backlog: **alerting / observability**. Three small, independent improvements.

## 1. Declines are INF, not ERR
A payer cancelling, entering a wrong PIN, or having no balance was raised via `frappe.throw` and caught by the STK worker's generic `except Exception` → logged **ERR**. Those are the majority of "failures" and were drowning out real faults.

- New typed `iPayDeclined(frappe.ValidationError)`; `verify_mpesa_payment` raises it (via `frappe.throw(..., exc=iPayDeclined)`, so the payer still sees the exact reason).
- `main.py` catches it before the generic handler → logs **INF** and records the reason on the request. Genuine errors (get_sid failure, unexpected exceptions) stay **ERR**.

## 2. Reconcile heartbeat
The 5-minute backstop had no liveness signal — if it stopped, payments would pile up unrecovered silently.

- Each run stamps `iPay Settings.last_reconcile_run` (even an empty run).
- New whitelisted `reconcile_heartbeat()` returns `{last_run, seconds_since, stale}` (stale > 15 min) for an external monitor (n8n / uptime check). An internal check can't detect a fully-dead scheduler, so this exposes state for an external one.

## 3. Money-at-risk alert
When reconcile confirms a payment at iPay but the **Payment Entry won't save**, the money is collected yet unrecorded — the one case that truly needs a human.

- New `notify_money_at_risk()` writes the Error Log (as before) **and** emails the new optional `iPay Settings.alert_email` (best-effort; alerting never breaks the payment path).

## Schema
Two new fields on **iPay Settings**: `alert_email` (optional) and `last_reconcile_run` (read-only). Applied by `bench migrate`.

Smoke-tested: modules import, fields present, `reconcile_heartbeat()` returns correctly.