### PR TITLE
feat(ipay): collect a cheque from the phone, and stop re-prompting for it

### DIFF
--- a/frontend/src/components/ChequeDialog.vue
+++ b/frontend/src/components/ChequeDialog.vue
@@ -1,0 +1,231 @@
+<script setup>
+import { computed, ref, watch } from 'vue'
+import { recordCheque } from '@/data/collection'
+import { formatKES } from '@/utils/format'
+import BaseDialog from '@/components/BaseDialog.vue'
+
+const MAX_DIMENSION = 1600 // a phone photo is 3-8 MB; the cheque only has to be readable
+const JPEG_QUALITY = 0.8
+const NUMBER_MAX = 30
+
+// `target` is { customer, customer_name, invoices, outstanding } or null. An empty `invoices`
+// records the cheque on account, against no invoice.
+const props = defineProps({ target: { type: Object, default: null } })
+const emit = defineEmits(['close', 'recorded'])
+
+const photo = ref('') // downscaled data URL, exactly what the server stores
+const amount = ref('')
+const number = ref('')
+const reviewing = ref(false)
+const saving = ref(false)
+const done = ref(false)
+const error = ref('')
+
+const invoiceCount = computed(() => props.target?.invoices?.length || 0)
+const covers = computed(() =>
+  invoiceCount.value
+    ? `${invoiceCount.value} invoice${invoiceCount.value === 1 ? '' : 's'}`
+    : 'On account',
+)
+const amountValue = computed(() => Number(amount.value) || 0)
+const canReview = computed(() => Boolean(photo.value) && amountValue.value > 0 && Boolean(number.value.trim()))
+
+// Shrink in the browser: a full-size photo would blow the upload cap and a slow line.
+function downscale(file) {
+  return new Promise((resolve, reject) => {
+    const image = new Image()
+    image.onerror = () => reject(new Error('unreadable'))
+    image.onload = () => {
+      const scale = Math.min(1, MAX_DIMENSION / Math.max(image.width, image.height))
+      const canvas = document.createElement('canvas')
+      canvas.width = Math.round(image.width * scale)
+      canvas.height = Math.round(image.height * scale)
+      canvas.getContext('2d').drawImage(image, 0, 0, canvas.width, canvas.height)
+      resolve(canvas.toDataURL('image/jpeg', JPEG_QUALITY))
+      URL.revokeObjectURL(image.src)
+    }
+    image.src = URL.createObjectURL(file)
+  })
+}
+
+async function onPick(event) {
+  const file = event.target.files?.[0]
+  if (!file) return
+  error.value = ''
+  try {
+    photo.value = await downscale(file)
+  } catch {
+    error.value = "That photo couldn't be read. Try again."
+  }
+}
+
+async function save() {
+  if (saving.value) return
+  saving.value = true
+  error.value = ''
+  try {
+    await recordCheque({
+      customer: props.target.customer,
+      amount: amountValue.value,
+      chequeNo: number.value.trim(),
+      photo: photo.value,
+      invoices: props.target.invoices || [],
+    })
+    done.value = true
+    emit('recorded', { invoices: props.target.invoices || [], amount: amountValue.value })
+  } catch (e) {
+    error.value = e?.messages?.[0] || "Couldn't record the cheque."
+    reviewing.value = false // back to the form, with everything they typed still there
+  } finally {
+    saving.value = false
+  }
+}
+
+watch(
+  () => props.target,
+  () => {
+    photo.value = ''
+    amount.value = ''
+    number.value = ''
+    reviewing.value = false
+    saving.value = false
+    done.value = false
+    error.value = ''
+  },
+)
+</script>
+
+<template>
+  <BaseDialog
+    :open="Boolean(target)"
+    labelledby="cheque-title"
+    focus="panel"
+    @close="$emit('close')"
+  >
+    <h2 id="cheque-title" class="font-display text-lg font-bold text-ink">
+      {{ done ? 'Cheque recorded' : reviewing ? 'Check this is right' : 'Collect a cheque' }}
+    </h2>
+    <p class="mt-0.5 truncate text-sm text-ink/60">{{ target?.customer_name }} · {{ covers }}</p>
+
+    <!-- Recorded: say plainly that no money has moved yet, so nobody treats it as paid. -->
+    <template v-if="done">
+      <p class="mt-4 rounded-xl bg-paper p-4 text-sm text-ink/80">
+        {{ formatKES(amountValue) }} — cheque {{ number }}. Accounts will bank it and confirm the
+        payment. The invoice stays open until it clears.
+      </p>
+      <button
+        type="button"
+        class="mt-4 h-12 w-full rounded-xl bg-ink font-semibold text-white"
+        @click="$emit('close')"
+      >
+        Done
+      </button>
+    </template>
+
+    <template v-else-if="reviewing">
+      <img :src="photo" alt="The cheque photo" class="mt-4 max-h-40 w-full rounded-xl object-contain" />
+      <dl class="mt-3 divide-y divide-hairline rounded-xl bg-paper px-3">
+        <div class="flex justify-between gap-3 py-2.5">
+          <dt class="text-sm text-ink/60">Amount</dt>
+          <dd class="font-mono text-base font-semibold tabular-nums text-ink">
+            {{ formatKES(amountValue) }}
+          </dd>
+        </div>
+        <div class="flex justify-between gap-3 py-2.5">
+          <dt class="text-sm text-ink/60">Cheque number</dt>
+          <dd class="font-mono text-sm font-semibold text-ink">{{ number }}</dd>
+        </div>
+        <div class="flex justify-between gap-3 py-2.5">
+          <dt class="text-sm text-ink/60">Covers</dt>
+          <dd class="text-sm font-medium text-ink">{{ covers }}</dd>
+        </div>
+      </dl>
+      <p v-if="error" class="mt-2 text-sm text-danger">{{ error }}</p>
+      <div class="mt-4 flex gap-2">
+        <button
+          type="button"
+          class="h-12 shrink-0 rounded-xl border border-hairline px-5 font-medium text-ink"
+          :disabled="saving"
+          @click="reviewing = false"
+        >
+          Back
+        </button>
+        <!-- Never bg-mpesa: green is the M-Pesa rail, and no money moves here. -->
+        <button
+          type="button"
+          class="h-12 flex-1 rounded-xl bg-ink font-semibold text-white disabled:opacity-40"
+          :disabled="saving"
+          :aria-busy="saving"
+          @click="save"
+        >
+          {{ saving ? 'Recording…' : 'Record cheque' }}
+        </button>
+      </div>
+    </template>
+
+    <template v-else>
+      <label
+        class="mt-4 grid h-32 w-full cursor-pointer place-items-center overflow-hidden rounded-xl border border-dashed border-hairline bg-paper text-sm font-medium text-ink/60"
+      >
+        <img v-if="photo" :src="photo" alt="The cheque photo" class="h-full w-full object-contain" />
+        <span v-else class="flex flex-col items-center gap-1">
+          <svg viewBox="0 0 24 24" class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="1.6">
+            <path d="M3 8.5h4L8.5 6h7L17 8.5h4v10H3z" stroke-linejoin="round" />
+            <circle cx="12" cy="13" r="3.2" />
+          </svg>
+          Photograph the cheque
+        </span>
+        <input type="file" accept="image/*" capture="environment" class="sr-only" @change="onPick" />
+      </label>
+
+      <label class="mt-3 block text-xs font-semibold text-ink/60" for="cheque-amount">
+        Amount on the cheque
+      </label>
+      <input
+        id="cheque-amount"
+        v-model="amount"
+        type="number"
+        inputmode="decimal"
+        min="0"
+        placeholder="0"
+        class="mt-1 h-12 w-full rounded-xl border border-hairline bg-white px-3 font-mono text-base tabular-nums text-ink focus:border-ink focus:outline-none focus:ring-2 focus:ring-ink/20"
+      />
+      <p v-if="target?.outstanding" class="mt-1 text-xs text-ink/50">
+        Outstanding {{ formatKES(target.outstanding) }} — enter what the cheque says.
+      </p>
+
+      <label class="mt-3 block text-xs font-semibold text-ink/60" for="cheque-number">
+        Cheque number
+      </label>
+      <input
+        id="cheque-number"
+        v-model="number"
+        type="text"
+        inputmode="numeric"
+        :maxlength="NUMBER_MAX"
+        placeholder="001894"
+        class="mt-1 h-12 w-full rounded-xl border border-hairline bg-white px-3 font-mono text-base text-ink focus:border-ink focus:outline-none focus:ring-2 focus:ring-ink/20"
+      />
+
+      <p v-if="error" class="mt-2 text-sm text-danger">{{ error }}</p>
+
+      <div class="mt-4 flex gap-2">
+        <button
+          type="button"
+          class="h-12 shrink-0 rounded-xl border border-hairline px-5 font-medium text-ink"
+          @click="$emit('close')"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          class="h-12 flex-1 rounded-xl bg-ink font-semibold text-white disabled:opacity-40"
+          :disabled="!canReview"
+          @click="reviewing = true"
+        >
+          Review
+        </button>
+      </div>
+    </template>
+  </BaseDialog>
+</template>

