### PR TITLE
feat(ipay): filter the internal collect list by sales team member

### DIFF
--- a/frontend/src/components/CustomerCard.vue
+++ b/frontend/src/components/CustomerCard.vue
@@ -5,6 +5,7 @@ defineProps({
   customer: { type: Object, required: true },
   driver: { type: String, default: '' }, // carried through so the detail stays driver-scoped
   paymentTerm: { type: String, default: '' }, // carried through so the detail stays term-scoped
+  salesPerson: { type: String, default: '' }, // carried through so the detail stays member-scoped
   routeName: { type: String, default: 'Customer' }, // 'InternalCustomer' for internal mode
 })
 </script>
@@ -14,7 +15,11 @@ defineProps({
     :to="{
       name: routeName,
       params: { customer: customer.customer },
-      query: { ...(driver ? { driver } : {}), ...(paymentTerm ? { payment_term: paymentTerm } : {}) },
+      query: {
+        ...(driver ? { driver } : {}),
+        ...(paymentTerm ? { payment_term: paymentTerm } : {}),
+        ...(salesPerson ? { sales_person: salesPerson } : {}),
+      },
     }"
     class="flex items-center gap-3 rounded-xl border border-hairline bg-white p-4 transition-colors active:bg-mpesa/5"
   >

--- a/frontend/src/components/CustomerListShell.vue
+++ b/frontend/src/components/CustomerListShell.vue
@@ -23,6 +23,7 @@ defineProps({
   cardRouteName: { type: String, default: 'Customer' },
   cardDriver: { type: String, default: '' },
   cardPaymentTerm: { type: String, default: '' },
+  cardSalesPerson: { type: String, default: '' },
 })
 defineEmits(['retry'])
 </script>
@@ -67,6 +68,7 @@ defineEmits(['retry'])
         :route-name="cardRouteName"
         :driver="cardDriver"
         :payment-term="cardPaymentTerm"
+        :sales-person="cardSalesPerson"
       />
     </div>
   </main>

--- a/frontend/src/data/collection.js
+++ b/frontend/src/data/collection.js
@@ -40,16 +40,28 @@ export const fetchCollectionStats = (driver, allTerms) =>
 
 // Internal (operator) mode: all-terms customer list (lazy) + one customer's invoices,
 // paginated + searchable.
-export const fetchInternalCustomers = (driver, paymentTerm) =>
-  call(API.internalCustomers, { driver: driver || '', payment_term: paymentTerm || '' }, 'GET')
+export const fetchInternalCustomers = (driver, paymentTerm, salesPerson) =>
+  call(
+    API.internalCustomers,
+    { driver: driver || '', payment_term: paymentTerm || '', sales_person: salesPerson || '' },
+    'GET',
+  )
 
 export const fetchInternalCustomerInvoices = (
   customer,
-  { start = 0, pageLength = 50, search = '', driver = '', paymentTerm = '' } = {},
+  { start = 0, pageLength = 50, search = '', driver = '', paymentTerm = '', salesPerson = '' } = {},
 ) =>
   call(
     API.internalCustomerInvoices,
-    { customer, start, page_length: pageLength, search, driver, payment_term: paymentTerm },
+    {
+      customer,
+      start,
+      page_length: pageLength,
+      search,
+      driver,
+      payment_term: paymentTerm,
+      sales_person: salesPerson,
+    },
     'GET',
   )
 

--- a/frontend/src/pages/InternalCollect.vue
+++ b/frontend/src/pages/InternalCollect.vue
@@ -23,6 +23,8 @@ const drivers = ref([])
 const driver = ref(route.query.driver || '') // restored when returning from a detail page
 const paymentTerms = ref([])
 const paymentTerm = ref(route.query.payment_term || '')
+const salesPersons = ref([])
+const salesPerson = ref(route.query.sales_person || '')
 
 const filtered = computed(() => {
   const query = search.value.trim().toLowerCase()
@@ -41,10 +43,11 @@ async function loadCustomers() {
   loadError.value = false
   notPermitted.value = false
   try {
-    const data = await fetchInternalCustomers(driver.value, paymentTerm.value)
+    const data = await fetchInternalCustomers(driver.value, paymentTerm.value, salesPerson.value)
     customers.value = data.customers || []
     drivers.value = data.drivers || []
     paymentTerms.value = data.payment_terms || []
+    salesPersons.value = data.sales_persons || []
   } catch (e) {
     if (e?.exc_type === 'PermissionError' || e?.response?.status === 403) notPermitted.value = true
     else loadError.value = true
@@ -62,7 +65,8 @@ async function loadStats() {
   }
 }
 
-// The driver/term filters are server-side (they scope each customer's balance), so re-fetch.
+// The driver/term/sales-person filters are server-side (they scope each customer's balance),
+// so re-fetch.
 function refreshAll() {
   loadCustomers()
   loadStats()
@@ -89,6 +93,7 @@ onMounted(refreshAll)
     card-route-name="InternalCustomer"
     :card-driver="driver"
     :card-payment-term="paymentTerm"
+    :card-sales-person="salesPerson"
     @retry="loadCustomers"
   >
     <template #filters>
@@ -118,6 +123,16 @@ onMounted(refreshAll)
       >
         <option value="">All terms</option>
         <option v-for="t in paymentTerms" :key="t" :value="t">{{ t }}</option>
+      </select>
+      <select
+        v-if="salesPersons.length"
+        v-model="salesPerson"
+        aria-label="Filter by sales team member"
+        class="h-11 w-full rounded-xl border border-hairline bg-white px-3 text-sm text-ink focus:border-mpesa focus:outline-none focus:ring-2 focus:ring-mpesa/40 sm:w-48"
+        @change="refreshAll"
+      >
+        <option value="">All sales members</option>
+        <option v-for="p in salesPersons" :key="p" :value="p">{{ p }}</option>
       </select>
     </template>
   </CustomerListShell>

--- a/frontend/src/pages/InternalCustomerDetail.vue
+++ b/frontend/src/pages/InternalCustomerDetail.vue
@@ -17,6 +17,7 @@ const router = useRouter()
 const customer = route.params.customer
 const driver = route.query.driver || '' // scope the detail to the driver picked on the list
 const paymentTerm = route.query.payment_term || '' // and to the payment term picked on the list
+const salesPerson = route.query.sales_person || '' // and to the sales team member picked there
 
 const customerName = ref('')
 const invoices = ref([])
@@ -66,6 +67,7 @@ async function load(reset = true) {
       search: search.value.trim(),
       driver,
       paymentTerm,
+      salesPerson,
     })
     if (seq !== loadSeq) return // a newer load/search superseded this response — drop it
     customerName.value = data.customer_name || customer
@@ -117,6 +119,7 @@ async function collect(names) {
           customer,
           ...(driver ? { driver } : {}),
           ...(paymentTerm ? { payment_term: paymentTerm } : {}),
+          ...(salesPerson ? { sales_person: salesPerson } : {}),
         },
       })
     else collectError.value = true
@@ -139,7 +142,11 @@ const canCollectAll = computed(
 const toList = () =>
   router.push({
     name: 'Internal',
-    query: { ...(driver ? { driver } : {}), ...(paymentTerm ? { payment_term: paymentTerm } : {}) },
+    query: {
+      ...(driver ? { driver } : {}),
+      ...(paymentTerm ? { payment_term: paymentTerm } : {}),
+      ...(salesPerson ? { sales_person: salesPerson } : {}),
+    },
   })
 
 function onPaid(name) {

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -401,6 +401,52 @@ def _internal_driver_names():
     return sorted(name for name in on_dns if name and name in active)
 
 
+def _sales_person_scope(sales_person):
+    """The invoices and the customers a sales team member is named on, read from the live
+    Sales Team rows of each."""
+    invoices = set(frappe.get_all(
+        "Sales Team",
+        filters={"parenttype": "Sales Invoice", "sales_person": sales_person},
+        pluck="parent",
+    ))
+    customers = set(frappe.get_all(
+        "Sales Team",
+        filters={"parenttype": "Customer", "sales_person": sales_person},
+        pluck="parent",
+    ))
+    return invoices, customers
+
+
+def _scope_to_sales_person(invoices, sales_person):
+    """Keep only invoices assigned to the named sales team member — by the invoice's own
+    sales team, or by their customer's. ERPNext copies the customer's team onto an invoice
+    when it is created and never refreshes it, so a reassigned customer's older invoices
+    keep the previous member; matching either honours both readings. Mirrors
+    _scope_to_driver: a post-filter, so it composes with the other internal filters."""
+    if not sales_person:
+        return invoices
+    named, customers = _sales_person_scope(sales_person)
+    return [inv for inv in invoices if inv.name in named or inv.customer in customers]
+
+
+def _internal_sales_persons():
+    """Sales team members named on any customer or invoice — the internal filter's options.
+    Read from the live Sales Team rows rather than the Sales Person master so a member whose
+    master record was deleted (their assignments survive) can still be filtered on, and a
+    disabled member's outstanding work stays reachable."""
+    names = frappe.get_all(
+        "Sales Team",
+        filters={"parenttype": ["in", ["Customer", "Sales Invoice"]]},
+        pluck="sales_person",
+        distinct=True,
+    )
+    # Drop tree group nodes (e.g. the "Sales Team" root, which some rows are booked against):
+    # the scope matches a name exactly, so a group would report only what is booked on the
+    # group itself and never its members' work — a total that reads as the whole team's.
+    groups = set(frappe.get_all("Sales Person", filters={"is_group": 1}, pluck="name"))
+    return sorted({name for name in names if name and name not in groups})
+
+
 def _internal_payment_terms():
     """Distinct payment-terms templates on outstanding invoices — the internal filter's
     options (so a member can view e.g. only NET 30 invoices)."""
@@ -419,15 +465,17 @@ def _internal_payment_terms():
 
 
 @frappe.whitelist()
-def internal_customers(driver=None, payment_term=None):
+def internal_customers(driver=None, payment_term=None, sales_person=None):
     """Internal top level: every customer with a COLLECTABLE balance (ALL terms, prepaid
     /actively-bundled excluded), newest-invoice customer first, optionally scoped to one
-    driver's deliveries and/or a payment term; the driver and payment-term options are
-    returned for the filters. Invoices are fetched lazily per customer. Excluding prepaid
-    here (via the order-first lookup) keeps a fully-prepaid customer from showing a balance
-    that opens to an empty drill-down."""
+    driver's deliveries, a payment term and/or a sales team member; the driver, payment-term
+    and sales-person options are returned for the filters. Invoices are fetched lazily per
+    customer. Excluding prepaid here (via the order-first lookup) keeps a fully-prepaid
+    customer from showing a balance that opens to an empty drill-down."""
     _require_internal()
-    invoices = _scope_to_driver(_internal_outstanding(payment_term=payment_term), driver)
+    invoices = _scope_to_sales_person(
+        _scope_to_driver(_internal_outstanding(payment_term=payment_term), driver), sales_person
+    )
     by_customer = {}
     for inv in invoices:
         row = _accumulate_customer(by_customer, inv)
@@ -438,19 +486,24 @@ def internal_customers(driver=None, payment_term=None):
         "customers": customers,
         "drivers": _internal_driver_names(),
         "payment_terms": _internal_payment_terms(),
+        "sales_persons": _internal_sales_persons(),
     }
 
 
 @frappe.whitelist()
-def internal_customer_invoices(customer, start=0, page_length=50, search=None, driver=None, payment_term=None):
+def internal_customer_invoices(customer, start=0, page_length=50, search=None, driver=None, payment_term=None, sales_person=None):
     """One customer's collectable invoices for the internal drill-down: ALL terms
     (prepaid/bundled excluded), newest first, paginated (big accounts hold thousands),
-    optionally scoped to one driver's deliveries and/or a payment term. `search` narrows by
+    optionally scoped to one driver's deliveries, a payment term and/or a sales team member.
+    The same scoping as the list it drills into, so the totals agree. `search` narrows by
     invoice number; the header totals cover the whole (scoped) balance."""
     _require_internal()
     start, page_length = cint(start), cint(page_length) or 50
 
-    invoices = _scope_to_driver(_internal_outstanding(customer, payment_term=payment_term), driver)
+    invoices = _scope_to_sales_person(
+        _scope_to_driver(_internal_outstanding(customer, payment_term=payment_term), driver),
+        sales_person,
+    )
     total = sum(flt(inv.outstanding_amount) for inv in invoices)
     count = len(invoices)
     if search:


### PR DESCRIPTION
Adds a **sales team member** filter to the internal collect page (`/collect/internal`), alongside the existing driver and payment-term filters. Requested so a member can see just their own book.

## Matching: the customer *or* the order — both are needed
ERPNext copies `Customer.sales_team` onto a Sales Invoice **at creation only** and never refreshes it, so the two diverge. Measured on live data:

| Member | Invoice route | Customer route | **Either (used)** |
|---|---|---|---|
| Sophia Khalid | 160 | 260 | **260** |
| Elsie Watare | 10 | 9 | **10** |

Neither route alone is complete — the invoice route would drop 100 of Sophia's invoices, and the customer route would miss the invoice whose customer was later reassigned away from Elsie. Matching either is the only correct reading.

## Options come from live Sales Team rows, not the Sales Person master
- **Betty Wangari** was deleted from the Sales Person master but still owns 57 customers / 73 invoices — a master-table dropdown would make her rows unreachable.
- 2 members are **disabled** yet still hold outstanding work, so `enabled=1` is not filtered either.
- **Tree group nodes are excluded**: the scope matches a name exactly, so the `Sales Team` root (booked on 17 invoices) reported KES 1,380 as though it were the whole team's ~KES 15.7M book. Excluding groups by `is_group` rather than by master-existence keeps the orphan above.

## Implementation
`_scope_to_sales_person` is a pure-Python post-filter mirroring the existing `_scope_to_driver`, so it composes with the other filters and needs no child-table join rewrite. The drill-down (`internal_customer_invoices`) takes the same argument so its totals agree with the card it opened from, and the filter round-trips through the URL query (list → detail → back, and into the request page) so it survives navigation.

Verified live: no filter is pass-through (5,352); unknown person → 0 (not everything); zero false positives; filtering narrows 141 → 56 customers for Sophia.

## Review
Reviewed adversarially across regression / correctness / security / efficiency lenses — 8 findings raised, 6 refuted, **2 confirmed and fixed**:
1. The group-node option above (major).
2. A `sm:flex-wrap` I had added to the shared filters row regressed the *driver* page's layout (its search input is uncapped, so it pushed the driver dropdown to a second line). Removed — flex-shrink keeps all four filters on one row, and the driver page is untouched.

Frontend rebuilt; the driver-facing `/collect` page is behaviourally unchanged.