### PR TITLE
refactor(ipay): one dialog shell, so the focus trap exists once

### DIFF
--- a/frontend/src/components/BaseDialog.vue
+++ b/frontend/src/components/BaseDialog.vue
@@ -1,0 +1,76 @@
+<script setup>
+import { nextTick, onUnmounted, ref, watch } from 'vue'
+
+// The app's modal shell: backdrop, panel, Escape and a Tab trap. Every dialog is built on this
+// so the trap exists once — it was copied by hand before and the copies drifted apart.
+const props = defineProps({
+  open: Boolean,
+  labelledby: { type: String, required: true },
+  // Where focus lands on open. 'panel' leaves a phone at the top of the content rather than
+  // scrolling to the first field.
+  focus: { type: String, default: 'input' },
+})
+const emit = defineEmits(['close'])
+
+const panel = ref(null)
+
+// Escape and the backdrop both just report intent; the caller decides what closing means.
+function onKeydown(e) {
+  if (e.key === 'Escape') return emit('close')
+  if (e.key !== 'Tab') return
+  // The panel leads the list: it holds focus on open, and querySelectorAll sees only its
+  // descendants — without it Shift+Tab lands on the page behind.
+  const items = [
+    panel.value,
+    ...Array.from(
+      panel.value?.querySelectorAll(
+        'textarea, input, select, button, [href], [tabindex]:not([tabindex="-1"])',
+      ) || [],
+    ),
+  ].filter((el) => el && !el.disabled)
+  if (!items.length) return
+  const first = items[0]
+  const last = items[items.length - 1]
+  if (e.shiftKey && document.activeElement === first) {
+    e.preventDefault()
+    last.focus()
+  } else if (!e.shiftKey && document.activeElement === last) {
+    e.preventDefault()
+    first.focus()
+  }
+}
+
+watch(
+  () => props.open,
+  (open) => {
+    window[open ? 'addEventListener' : 'removeEventListener']('keydown', onKeydown)
+    if (open)
+      nextTick(() =>
+        (props.focus === 'input' ? panel.value?.querySelector('input') : panel.value)?.focus(),
+      )
+  },
+)
+
+onUnmounted(() => window.removeEventListener('keydown', onKeydown))
+
+defineExpose({ panel })
+</script>
+
+<template>
+  <div
+    v-if="open"
+    class="fixed inset-0 z-50 flex items-end justify-center bg-ink/50 p-4 sm:items-center"
+    @click.self="$emit('close')"
+  >
+    <div
+      ref="panel"
+      role="dialog"
+      aria-modal="true"
+      :aria-labelledby="labelledby"
+      tabindex="-1"
+      class="w-full max-w-md rounded-3xl bg-paper p-6 focus:outline-none"
+    >
+      <slot />
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/NotesDialog.vue
+++ b/frontend/src/components/NotesDialog.vue
@@ -1,16 +1,15 @@
 <script setup>
-import { computed, nextTick, onUnmounted, ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { addInvoiceNote, fetchInvoiceNotes } from '@/data/collection'
 import { formatDateTime } from '@/utils/format'
+import BaseDialog from '@/components/BaseDialog.vue'
 
 const MAX = 500
 
-// `target` is { invoice, customer_name } or null — mirrors PromptDialog's null-able prop, which
-// is what arms and disarms the keydown listener below.
+// `target` is { invoice, customer_name } or null — null closes the dialog.
 const props = defineProps({ target: { type: Object, default: null } })
 const emit = defineEmits(['close', 'saved'])
 
-const dialogRef = ref(null)
 const notes = ref([])
 const draft = ref('')
 const loading = ref(false)
@@ -55,114 +54,67 @@ async function save() {
   }
 }
 
