### PR TITLE
feat(ipay): rate-limit hardening — per-operator cap + iPay 429 backoff

### DIFF
--- a/ipay/ipay/main/utils/get_sid.py
+++ b/ipay/ipay/main/utils/get_sid.py
@@ -5,6 +5,7 @@ import logging
 import frappe
 
 from ipay.ipay.main.utils.constants import clean_oid
+from ipay.ipay.main.utils.http import post_with_backoff
 
 logger = logging.getLogger(__name__)
 
@@ -66,17 +67,15 @@ def get_sid(vid: str, secret_key: str, amount: str, oid: str, phone: str, eml: s
         
         # Send a POST request. iPay's /transact latency is variable (often several seconds,
         # sometimes >15s); this runs in the long STK worker (no web timeout), so allow more
-        # headroom before giving up with "Failed to get session id".
-        response = requests.post(
+        # headroom before giving up with "Failed to get session id". A momentary 429/5xx is
+        # retried with backoff rather than failing the whole payment.
+        response = post_with_backoff(
             "https://apis.ipayafrica.com/payments/v2/transact",
             data=transaction_payload,
             headers={"Content-Type": "application/x-www-form-urlencoded"},
-            timeout=45
+            timeout=45,
         )
-        
-        # Raise HTTP error for bad responses
-        response.raise_for_status()
-        
+
         logger.info("SID served successfully")
         response_json = response.json()
         logger.info("Response: %s", response_json)

--- a/ipay/ipay/main/utils/http.py
+++ b/ipay/ipay/main/utils/http.py
@@ -1,0 +1,32 @@
+import time
+
+import requests
+
+# iPay statuses worth retrying: 429 (rate limited) and transient 5xx. Any other
+# 4xx is a request problem — retrying it just wastes time.
+RETRYABLE_STATUS = {429, 502, 503, 504}
+
+
+def _retry_after_seconds(response):
+    """Seconds to wait from a numeric Retry-After header, if iPay sent one."""
+    value = response.headers.get("Retry-After")
+    try:
+        return int(value) if value else None
+    except (TypeError, ValueError):
+        return None
+
+
+def post_with_backoff(url, *, data, headers=None, timeout=45, retries=2, backoff=(2, 5)):
+    """POST that retries a rate-limited / transient iPay response with exponential
+    backoff (honouring Retry-After), then raises like a plain request. Only ever
+    called from the long STK worker, where a few seconds of wait is safe and beats
+    failing a whole payment on a momentary 429."""
+    attempt = 0
+    while True:
+        response = requests.post(url, data=data, headers=headers, timeout=timeout)
+        if response.status_code not in RETRYABLE_STATUS or attempt >= retries:
+            response.raise_for_status()
+            return response
+        wait = _retry_after_seconds(response) or backoff[min(attempt, len(backoff) - 1)]
+        time.sleep(wait)
+        attempt += 1

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -618,11 +618,48 @@ def discard_bundle(request):
     return {"cancelled": True}
 
 
+def _throttle(scope, *, cooldown_sec, window_sec, max_in_window, cooldown_msg, cap_msg):
+    """Sliding-window throttle keyed on `scope` (a token or a user). The optional
+    cooldown stops rapid re-fires; the window cap stops sustained abuse. Returns an
+    error dict when blocked, else None — a blocked call never counts against the cap."""
+    cache = frappe.cache()
+    cooldown_key = f"ipay_stk_cooldown:{scope}"
+    count_key = f"ipay_stk_count:{scope}"
+    # expires=True so a miss is read from redis every time, not cached process-locally
+    # — otherwise a second check in one request would see a stale value.
+    if cooldown_sec and cache.get_value(cooldown_key, expires=True):
+        return {"status": "error", "message": cooldown_msg}
+    count = int(cache.get_value(count_key, expires=True) or 0)
+    if count >= max_in_window:
+        return {"status": "error", "message": cap_msg}
+    if cooldown_sec:
+        cache.set_value(cooldown_key, 1, expires_in_sec=cooldown_sec)
+    cache.set_value(count_key, count + 1, expires_in_sec=window_sec)
+    return None
+
+
+def _operator_throttle():
+    """Per-operator cap so a runaway UI loop or a compromised session can't fire
+    unbounded STK pushes. Generous enough for real door-to-door collection — the
+    per-request dedup already blocks re-prompting the same request."""
+    return _throttle(
+        f"user:{frappe.session.user}",
+        cooldown_sec=0,
+        window_sec=60,
+        max_in_window=30,
+        cooldown_msg="",
+        cap_msg="Too many prompts in a short time — please wait a minute and try again.",
+    )
+
+
 @frappe.whitelist(methods=["POST"])
 def prompt_mpesa(invoice, phone=None):
     """Operator action (collection page): send an M-Pesa STK push for an invoice."""
     _require_operator()
     _require_invoice_access(invoice)
+    blocked = _operator_throttle()
+    if blocked:
+        return blocked
     request_name = _ensure_request(invoice)
     result = _enqueue_stk(request_name, phone)
     result["request"] = request_name
@@ -636,6 +673,9 @@ def prompt_request_mpesa(request, phone=None):
     across all the request's invoices. Single invoices use prompt_mpesa."""
     _require_operator()
     _require_request_access(request)
+    blocked = _operator_throttle()
+    if blocked:
+        return blocked
     result = _enqueue_stk(request, phone)
     result["request"] = request
     return result
@@ -753,15 +793,16 @@ def pay_prompt_mpesa(token, phone):
     if _payment_state(request_name)["paid"]:
         return {"status": "error", "message": "This invoice has already been paid."}
 
-    cache = frappe.cache()
-    cooldown_key = f"ipay_stk_cooldown:{token}"
-    count_key = f"ipay_stk_count:{token}"
-    if cache.get_value(cooldown_key):
-        return {"status": "error", "message": "Please wait a moment before requesting another prompt."}
-    if int(cache.get_value(count_key) or 0) >= 5:
-        return {"status": "error", "message": "Too many attempts. Please try again later."}
-    cache.set_value(cooldown_key, 1, expires_in_sec=30)
-    cache.set_value(count_key, int(cache.get_value(count_key) or 0) + 1, expires_in_sec=3600)
+    blocked = _throttle(
+        token,
+        cooldown_sec=30,
+        window_sec=3600,
+        max_in_window=5,
+        cooldown_msg="Please wait a moment before requesting another prompt.",
+        cap_msg="Too many attempts. Please try again later.",
+    )
+    if blocked:
+        return blocked
 
     return _enqueue_stk(request_name, phone)
 

--- a/ipay/ipay/main/utils/trigger_stk_push.py
+++ b/ipay/ipay/main/utils/trigger_stk_push.py
@@ -2,7 +2,9 @@ import requests
 import hmac
 import hashlib
 import logging
-import frappe  
+import frappe
+
+from ipay.ipay.main.utils.http import post_with_backoff
 
 logger = logging.getLogger(__name__)
 
@@ -22,13 +24,14 @@ def trigger_stk_push(phone: str, sid: str, vid: str, secret_key: str) -> dict:
             'hash': hash_value
         }       
 
-        # Send the STK push request
-        response = requests.post('https://apis.ipayafrica.com/payments/v2/transact/push/mpesa',
-                                 data=stk_push_payload,
-                                 headers={'Content-Type': 'application/x-www-form-urlencoded'})
-        
-        # check if the request was successful
-        response.raise_for_status()
+        # Send the STK push request. A momentary 429/5xx is retried with backoff; a
+        # timeout bounds the call so a hung socket can't wedge the worker.
+        response = post_with_backoff(
+            'https://apis.ipayafrica.com/payments/v2/transact/push/mpesa',
+            data=stk_push_payload,
+            headers={'Content-Type': 'application/x-www-form-urlencoded'},
+            timeout=30,
+        )
         logger.info('STK push initiated successfully')
         return response.json()
     


### PR DESCRIPTION
Third item of the post-#72 hardening backlog: **rate-limit hardening**.

## 1. Per-operator prompt cap
The guest pay-link path was rate-limited (30s cooldown + 5/hour per token), but the **operator** endpoints (`prompt_mpesa`, `prompt_request_mpesa`) had only per-request dedup — nothing stopped a runaway UI loop or a compromised session from firing STK pushes across many different requests.

- New shared `_throttle(scope, ...)` sliding-window helper.
- Operator cap: **30 prompts / minute / user** — generous for real door-to-door collection (dedup already blocks re-prompting the *same* request), but bounds abuse.
- The guest path is refactored onto the same helper, behaviour unchanged.

### Fix found while testing
`get_value` defaults to `expires=False`, which **caches the first miss in `frappe.local.cache`**; a later `set_value(expires_in_sec=...)` doesn't refresh local cache, so a second check in one request reads a stale value. Now passes `expires=True` on the counters (correct usage for expiring keys). The existing guest code happened to avoid this by only checking once per request.

## 2. iPay 429 / transient-error backoff
`get_sid` and `trigger_stk_push` did a single POST and failed the whole payment on any error — including a momentary **429** (rate limited by iPay) or transient 5xx.

- New shared `post_with_backoff()` retries `{429, 502, 503, 504}` with exponential backoff, honouring `Retry-After`, then raises like a plain request. Only runs in the long STK worker, where a few seconds' wait is safe.
- `trigger_stk_push` also gains a **timeout** (it had none — a hung socket could wedge the worker indefinitely).
- The verify loop already tolerates 429 (treats it as transient and keeps polling), so it's unchanged.

## Verified
- `post_with_backoff`: 429→200 retries once then returns; permanent 429 raises after 3 attempts.
- `_throttle`: caps at the window limit (`[None, None, CAP, CAP]` for max=2).