--- a/frontend/src/components/CollectBar.vue
+++ b/frontend/src/components/CollectBar.vue
@@ -14,8 +14,9 @@ defineProps({
   mpesaMax: { type: Number, default: 0 },
   collectError: Boolean,
   showTickHint: Boolean,
+  showCheque: Boolean, // cheque collection is offered even where bundling is not
 })
-defineEmits(['collect', 'clear'])
+defineEmits(['collect', 'clear', 'cheque'])
 </script>
 
 <template>
@@ -53,4 +54,13 @@ defineEmits(['collect', 'clear'])
   <p v-if="showTickHint" class="-mt-2 px-1 text-xs text-ink/60">
     Tick invoices to collect only some.
   </p>
+  <!-- Deliberately quiet: cheques are the exception, and M-Pesa stays the obvious action. -->
+  <button
+    v-if="showCheque"
+    type="button"
+    class="h-11 rounded-xl border border-hairline bg-white text-sm font-medium text-ink/70 transition active:bg-paper"
+    @click="$emit('cheque')"
+  >
+    {{ selectedCount ? `Cheque for ${selectedCount} — ${formatKES(selectedTotal)}` : 'Collect a cheque' }}
+  </button>
 </template>

--- a/frontend/src/components/InvoiceCard.vue
+++ b/frontend/src/components/InvoiceCard.vue
@@ -11,7 +11,7 @@ const props = defineProps({
   actionsDisabled: Boolean,
   mpesaMax: { type: Number, default: 0 }, // M-Pesa ceiling; 0 = no cap
 })