-// Close on Escape and trap Tab within the dialog. `textarea` matters here — PromptDialog's
-// selector omits it because it has none.
-function onKeydown(e) {
-  if (e.key === 'Escape') return emit('close')
-  if (e.key !== 'Tab') return
-  // The dialog itself leads the list: it holds focus on open, and querySelectorAll would
-  // only see its descendants — so Shift+Tab would otherwise land on the page behind.
-  const items = [
-    dialogRef.value,
-    ...Array.from(
-      dialogRef.value?.querySelectorAll(
-        'textarea, input, button, [href], [tabindex]:not([tabindex="-1"])',
-      ) || [],
-    ),
-  ].filter((el) => el && !el.disabled)
-  if (!items.length) return
-  const first = items[0]
-  const last = items[items.length - 1]
-  if (e.shiftKey && document.activeElement === first) {
-    e.preventDefault()
-    last.focus()
-  } else if (!e.shiftKey && document.activeElement === last) {
-    e.preventDefault()
-    first.focus()
-  }
-}
-
 watch(
   () => props.target,
   (target) => {
     draft.value = ''
     error.value = ''
     notes.value = []
-    window[target ? 'addEventListener' : 'removeEventListener']('keydown', onKeydown)
-    if (target) {
-      load()
-      // Focus the dialog, not the composer: autofocusing the field would scroll a phone past
-      // the notes the operator opened this to read.
-      nextTick(() => dialogRef.value?.focus())
-    }
+    if (target) load()
   },
 )
-
-onUnmounted(() => window.removeEventListener('keydown', onKeydown))
 </script>
 
 <template>
-  <div
-    v-if="target"
-    class="fixed inset-0 z-50 flex items-end justify-center bg-ink/50 p-4 sm:items-center"
-    @click.self="$emit('close')"
-  >
-    <div
-      ref="dialogRef"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="notes-title"
-      tabindex="-1"
-      class="w-full max-w-md rounded-3xl bg-paper p-6 focus:outline-none"
-    >
-      <h2 id="notes-title" class="font-display text-lg font-bold text-ink">Notes</h2>
-      <p class="mt-0.5 truncate text-sm text-ink/60">
-        {{ target.customer_name }} · {{ target.invoice }}
-      </p>
+  <!-- focus="panel": the operator opened this to READ; don't scroll them past the notes. -->
+  <BaseDialog :open="Boolean(target)" labelledby="notes-title" focus="panel" @close="$emit('close')">
+    <h2 id="notes-title" class="font-display text-lg font-bold text-ink">Notes</h2>
+    <p class="mt-0.5 truncate text-sm text-ink/60">
+      {{ target.customer_name }} · {{ target.invoice }}
+    </p>
 
-      <p v-if="loading" class="py-6 text-center text-sm text-ink/50">Loading…</p>
-      <div v-else-if="notes.length" class="mt-4 flex max-h-56 flex-col gap-2 overflow-y-auto">
-        <div v-for="note in notes" :key="note.name" class="rounded-xl bg-white p-3">
-          <div class="flex justify-between gap-2 text-[11px] font-semibold text-ink/55">
-            <span class="truncate">{{ note.author }}</span>
-            <span class="shrink-0">{{ formatDateTime(note.creation) }}</span>
-          </div>
-          <p class="mt-0.5 whitespace-pre-wrap break-words text-sm text-ink">{{ note.content }}</p>
+    <p v-if="loading" class="py-6 text-center text-sm text-ink/50">Loading…</p>
+    <div v-else-if="notes.length" class="mt-4 flex max-h-56 flex-col gap-2 overflow-y-auto">
+      <div v-for="note in notes" :key="note.name" class="rounded-xl bg-white p-3">
+        <div class="flex justify-between gap-2 text-[11px] font-semibold text-ink/55">
+          <span class="truncate">{{ note.author }}</span>
+          <span class="shrink-0">{{ formatDateTime(note.creation) }}</span>
         </div>
-      </div>
-      <p v-else class="py-6 text-center text-sm text-ink/50">No notes yet.</p>
-
-      <textarea
-        v-model="draft"
-        rows="3"
-        :maxlength="MAX"
-        aria-label="Add a note"
-        placeholder="Add a note about collecting this invoice…"
-        class="mt-4 w-full rounded-xl border border-hairline bg-white px-3 py-2 text-sm text-ink placeholder:text-ink/50 focus:border-mpesa focus:outline-none focus:ring-2 focus:ring-mpesa/40"
-      />
-      <p v-if="error" class="mt-2 text-sm text-danger">{{ error }}</p>
-
-      <div class="mt-3 flex items-center justify-between gap-3">
-        <span class="font-mono text-[11px] tabular-nums text-ink/50">{{ draft.length }} / {{ MAX }}</span>
-        <div class="flex gap-2">
-          <button
-            type="button"
-            class="h-11 rounded-xl border border-hairline bg-white px-4 font-medium text-ink"
-            @click="$emit('close')"
-          >
-            Close
-          </button>
-          <button
-            type="button"
-            class="h-11 rounded-xl bg-mpesa px-5 font-semibold text-white disabled:opacity-40"
-            :disabled="!canSave"
-            :aria-busy="saving"
-            @click="save"
-          >
-            {{ saving ? 'Saving…' : 'Save note' }}
-          </button>
-        </div>
+        <p class="mt-0.5 whitespace-pre-wrap break-words text-sm text-ink">{{ note.content }}</p>
       </div>
     </div>
