### PR TITLE
feat(ipay): show the sales member on the invoice card

### DIFF
--- a/frontend/src/components/InvoiceCard.vue
+++ b/frontend/src/components/InvoiceCard.vue
@@ -76,8 +76,12 @@ async function payViaIpay() {
         <p v-if="invoice.delivery_note" class="break-words text-xs text-ink/70">
           {{ invoice.delivery_note }}
         </p>
+        <!-- Both people are labelled: two bare names would be indistinguishable. -->
         <p v-if="invoice.driver_name" class="break-words text-xs text-ink/55">
-          {{ invoice.driver_name }}
+          Driver · {{ invoice.driver_name }}
+        </p>
+        <p v-if="invoice.sales_person_name" class="break-words text-xs text-ink/55">
+          Sales · {{ invoice.sales_person_name }}
         </p>
       </div>
 

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -225,6 +225,7 @@ def _customer_invoices(user, customer, driver=None):
     if driver:
         invoices = [inv for inv in invoices if driver in (inv.get("drivers") or [])]
     _annotate_customer_phone(invoices)
+    _annotate_sales_person(invoices)
     _annotate_notes(invoices)
     return invoices
 
@@ -244,6 +245,36 @@ def _annotate_customer_phone(invoices):
     }
     for inv in invoices:
         inv.customer_phone = phone_by_customer.get(inv.customer, "")
+
+
+def _annotate_sales_person(invoices):
+    """Attach the sales team member(s) behind each invoice in place (two batched queries) —
+    the invoice's own Sales Team plus its customer's, the same union the sales scoping matches,
+    so a card shows who owns it and why it sits in that member's book. Both are kept because
+    ERPNext snapshots the customer's team onto the invoice at creation and never refreshes it."""
+    if not invoices:
+        return
+    by_invoice, by_customer = {}, {}
+    for row in frappe.get_all(
+        "Sales Team",
+        filters={"parenttype": "Sales Invoice", "parent": ["in", [inv.name for inv in invoices]]},
+        fields=["parent", "sales_person"],
+    ):
+        by_invoice.setdefault(row.parent, set()).add(row.sales_person)
+
+    customers = list({inv.customer for inv in invoices if inv.customer})
+    if customers:
+        for row in frappe.get_all(
+            "Sales Team",
+            filters={"parenttype": "Customer", "parent": ["in", customers]},
+            fields=["parent", "sales_person"],
+        ):
+            by_customer.setdefault(row.parent, set()).add(row.sales_person)
+
+    for inv in invoices:
+        people = by_invoice.get(inv.name, set()) | by_customer.get(inv.customer, set())
+        inv.sales_persons = sorted(p for p in people if p)
+        inv.sales_person_name = ", ".join(inv.sales_persons)
 
 
 def _annotate_notes(invoices):
@@ -487,6 +518,7 @@ def _drill_down(invoices, customer, start, page_length, search):
     page = invoices[start : start + page_length]
     _annotate_delivery(page)
     _annotate_customer_phone(page)
+    _annotate_sales_person(page)
     _annotate_notes(page)
     return {
         "customer": customer,


### PR DESCRIPTION
Based directly on `main` — not stacked.

The invoice card already named the driver; it now names the sales member too, so whoever is looking at an invoice can see who owns the account without leaving the page.

```
IV06240408                       KES 27.00
[Cash on Delivery]
Due 12 Jun
DN-0042
Driver · Otieno
Sales  · Sophia Khalid
```

## Two design decisions worth knowing

**Both names are labelled now.** The driver line was bare (`Otieno`), which read fine only while it was the sole person on the card. A second bare name underneath would be indistinguishable from it, so both lines gained a label.

**It shows both members when they disagree.** ERPNext copies the customer's Sales Team onto an invoice at creation and never refreshes it, so a reassigned customer's older invoices keep the previous member. Where the invoice's own team and its customer's differ, both names appear — the same union the sales scoping matches, so the card explains why an invoice sits in a given member's book rather than contradicting the filter. It mirrors how `driver_name` already joins multiple drivers.

## Cost
A `v-if` line (~16px, only when known) and **two batched queries per page**, never per card — it sits next to `_annotate_delivery` and follows its shape exactly.

## Verified live
- 4,793 of 5,352 outstanding invoices carry a member; 559 have none and omit the line
- 10 invoices diverge and render both names
- The real endpoint payload carries `sales_person_name`
- 20/20 tests pass