-defineEmits(['prompt', 'toggle-select', 'notes'])
+defineEmits(['prompt', 'toggle-select', 'notes', 'cheque'])
 
 const checkoutBusy = ref(false)
 
@@ -114,30 +114,53 @@ async function payViaIpay() {
       </span>
     </button>
 
-    <div class="mt-2 flex gap-2">
-      <button
-        v-if="!mpesaBlocked"
-        type="button"
-        class="h-12 flex-1 rounded-xl bg-mpesa font-semibold text-white transition active:scale-[.98] disabled:opacity-40"
-        :disabled="actionsDisabled"
-        @click="$emit('prompt')"
-      >
-        Prompt M-Pesa
-      </button>
-      <button
-        v-if="enableRedirect"
-        type="button"
-        class="h-12 flex-1 rounded-xl border border-hairline px-4 font-medium text-ink transition active:scale-[.98] disabled:opacity-40"
-        :disabled="actionsDisabled || checkoutBusy"
-        :aria-busy="checkoutBusy"
-        @click="payViaIpay"
-      >
-        {{ checkoutBusy ? 'Opening…' : 'Card / other' }}
-      </button>
-    </div>
-    <p v-if="mpesaBlocked" class="mt-2 text-xs text-owed">
-      M-Pesa isn't available over {{ formatKES(mpesaMax) }}.
-      {{ enableRedirect ? 'Use Card / other.' : 'Card checkout is off — contact the internal team.' }}
+    <!-- A cheque is recorded but not yet banked, so the invoice is still open. Charging it again
+         would take the money twice — the actions go away entirely until accounts clear it. -->
+    <p
+      v-if="invoice.awaiting_cheque"
+      class="mt-2 flex items-center gap-2 rounded-xl bg-ink/5 px-3 py-2.5 text-[13px] font-medium text-ink/75"
+    >
+      <svg viewBox="0 0 20 20" class="h-4 w-4 shrink-0" fill="none" stroke="currentColor" stroke-width="1.7">
+        <rect x="2.5" y="5" width="15" height="10" rx="1.5" />
+        <path d="M2.5 9h15" />
+      </svg>
+      Awaiting cheque — with accounts to bank.
     </p>
+
+    <template v-else>
+      <div class="mt-2 flex gap-2">
+        <button
+          v-if="!mpesaBlocked"
+          type="button"
+          class="h-12 flex-1 rounded-xl bg-mpesa font-semibold text-white transition active:scale-[.98] disabled:opacity-40"
+          :disabled="actionsDisabled"
+          @click="$emit('prompt')"
+        >
+          Prompt M-Pesa
+        </button>
+        <button
+          v-if="enableRedirect"
+          type="button"
+          class="h-12 flex-1 rounded-xl border border-hairline px-4 font-medium text-ink transition active:scale-[.98] disabled:opacity-40"
+          :disabled="actionsDisabled || checkoutBusy"
+          :aria-busy="checkoutBusy"
+          @click="payViaIpay"
+        >
+          {{ checkoutBusy ? 'Opening…' : 'Card / other' }}
+        </button>
+        <button
+          type="button"
+          class="h-12 shrink-0 rounded-xl border border-hairline px-4 text-sm font-medium text-ink/70 transition active:scale-[.98] disabled:opacity-40"
+          :disabled="actionsDisabled"
+          @click="$emit('cheque')"
+        >
+          Cheque
+        </button>
+      </div>
+      <p v-if="mpesaBlocked" class="mt-2 text-xs text-owed">
+        M-Pesa isn't available over {{ formatKES(mpesaMax) }}.
+        {{ enableRedirect ? 'Use Card / other.' : 'Card checkout is off — contact the internal team.' }}
+      </p>
+    </template>
   </article>
 </template>

--- a/frontend/src/components/InvoiceCard.vue
+++ b/frontend/src/components/InvoiceCard.vue
@@ -20,6 +20,12 @@ const mpesaBlocked = computed(
   () => props.mpesaMax > 0 && Number(props.invoice.outstanding_amount || 0) > props.mpesaMax,
 )
 
+// A cheque can cover part of an invoice. Prompting is still suppressed — charging the whole
+// balance would take the cheque's share twice — so the shortfall is named instead of hidden.
+const chequeIsPartial = computed(
+  () => Number(props.invoice.awaiting_cheque || 0) < Number(props.invoice.outstanding_amount || 0),
+)
+
 // The row truncates the note visually; a screen reader gets the count and the note itself.
 const noteLabel = computed(() => {
   const count = props.invoice.note_count || 0
@@ -124,7 +130,13 @@ async function payViaIpay() {
         <rect x="2.5" y="5" width="15" height="10" rx="1.5" />
         <path d="M2.5 9h15" />
       </svg>
-      Awaiting cheque — with accounts to bank.
+      <span>
+        Cheque for {{ formatKES(invoice.awaiting_cheque) }} with accounts to bank.
+        <template v-if="chequeIsPartial">
+          {{ formatKES(Number(invoice.outstanding_amount) - invoice.awaiting_cheque) }} of this
+          invoice is still owed — collect it with the rest of the round.
+        </template>
+      </span>
     </p>
 
     <template v-else>

--- a/frontend/src/data/collection.js
+++ b/frontend/src/data/collection.js
@@ -20,6 +20,7 @@ const API = {
   saveContact: 'ipay.ipay.main.utils.ipay_redirect.save_customer_contact',
   invoiceNotes: 'ipay.ipay.main.utils.ipay_redirect.invoice_notes',
   addInvoiceNote: 'ipay.ipay.main.utils.ipay_redirect.add_invoice_note',
+  recordCheque: 'ipay.ipay.main.utils.ipay_redirect.record_cheque',
   paymentState: 'ipay.ipay.main.utils.ipay_redirect.payment_state',
   createBundle: 'ipay.ipay.main.utils.ipay_redirect.create_bundle',
   requestDetail: 'ipay.ipay.main.utils.ipay_redirect.request_detail',
@@ -109,6 +110,17 @@ export const saveCustomerContact = (request, phone) =>
 // Collection notes on an invoice — plain text; the server escapes on write and unescapes here.
 export const fetchInvoiceNotes = (invoice) => call(API.invoiceNotes, { invoice }, 'GET')
 export const addInvoiceNote = (invoice, note) => call(API.addInvoiceNote, { invoice, note })
+
+// A collected cheque becomes a DRAFT Payment Entry for the accounts team to submit. No invoices
+// records it on account. `photo` is a downscaled data URL; the server attaches it to the entry.
+export const recordCheque = ({ customer, amount, chequeNo, photo, invoices = [] }) =>
+  call(API.recordCheque, {
+    customer,
+    amount,
+    cheque_no: chequeNo,
+    photo,
+    invoices: JSON.stringify(invoices),
+  })
 
 export const paymentState = (request) => call(API.paymentState, { request }, 'GET')
 

--- a/frontend/src/pages/CustomerDetail.vue
+++ b/frontend/src/pages/CustomerDetail.vue
@@ -2,11 +2,13 @@
 import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { createBundle, fetchCustomerCollection } from '@/data/collection'
+import { formatKES } from '@/utils/format'
 import { useResumeRefresh } from '@/composables/useResumeRefresh'
 import { useInvoiceSelection } from '@/composables/useInvoiceSelection'
 import InvoiceCard from '@/components/InvoiceCard.vue'
 import PromptDialog from '@/components/PromptDialog.vue'
 import NotesDialog from '@/components/NotesDialog.vue'
+import ChequeDialog from '@/components/ChequeDialog.vue'
 import CustomerMoneyHeader from '@/components/CustomerMoneyHeader.vue'
 import CollectBar from '@/components/CollectBar.vue'
 import ErrorRetry from '@/components/ErrorRetry.vue'
@@ -18,6 +20,7 @@ const driver = route.query.driver || '' // scope the detail to the driver picked
 
 const customerName = ref('')
 const invoices = ref([])
+const chequeOnAccount = ref(0)
 const enableRedirect = ref(false)
 const canBundle = ref(false)
 const mpesaMax = ref(0)
@@ -27,6 +30,7 @@ const creatingBundle = ref(false)
 const collectError = ref(false)
 const prompting = ref(null)
 const noting = ref(null)
+const chequing = ref(null)
 
 const { selected, isSelected, toggleSelect, clearSelection, dropSelected, selectedTotal } =
   useInvoiceSelection()
@@ -65,6 +69,7 @@ async function load() {
     enableRedirect.value = Boolean(data.enable_redirect)
     canBundle.value = Boolean(data.can_bundle)
     mpesaMax.value = data.mpesa_max || 0
+    chequeOnAccount.value = Number(data.cheque_on_account || 0)
   } catch {
     loadError.value = true
   } finally {
@@ -117,6 +122,20 @@ function onPaid(name) {
   if (!invoices.value.length) toList()
 }
 
+// A cheque covers the ticked invoices; nothing ticked records it against the customer instead.
+function chequeFor(names, outstanding) {
+  chequing.value = { customer, customer_name: customerName.value, invoices: names, outstanding }
+}
+
+// Mark the cards in place rather than reloading, which would clear the ticked set underneath.
+function onChequeRecorded({ invoices: names, amount }) {
+  if (!names.length) chequeOnAccount.value += amount
+  invoices.value.forEach((inv) => {
+    if (names.includes(inv.name)) inv.awaiting_cheque = true
+  })
+  clearSelection()
+}
+
 // Patch the card in place: reloading the list would clear a ticked bundle and reset paging.
 function onNoteSaved({ invoice, count, latest }) {
   const inv = invoices.value.find((i) => i.name === invoice)
@@ -155,9 +174,16 @@ onMounted(load)
         :mpesa-max="mpesaMax"
         :collect-error="collectError"
         :show-tick-hint="selectable && !selected.length"
+        :show-cheque="invoices.length > 0"
         @collect="collectNow"
         @clear="clearSelection"
+        @cheque="chequeFor(selected.map((i) => i.name), selected.length ? selectedTotal : total)"
       />
+
+      <p v-if="chequeOnAccount" class="-mt-2 rounded-xl bg-ink/5 px-3 py-2.5 text-[13px] text-ink/75">
+        {{ formatKES(chequeOnAccount) }} already collected by cheque, with accounts to bank. It is
+        not tied to an invoice, so check before collecting again.
+      </p>
 
       <input
         v-if="invoices.length > 1"
@@ -186,6 +212,7 @@ onMounted(load)
           :actions-disabled="selected.length > 0"
           @prompt="promptInvoice(inv)"
           @notes="noting = { invoice: inv.name, customer_name: inv.customer_name }"
+          @cheque="chequeFor([inv.name], Number(inv.outstanding_amount || 0))"
           @toggle-select="toggleSelect(inv)"
         />
       </div>
@@ -193,5 +220,6 @@ onMounted(load)
 
     <PromptDialog :target="prompting" @close="prompting = null" @paid="onPaid" @changed="load" />
     <NotesDialog :target="noting" @close="noting = null" @saved="onNoteSaved" />
+    <ChequeDialog :target="chequing" @close="chequing = null" @recorded="onChequeRecorded" />
   </main>
 </template>

--- a/frontend/src/pages/PagedCustomerDetail.vue
+++ b/frontend/src/pages/PagedCustomerDetail.vue
@@ -6,11 +6,13 @@ import {
   fetchInternalCustomerInvoices,
   fetchSalesCustomerInvoices,
 } from '@/data/collection'
+import { formatKES } from '@/utils/format'
 import { useResumeRefresh } from '@/composables/useResumeRefresh'
 import { useInvoiceSelection } from '@/composables/useInvoiceSelection'
 import InvoiceCard from '@/components/InvoiceCard.vue'
 import PromptDialog from '@/components/PromptDialog.vue'
 import NotesDialog from '@/components/NotesDialog.vue'
+import ChequeDialog from '@/components/ChequeDialog.vue'
 import CustomerMoneyHeader from '@/components/CustomerMoneyHeader.vue'
 import CollectBar from '@/components/CollectBar.vue'
 import ErrorRetry from '@/components/ErrorRetry.vue'
@@ -49,6 +51,7 @@ const scopeQuery = () =>
 const customerName = ref('')
 const invoices = ref([])
 const total = ref(0)
+const chequeOnAccount = ref(0)
 const count = ref(0)
 const hasMore = ref(false)
 const enableRedirect = ref(false)
@@ -61,6 +64,7 @@ const creatingBundle = ref(false)
 const collectError = ref(false)
 const prompting = ref(null)
 const noting = ref(null)
+const chequing = ref(null)
 
 const search = ref('')
 let searchTimer = null
@@ -104,6 +108,7 @@ async function load(reset = true) {
     count.value = data.invoice_count
     enableRedirect.value = Boolean(data.enable_redirect)
     mpesaMax.value = data.mpesa_max || 0
+    chequeOnAccount.value = Number(data.cheque_on_account || 0)
     invoices.value = reset ? data.invoices || [] : [...invoices.value, ...(data.invoices || [])]
     hasMore.value = Boolean(data.has_more)
   } catch {
@@ -177,6 +182,20 @@ function onPaid(name) {
   else if (!invoices.value.length) load(true)
 }
 
+// A cheque covers the ticked invoices; nothing ticked records it against the customer instead.
+function chequeFor(names, outstanding) {
+  chequing.value = { customer, customer_name: customerName.value, invoices: names, outstanding }
+}
+
+// Mark the cards in place rather than reloading, which would clear the ticked set underneath.
+function onChequeRecorded({ invoices: names, amount }) {
+  if (!names.length) chequeOnAccount.value += amount
+  invoices.value.forEach((inv) => {
+    if (names.includes(inv.name)) inv.awaiting_cheque = true
+  })
+  clearSelection()
+}
+
 // Patch the card in place: reloading the list would clear a ticked bundle and reset paging.
 function onNoteSaved({ invoice, count, latest }) {
   const inv = invoices.value.find((i) => i.name === invoice)
@@ -220,9 +239,16 @@ onMounted(() => load(true))
         :mpesa-max="mpesaMax"
         :collect-error="collectError"
         :show-tick-hint="selectable && !selected.length"
+        :show-cheque="count > 0"
         @collect="collectNow"
         @clear="clearSelection"
+        @cheque="chequeFor(selected.map((i) => i.name), selected.length ? selectedTotal : total)"
       />
+
+      <p v-if="chequeOnAccount" class="-mt-2 rounded-xl bg-ink/5 px-3 py-2.5 text-[13px] text-ink/75">
+        {{ formatKES(chequeOnAccount) }} already collected by cheque, with accounts to bank. It is
+        not tied to an invoice, so check before collecting again.
+      </p>
 
       <input
         v-model="search"
@@ -252,6 +278,7 @@ onMounted(() => load(true))
             :actions-disabled="selected.length > 0"
             @prompt="promptInvoice(inv)"
             @notes="noting = { invoice: inv.name, customer_name: inv.customer_name }"
+            @cheque="chequeFor([inv.name], Number(inv.outstanding_amount || 0))"
             @toggle-select="toggleSelect(inv)"
           />
         </div>
@@ -269,6 +296,7 @@ onMounted(() => load(true))
 
       <PromptDialog :target="prompting" @close="prompting = null" @paid="onPaid" @changed="load(true)" />
       <NotesDialog :target="noting" @close="noting = null" @saved="onNoteSaved" />
+      <ChequeDialog :target="chequing" @close="chequing = null" @recorded="onChequeRecorded" />
     </template>
   </main>
 </template>

--- a/ipay/ipay/main/utils/constants.py
+++ b/ipay/ipay/main/utils/constants.py
@@ -32,6 +32,11 @@ ACTIVE_BUNDLE_WINDOW_MIN = 30
 COLLECTION_NOTE_SUBJECT = "iPay Collection Note"
 COLLECTION_NOTE_MAX_LENGTH = 500
 
+# The Mode of Payment a collected cheque is recorded under — what marks a draft Payment Entry as
+# "a cheque a collector took", both when writing one and when flagging the invoices it covers.
+CHEQUE_MODE = "Cheque"
+CHEQUE_NO_MAX_LENGTH = 30
+
 
 def note_filters(reference_name):
     """Comment filters for the collection notes on one invoice, or on a list of them."""

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -314,9 +314,9 @@ def _annotate_awaiting_cheque(invoices):
     rows = frappe.get_all(
         "Payment Entry Reference",
         filters={"reference_doctype": "Sales Invoice", "reference_name": ["in", names], "docstatus": 0},
-        fields=["parent", "reference_name"],
+        fields=["parent", "reference_name", "allocated_amount"],
     )
-    drafts = set()
+    covered = {}
     if rows:
         cheques = set(
             frappe.get_all(
@@ -329,9 +329,13 @@ def _annotate_awaiting_cheque(invoices):
                 pluck="name",
             )
         )
-        drafts = {r.reference_name for r in rows if r.parent in cheques}
+        for row in rows:
+            if row.parent in cheques:
+                covered[row.reference_name] = covered.get(row.reference_name, 0) + flt(row.allocated_amount)
+    # The amount rides along: a cheque may cover only part of the invoice, and "awaiting" without
+    # a figure would read as though the whole balance were settled.
     for inv in invoices:
-        inv.awaiting_cheque = inv.name in drafts
+        inv.awaiting_cheque = flt(covered.get(inv.name, 0))
 
 
 def _cheque_on_account(customer):

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -3,7 +3,12 @@ from frappe.utils import add_to_date, cint, flt, now_datetime, today
 
 from ipay.ipay.main.utils.prepaid import all_prepaid_invoice_names, prepaid_invoice_names
 from ipay.ipay.main.utils.collector import OPERATOR_ROLES, collector_scope, is_collector_only
-from ipay.ipay.main.utils.constants import ACTIVE_BUNDLE_WINDOW_MIN, note_filters, note_text
+from ipay.ipay.main.utils.constants import (
+    ACTIVE_BUNDLE_WINDOW_MIN,
+    CHEQUE_MODE,
+    note_filters,
+    note_text,
+)
 from ipay.ipay.main.utils.sales import (
     SALES_MANAGER_ROLES,
     SALES_ROLE,
@@ -227,6 +232,7 @@ def _customer_invoices(user, customer, driver=None):
     _annotate_customer_phone(invoices)
     _annotate_sales_person(invoices)
     _annotate_notes(invoices)
+    _annotate_awaiting_cheque(invoices)
     return invoices
 
 
@@ -296,6 +302,54 @@ def _annotate_notes(invoices):
     for inv in invoices:
         inv.note_count = counts.get(inv.name, 0)
         inv.note_latest = note_text(latest.get(inv.name) or "")
+
+
+def _annotate_awaiting_cheque(invoices):
+    """Flag invoices a collected cheque already covers, batched. A cheque sits as a DRAFT Payment
+    Entry until accounts submit it, and a draft does not reduce outstanding — so without this the
+    invoice still looks unpaid and would be charged a second time."""
+    names = [inv.name for inv in invoices]
+    if not names:
+        return
+    rows = frappe.get_all(
+        "Payment Entry Reference",
+        filters={"reference_doctype": "Sales Invoice", "reference_name": ["in", names], "docstatus": 0},
+        fields=["parent", "reference_name"],
+    )
+    drafts = set()
+    if rows:
+        cheques = set(
+            frappe.get_all(
+                "Payment Entry",
+                filters={
+                    "name": ["in", list({r.parent for r in rows})],
+                    "docstatus": 0,
+                    "mode_of_payment": CHEQUE_MODE,
+                },
+                pluck="name",
+            )
+        )
+        drafts = {r.reference_name for r in rows if r.parent in cheques}
+    for inv in invoices:
+        inv.awaiting_cheque = inv.name in drafts
+
+
+def _cheque_on_account(customer):
+    """What a customer has handed over in cheques that name no invoice. Nothing marks those
+    invoices, so this is the only thing standing between an on-account cheque and collecting
+    the same money twice."""
+    amounts = frappe.get_all(
+        "Payment Entry",
+        filters={
+            "party_type": "Customer",
+            "party": customer,
+            "docstatus": 0,
+            "mode_of_payment": CHEQUE_MODE,
+            "total_allocated_amount": 0,
+        },
+        pluck="unallocated_amount",
+    )
+    return flt(sum(amounts))
 
 
 def get_context(context):
@@ -437,6 +491,7 @@ def customer_collection(customer, driver=None):
         "customer": customer,
         "customer_name": invoices[0].customer_name if invoices else customer,
         "invoices": invoices,
+        "cheque_on_account": _cheque_on_account(customer),
         **_settings_flags(),
         "can_bundle": not is_collector_only(frappe.session.user),
     }
@@ -520,9 +575,11 @@ def _drill_down(invoices, customer, start, page_length, search):
     _annotate_customer_phone(page)
     _annotate_sales_person(page)
     _annotate_notes(page)
+    _annotate_awaiting_cheque(page)
     return {
         "customer": customer,
         "customer_name": frappe.db.get_value("Customer", customer, "customer_name") or customer,
+        "cheque_on_account": _cheque_on_account(customer),
         "invoices": page,
         "invoice_count": count,
         "total_outstanding": total,


### PR DESCRIPTION
Phases 2 and 3 of cheque collection — the capture journey plus the awaiting-cheque marker, which ship together because the marker is what makes the feature safe. Branched off `main` at d2e8ea1 (with #84's `BaseDialog`).

## ⚠️ Merge #85 first

This calls `record_cheque`, which lives in #85. Merged before it, the buttons would call a method that does not exist. The two touch different files, so there is no conflict — only an order.

## What a collector sees

- **On an invoice card**, next to Prompt M-Pesa: a quiet `Cheque` button.
- **On the collect bar**: `Cheque for 3 — KES X` when invoices are ticked, `Collect a cheque` when not (recorded on account).
- **The dialog**: photograph → amount → number → **confirm** → done. Nothing is `bg-mpesa`; green is the M-Pesa rail and a cheque moves no money yet. The success screen says plainly that accounts still have to bank it.

## A finding that changed the design

The plan assumed drivers would tick invoices and cheque the ticked set. **They can't** — `can_bundle = not is_collector_only(user)`, and both the tick UI and the whole collect bar are gated on it. A driver would have been left with only on-account cheques, which name no invoice and so leave it promptable — the exact double-collection the marker exists to prevent.

So cheque mirrors the **existing prompt structure** instead: per-invoice on the card, per-set on the bar. A driver records against the invoice in hand and the marker protects it; whoever can tick still gets "tick several, one cheque".

## Why the marker is not decoration

A cheque is a **draft** Payment Entry until accounts submit it, and a draft **does not reduce outstanding** (verified: 2073.0 → 2073.0). Without a marker the invoice keeps looking unpaid and the next round charges it again — taking the money twice. So covered invoices lose their prompt buttons, and the on-account case carries a customer-level notice, since nothing else marks it.

**A cheque can also cover only part of an invoice.** Prompting stays suppressed (charging the balance would take the cheque's share twice), but a bare "awaiting cheque" would read as settled — so the card names the amount and the shortfall: *"Cheque for KES 700 with accounts to bank. KES 95,013 of this invoice is still owed."*

## Verified on dev

Marker unit cases: a draft cheque flags its invoice; another invoice is not flagged; a **draft M-Pesa** entry does not flag it (mode check); an invoice-tied cheque does not leak into the on-account total; an empty page issues no query.

End-to-end on a throwaway branch carrying both PRs, driven as a real collector through their own list → customer → invoice: cheque recorded → draft PE owned by the collector, booked to `Undeposited Cheque - TSL`, photo attached and private → the card comes back `awaiting_cheque` with the amount, other invoices untouched, the invoice still outstanding → an on-account cheque drives `cheque_on_account`. The 20 mock tests still pass, and the frontend builds clean.

**Not automatically tested:** the dialog's runtime behaviour (camera capture, canvas downscale, focus) — the repo has no frontend test tooling, so a click-through on a real phone is worth doing before this goes out.

## Small follow-up after both merge

`CHEQUE_MODE` is defined in `constants.py` here and in `ipay_redirect.py` in #85 — neither branch can see the other's, since both are off main. Once #85 lands I will rebase this and drop the duplicate so the constant has one home.