-  </div>
+    <p v-else class="py-6 text-center text-sm text-ink/50">No notes yet.</p>
+
+    <textarea
+      v-model="draft"
+      rows="3"
+      :maxlength="MAX"
+      aria-label="Add a note"
+      placeholder="Add a note about collecting this invoice…"
+      class="mt-4 w-full rounded-xl border border-hairline bg-white px-3 py-2 text-sm text-ink placeholder:text-ink/50 focus:border-mpesa focus:outline-none focus:ring-2 focus:ring-mpesa/40"
+    />
+    <p v-if="error" class="mt-2 text-sm text-danger">{{ error }}</p>
+
+    <div class="mt-3 flex items-center justify-between gap-3">
+      <span class="font-mono text-[11px] tabular-nums text-ink/50">{{ draft.length }} / {{ MAX }}</span>
+      <div class="flex gap-2">
+        <button
+          type="button"
+          class="h-11 rounded-xl border border-hairline bg-white px-4 font-medium text-ink"
+          @click="$emit('close')"
+        >
+          Close
+        </button>
+        <button
+          type="button"
+          class="h-11 rounded-xl bg-mpesa px-5 font-semibold text-white disabled:opacity-40"
+          :disabled="!canSave"
+          :aria-busy="saving"
+          @click="save"
+        >
+          {{ saving ? 'Saving…' : 'Save note' }}
+        </button>
+      </div>
+    </div>
+  </BaseDialog>
 </template>

--- a/frontend/src/components/PromptDialog.vue
+++ b/frontend/src/components/PromptDialog.vue
@@ -7,6 +7,7 @@ import {
   saveCustomerContact,
 } from '@/data/collection'
 import { formatKES } from '@/utils/format'
+import BaseDialog from '@/components/BaseDialog.vue'
 
 // One M-Pesa STK prompt for a target (a single invoice or a bundle request). The number and
 // the amount are shown so the operator confirms both before charging. On success a "money
@@ -24,7 +25,7 @@ const busy = ref(false)
 const message = ref(null) // { tone, text }
 const paid = ref(false)
 const receipt = ref('')
-const dialogRef = ref(null)
+const doneRef = ref(null)
 let pollTimer = null
 let returnTimer = null
 
@@ -36,38 +37,19 @@ const toneBox = {
 }
 const waiting = computed(() => busy.value && message.value?.tone === 'info')
 
-// Close on Escape and trap Tab within the dialog (keyboard/AT users can't wander to the
-// page behind the modal). On the success screen, Escape acknowledges rather than abandons.
-function onKeydown(e) {
-  if (e.key === 'Escape') return paid.value ? finishPaid() : emit('close')
-  if (e.key !== 'Tab') return
-  const items = Array.from(
-    dialogRef.value?.querySelectorAll('input, button, [href], [tabindex]:not([tabindex="-1"])') || [],
-  ).filter((el) => !el.disabled)
-  if (!items.length) return
-  const first = items[0]
-  const last = items[items.length - 1]
-  if (e.shiftKey && document.activeElement === first) {
-    e.preventDefault()
-    last.focus()
-  } else if (!e.shiftKey && document.activeElement === last) {
-    e.preventDefault()
-    first.focus()
-  }
-}
+// On the success screen a dismiss acknowledges the payment rather than abandoning it.
+const onDismiss = () => (paid.value ? finishPaid() : emit('close'))
 
 watch(
   () => props.target,
-  (target) => {
-    phone.value = target?.phone || ''
+  () => {
+    phone.value = props.target?.phone || ''
     busy.value = false
     message.value = null
     paid.value = false
     receipt.value = ''
     stopPolling()
     clearReturn()
-    window[target ? 'addEventListener' : 'removeEventListener']('keydown', onKeydown)
-    if (target) nextTick(() => dialogRef.value?.querySelector('input')?.focus())
   },
 )
 
@@ -121,7 +103,7 @@ function startPolling(request) {
         receipt.value = state.detail || ''
         paid.value = true
         returnTimer = setTimeout(finishPaid, RETURN_AFTER_MS)
-        nextTick(() => dialogRef.value?.querySelector('button')?.focus())
+        nextTick(() => doneRef.value?.focus())
       } else if (state.partial) {
         settle('warn', state.detail || 'Paid, but the amount differs — the team will reconcile it.')
         emit('changed')
@@ -169,23 +151,11 @@ function clearReturn() {
 onUnmounted(() => {
   stopPolling()
   clearReturn()
-  window.removeEventListener('keydown', onKeydown)
 })
 </script>
 
 <template>
-  <div
-    v-if="target"
-    class="fixed inset-0 z-50 flex items-end justify-center bg-ink/50 p-4 sm:items-center"
-    @click.self="paid ? finishPaid() : $emit('close')"
-  >
-    <div
-      ref="dialogRef"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="prompt-title"
-      class="w-full max-w-md rounded-3xl bg-paper p-6"
-    >
+  <BaseDialog :open="Boolean(target)" labelledby="prompt-title" @close="onDismiss">
       <!-- Success: money received -->
       <div v-if="paid" class="text-center">
         <div class="mx-auto grid h-16 w-16 place-items-center rounded-full bg-landed/15">
@@ -207,6 +177,7 @@ onUnmounted(() => {
         </p>
         <p v-if="receipt" class="mx-auto mt-3 max-w-xs text-xs text-ink/60">{{ receipt }}</p>
         <button
+          ref="doneRef"
           type="button"
           class="mt-6 h-12 w-full rounded-xl bg-ink font-semibold text-paper transition active:scale-[.98]"
           @click="finishPaid"
@@ -266,7 +237,6 @@ onUnmounted(() => {
             {{ busy ? 'Waiting…' : 'Send prompt' }}
           </button>
         </div>
-      </template>
-    </div>
-  </div>
+    </template>
+  </BaseDialog>
 </template>


### PR DESCRIPTION
Based directly on `main`. **Phase 0 of the cheque-collection plan** — no cheque code; this only removes the duplication the cheque sheet would otherwise inherit.

## Why now
`PromptDialog` and `NotesDialog` each carried their own backdrop, panel, Escape handler and Tab trap — and the copies had **already drifted**:

| | PromptDialog (before) | NotesDialog |
|---|---|---|
| Trap includes the panel that holds focus | ❌ Shift+Tab escapes to the page behind | ✅ fixed when copied |
| Trap selector covers `textarea` / `select` | ❌ | ✅ widened when copied |

`NotesDialog` silently fixed a real bug and `PromptDialog` never got it. The cheque sheet would be the third copy, inheriting whichever half it was cloned from. Extract now, fix once, for three callers.

## What changed
`BaseDialog.vue` owns the shell: backdrop, panel, Escape, the trap (union selector, panel first) and focus-on-open. The other two keep only their bodies and the two things that genuinely differ:

- **PromptDialog** intercepts a dismiss, so Escape/backdrop on the success screen *acknowledges* the payment rather than abandoning it (`paid ? finishPaid() : close`).
- **NotesDialog** uses `focus="panel"`, so a phone isn't scrolled past the notes it was opened to read.

## Behaviour
Unchanged for both — **except PromptDialog inherits the two trap fixes**. Callers are untouched: identical props and events at all five call sites (`CustomerDetail` ×2, `PagedCustomerDetail` ×2, `RequestDetail` ×1).

## Verified
- Builds clean; tags balance; no unused imports left behind
- Caller contracts identical (grepped all five)
- Live on dev

Worth a click-through of both dialogs before merge — the repo has no frontend test tooling, and adding vitest for one refactor felt like the wrong trade. The behaviours to spot-check are: prompt still charges and shows the success screen, Escape on that screen still says Done rather than abandoning, and notes still open focused at the top.
