### PR TITLE
refactor(ipay): one home for the cheque constants

### DIFF
--- a/frontend/src/components/BaseDialog.vue
+++ b/frontend/src/components/BaseDialog.vue
@@ -1,0 +1,76 @@
+<script setup>
+import { nextTick, onUnmounted, ref, watch } from 'vue'
+
+// The app's modal shell: backdrop, panel, Escape and a Tab trap. Every dialog is built on this
+// so the trap exists once — it was copied by hand before and the copies drifted apart.
+const props = defineProps({
+  open: Boolean,
+  labelledby: { type: String, required: true },
+  // Where focus lands on open. 'panel' leaves a phone at the top of the content rather than
+  // scrolling to the first field.
+  focus: { type: String, default: 'input' },
+})
+const emit = defineEmits(['close'])
+
+const panel = ref(null)
+
+// Escape and the backdrop both just report intent; the caller decides what closing means.
+function onKeydown(e) {
+  if (e.key === 'Escape') return emit('close')
+  if (e.key !== 'Tab') return
+  // The panel leads the list: it holds focus on open, and querySelectorAll sees only its
+  // descendants — without it Shift+Tab lands on the page behind.
+  const items = [
+    panel.value,
+    ...Array.from(
+      panel.value?.querySelectorAll(
+        'textarea, input, select, button, [href], [tabindex]:not([tabindex="-1"])',
+      ) || [],
+    ),
+  ].filter((el) => el && !el.disabled)
+  if (!items.length) return
+  const first = items[0]
+  const last = items[items.length - 1]
+  if (e.shiftKey && document.activeElement === first) {
+    e.preventDefault()
+    last.focus()
+  } else if (!e.shiftKey && document.activeElement === last) {
+    e.preventDefault()
+    first.focus()
+  }
+}
+
+watch(
+  () => props.open,
+  (open) => {
+    window[open ? 'addEventListener' : 'removeEventListener']('keydown', onKeydown)
+    if (open)
+      nextTick(() =>
+        (props.focus === 'input' ? panel.value?.querySelector('input') : panel.value)?.focus(),
+      )
+  },
+)
+
+onUnmounted(() => window.removeEventListener('keydown', onKeydown))
+
+defineExpose({ panel })
+</script>
+
+<template>
+  <div
+    v-if="open"
+    class="fixed inset-0 z-50 flex items-end justify-center bg-ink/50 p-4 sm:items-center"
+    @click.self="$emit('close')"
+  >
+    <div
+      ref="panel"
+      role="dialog"
+      aria-modal="true"
+      :aria-labelledby="labelledby"
+      tabindex="-1"
+      class="w-full max-w-md rounded-3xl bg-paper p-6 focus:outline-none"
+    >
+      <slot />
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/ChequeDialog.vue
+++ b/frontend/src/components/ChequeDialog.vue
@@ -1,0 +1,231 @@
+<script setup>
+import { computed, ref, watch } from 'vue'
+import { recordCheque } from '@/data/collection'
+import { formatKES } from '@/utils/format'
+import BaseDialog from '@/components/BaseDialog.vue'
+
+const MAX_DIMENSION = 1600 // a phone photo is 3-8 MB; the cheque only has to be readable
+const JPEG_QUALITY = 0.8
+const NUMBER_MAX = 30
+
+// `target` is { customer, customer_name, invoices, outstanding } or null. An empty `invoices`
+// records the cheque on account, against no invoice.
+const props = defineProps({ target: { type: Object, default: null } })
+const emit = defineEmits(['close', 'recorded'])
+
+const photo = ref('') // downscaled data URL, exactly what the server stores
+const amount = ref('')
+const number = ref('')
+const reviewing = ref(false)
+const saving = ref(false)
+const done = ref(false)
+const error = ref('')
+
+const invoiceCount = computed(() => props.target?.invoices?.length || 0)
+const covers = computed(() =>
+  invoiceCount.value
+    ? `${invoiceCount.value} invoice${invoiceCount.value === 1 ? '' : 's'}`
+    : 'On account',
+)
+const amountValue = computed(() => Number(amount.value) || 0)
+const canReview = computed(() => Boolean(photo.value) && amountValue.value > 0 && Boolean(number.value.trim()))
+
+// Shrink in the browser: a full-size photo would blow the upload cap and a slow line.
+function downscale(file) {
+  return new Promise((resolve, reject) => {
+    const image = new Image()
+    image.onerror = () => reject(new Error('unreadable'))
+    image.onload = () => {
+      const scale = Math.min(1, MAX_DIMENSION / Math.max(image.width, image.height))
+      const canvas = document.createElement('canvas')
+      canvas.width = Math.round(image.width * scale)
+      canvas.height = Math.round(image.height * scale)
+      canvas.getContext('2d').drawImage(image, 0, 0, canvas.width, canvas.height)
+      resolve(canvas.toDataURL('image/jpeg', JPEG_QUALITY))
+      URL.revokeObjectURL(image.src)
+    }
+    image.src = URL.createObjectURL(file)
+  })
+}
+
+async function onPick(event) {
+  const file = event.target.files?.[0]
+  if (!file) return
+  error.value = ''
+  try {
+    photo.value = await downscale(file)
+  } catch {
+    error.value = "That photo couldn't be read. Try again."
+  }
+}
+
+async function save() {
+  if (saving.value) return
+  saving.value = true
+  error.value = ''
+  try {
+    await recordCheque({
+      customer: props.target.customer,
+      amount: amountValue.value,
+      chequeNo: number.value.trim(),
+      photo: photo.value,
+      invoices: props.target.invoices || [],
+    })
+    done.value = true
+    emit('recorded', { invoices: props.target.invoices || [], amount: amountValue.value })
+  } catch (e) {
+    error.value = e?.messages?.[0] || "Couldn't record the cheque."
+    reviewing.value = false // back to the form, with everything they typed still there
+  } finally {
+    saving.value = false
+  }
+}
+
+watch(
+  () => props.target,
+  () => {
+    photo.value = ''
+    amount.value = ''
+    number.value = ''
+    reviewing.value = false
+    saving.value = false
+    done.value = false
+    error.value = ''
+  },
+)
+</script>
+
+<template>
+  <BaseDialog
+    :open="Boolean(target)"
+    labelledby="cheque-title"
+    focus="panel"
+    @close="$emit('close')"
+  >
+    <h2 id="cheque-title" class="font-display text-lg font-bold text-ink">
+      {{ done ? 'Cheque recorded' : reviewing ? 'Check this is right' : 'Collect a cheque' }}
+    </h2>
+    <p class="mt-0.5 truncate text-sm text-ink/60">{{ target?.customer_name }} · {{ covers }}</p>
+
+    <!-- Recorded: say plainly that no money has moved yet, so nobody treats it as paid. -->
+    <template v-if="done">
+      <p class="mt-4 rounded-xl bg-paper p-4 text-sm text-ink/80">
+        {{ formatKES(amountValue) }} — cheque {{ number }}. Accounts will bank it and confirm the
+        payment. The invoice stays open until it clears.
+      </p>
+      <button
+        type="button"
+        class="mt-4 h-12 w-full rounded-xl bg-ink font-semibold text-white"
+        @click="$emit('close')"
+      >
+        Done
+      </button>
+    </template>
+
+    <template v-else-if="reviewing">
+      <img :src="photo" alt="The cheque photo" class="mt-4 max-h-40 w-full rounded-xl object-contain" />
+      <dl class="mt-3 divide-y divide-hairline rounded-xl bg-paper px-3">
+        <div class="flex justify-between gap-3 py-2.5">
+          <dt class="text-sm text-ink/60">Amount</dt>
+          <dd class="font-mono text-base font-semibold tabular-nums text-ink">
+            {{ formatKES(amountValue) }}
+          </dd>
+        </div>
+        <div class="flex justify-between gap-3 py-2.5">
+          <dt class="text-sm text-ink/60">Cheque number</dt>
+          <dd class="font-mono text-sm font-semibold text-ink">{{ number }}</dd>
+        </div>
+        <div class="flex justify-between gap-3 py-2.5">
+          <dt class="text-sm text-ink/60">Covers</dt>
+          <dd class="text-sm font-medium text-ink">{{ covers }}</dd>
+        </div>
+      </dl>
+      <p v-if="error" class="mt-2 text-sm text-danger">{{ error }}</p>
+      <div class="mt-4 flex gap-2">
+        <button
+          type="button"
+          class="h-12 shrink-0 rounded-xl border border-hairline px-5 font-medium text-ink"
+          :disabled="saving"
+          @click="reviewing = false"
+        >
+          Back
+        </button>
+        <!-- Never bg-mpesa: green is the M-Pesa rail, and no money moves here. -->
+        <button
+          type="button"
+          class="h-12 flex-1 rounded-xl bg-ink font-semibold text-white disabled:opacity-40"
+          :disabled="saving"
+          :aria-busy="saving"
+          @click="save"
+        >
+          {{ saving ? 'Recording…' : 'Record cheque' }}
+        </button>
+      </div>
+    </template>
+
+    <template v-else>
+      <label
+        class="mt-4 grid h-32 w-full cursor-pointer place-items-center overflow-hidden rounded-xl border border-dashed border-hairline bg-paper text-sm font-medium text-ink/60"
+      >
+        <img v-if="photo" :src="photo" alt="The cheque photo" class="h-full w-full object-contain" />
+        <span v-else class="flex flex-col items-center gap-1">
+          <svg viewBox="0 0 24 24" class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="1.6">
+            <path d="M3 8.5h4L8.5 6h7L17 8.5h4v10H3z" stroke-linejoin="round" />
+            <circle cx="12" cy="13" r="3.2" />
+          </svg>
+          Photograph the cheque
+        </span>
+        <input type="file" accept="image/*" capture="environment" class="sr-only" @change="onPick" />
+      </label>
+
+      <label class="mt-3 block text-xs font-semibold text-ink/60" for="cheque-amount">
+        Amount on the cheque
+      </label>
+      <input
+        id="cheque-amount"
+        v-model="amount"
+        type="number"
+        inputmode="decimal"
+        min="0"
+        placeholder="0"
+        class="mt-1 h-12 w-full rounded-xl border border-hairline bg-white px-3 font-mono text-base tabular-nums text-ink focus:border-ink focus:outline-none focus:ring-2 focus:ring-ink/20"
+      />
+      <p v-if="target?.outstanding" class="mt-1 text-xs text-ink/50">
+        Outstanding {{ formatKES(target.outstanding) }} — enter what the cheque says.
+      </p>
+
+      <label class="mt-3 block text-xs font-semibold text-ink/60" for="cheque-number">
+        Cheque number
+      </label>
+      <input
+        id="cheque-number"
+        v-model="number"
+        type="text"
+        inputmode="numeric"
+        :maxlength="NUMBER_MAX"
+        placeholder="001894"
+        class="mt-1 h-12 w-full rounded-xl border border-hairline bg-white px-3 font-mono text-base text-ink focus:border-ink focus:outline-none focus:ring-2 focus:ring-ink/20"
+      />
+
+      <p v-if="error" class="mt-2 text-sm text-danger">{{ error }}</p>
+
+      <div class="mt-4 flex gap-2">
+        <button
+          type="button"
+          class="h-12 shrink-0 rounded-xl border border-hairline px-5 font-medium text-ink"
+          @click="$emit('close')"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          class="h-12 flex-1 rounded-xl bg-ink font-semibold text-white disabled:opacity-40"
+          :disabled="!canReview"
+          @click="reviewing = true"
+        >
+          Review
+        </button>
+      </div>
+    </template>
+  </BaseDialog>
+</template>

--- a/frontend/src/components/CollectBar.vue
+++ b/frontend/src/components/CollectBar.vue
@@ -14,8 +14,9 @@ defineProps({
   mpesaMax: { type: Number, default: 0 },
   collectError: Boolean,
   showTickHint: Boolean,
+  showCheque: Boolean, // cheque collection is offered even where bundling is not
 })
-defineEmits(['collect', 'clear'])
+defineEmits(['collect', 'clear', 'cheque'])
 </script>
 
 <template>
@@ -53,4 +54,13 @@ defineEmits(['collect', 'clear'])
   <p v-if="showTickHint" class="-mt-2 px-1 text-xs text-ink/60">
     Tick invoices to collect only some.
   </p>
+  <!-- Deliberately quiet: cheques are the exception, and M-Pesa stays the obvious action. -->
+  <button
+    v-if="showCheque"
+    type="button"
+    class="h-11 rounded-xl border border-hairline bg-white text-sm font-medium text-ink/70 transition active:bg-paper"
+    @click="$emit('cheque')"
+  >
+    {{ selectedCount ? `Cheque for ${selectedCount} — ${formatKES(selectedTotal)}` : 'Collect a cheque' }}
+  </button>
 </template>

--- a/frontend/src/components/InvoiceCard.vue
+++ b/frontend/src/components/InvoiceCard.vue
@@ -11,7 +11,7 @@ const props = defineProps({
   actionsDisabled: Boolean,
   mpesaMax: { type: Number, default: 0 }, // M-Pesa ceiling; 0 = no cap
 })
-defineEmits(['prompt', 'toggle-select', 'notes'])
+defineEmits(['prompt', 'toggle-select', 'notes', 'cheque'])
 
 const checkoutBusy = ref(false)
 
@@ -114,30 +114,53 @@ async function payViaIpay() {
       </span>
     </button>
 
-    <div class="mt-2 flex gap-2">
-      <button
-        v-if="!mpesaBlocked"
-        type="button"
-        class="h-12 flex-1 rounded-xl bg-mpesa font-semibold text-white transition active:scale-[.98] disabled:opacity-40"
-        :disabled="actionsDisabled"
-        @click="$emit('prompt')"
-      >
-        Prompt M-Pesa
-      </button>
-      <button
-        v-if="enableRedirect"
-        type="button"
-        class="h-12 flex-1 rounded-xl border border-hairline px-4 font-medium text-ink transition active:scale-[.98] disabled:opacity-40"
-        :disabled="actionsDisabled || checkoutBusy"
-        :aria-busy="checkoutBusy"
-        @click="payViaIpay"
-      >
-        {{ checkoutBusy ? 'Opening…' : 'Card / other' }}
-      </button>
-    </div>
-    <p v-if="mpesaBlocked" class="mt-2 text-xs text-owed">
-      M-Pesa isn't available over {{ formatKES(mpesaMax) }}.
-      {{ enableRedirect ? 'Use Card / other.' : 'Card checkout is off — contact the internal team.' }}
+    <!-- A cheque is recorded but not yet banked, so the invoice is still open. Charging it again
+         would take the money twice — the actions go away entirely until accounts clear it. -->
+    <p
+      v-if="invoice.awaiting_cheque"
+      class="mt-2 flex items-center gap-2 rounded-xl bg-ink/5 px-3 py-2.5 text-[13px] font-medium text-ink/75"
+    >
+      <svg viewBox="0 0 20 20" class="h-4 w-4 shrink-0" fill="none" stroke="currentColor" stroke-width="1.7">
+        <rect x="2.5" y="5" width="15" height="10" rx="1.5" />
+        <path d="M2.5 9h15" />
+      </svg>
+      Awaiting cheque — with accounts to bank.
     </p>
+
+    <template v-else>
+      <div class="mt-2 flex gap-2">
+        <button
+          v-if="!mpesaBlocked"
+          type="button"
+          class="h-12 flex-1 rounded-xl bg-mpesa font-semibold text-white transition active:scale-[.98] disabled:opacity-40"
+          :disabled="actionsDisabled"
+          @click="$emit('prompt')"
+        >
+          Prompt M-Pesa
+        </button>
+        <button
+          v-if="enableRedirect"
+          type="button"
+          class="h-12 flex-1 rounded-xl border border-hairline px-4 font-medium text-ink transition active:scale-[.98] disabled:opacity-40"
+          :disabled="actionsDisabled || checkoutBusy"
+          :aria-busy="checkoutBusy"
+          @click="payViaIpay"
+        >
+          {{ checkoutBusy ? 'Opening…' : 'Card / other' }}
+        </button>
+        <button
+          type="button"
+          class="h-12 shrink-0 rounded-xl border border-hairline px-4 text-sm font-medium text-ink/70 transition active:scale-[.98] disabled:opacity-40"
+          :disabled="actionsDisabled"
+          @click="$emit('cheque')"
+        >
+          Cheque
+        </button>
+      </div>
+      <p v-if="mpesaBlocked" class="mt-2 text-xs text-owed">
+        M-Pesa isn't available over {{ formatKES(mpesaMax) }}.
+        {{ enableRedirect ? 'Use Card / other.' : 'Card checkout is off — contact the internal team.' }}
+      </p>
+    </template>
   </article>
 </template>

--- a/frontend/src/components/InvoiceCard.vue
+++ b/frontend/src/components/InvoiceCard.vue
@@ -20,6 +20,12 @@ const mpesaBlocked = computed(
   () => props.mpesaMax > 0 && Number(props.invoice.outstanding_amount || 0) > props.mpesaMax,
 )
 
+// A cheque can cover part of an invoice. Prompting is still suppressed — charging the whole
+// balance would take the cheque's share twice — so the shortfall is named instead of hidden.
+const chequeIsPartial = computed(
+  () => Number(props.invoice.awaiting_cheque || 0) < Number(props.invoice.outstanding_amount || 0),
+)
+
 // The row truncates the note visually; a screen reader gets the count and the note itself.
 const noteLabel = computed(() => {
   const count = props.invoice.note_count || 0
@@ -124,7 +130,13 @@ async function payViaIpay() {
         <rect x="2.5" y="5" width="15" height="10" rx="1.5" />
         <path d="M2.5 9h15" />
       </svg>
-      Awaiting cheque — with accounts to bank.
+      <span>
+        Cheque for {{ formatKES(invoice.awaiting_cheque) }} with accounts to bank.
+        <template v-if="chequeIsPartial">
+          {{ formatKES(Number(invoice.outstanding_amount) - invoice.awaiting_cheque) }} of this
+          invoice is still owed — collect it with the rest of the round.
+        </template>
+      </span>
     </p>
 
     <template v-else>

--- a/frontend/src/components/NotesDialog.vue
+++ b/frontend/src/components/NotesDialog.vue
@@ -1,16 +1,15 @@
 <script setup>
-import { computed, nextTick, onUnmounted, ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { addInvoiceNote, fetchInvoiceNotes } from '@/data/collection'
 import { formatDateTime } from '@/utils/format'
+import BaseDialog from '@/components/BaseDialog.vue'
 
 const MAX = 500
 
-// `target` is { invoice, customer_name } or null — mirrors PromptDialog's null-able prop, which
-// is what arms and disarms the keydown listener below.
+// `target` is { invoice, customer_name } or null — null closes the dialog.
 const props = defineProps({ target: { type: Object, default: null } })
 const emit = defineEmits(['close', 'saved'])
 
-const dialogRef = ref(null)
 const notes = ref([])
 const draft = ref('')
 const loading = ref(false)
@@ -55,114 +54,67 @@ async function save() {
   }
 }
 
-// Close on Escape and trap Tab within the dialog. `textarea` matters here — PromptDialog's
-// selector omits it because it has none.
-function onKeydown(e) {
-  if (e.key === 'Escape') return emit('close')
-  if (e.key !== 'Tab') return
-  // The dialog itself leads the list: it holds focus on open, and querySelectorAll would
-  // only see its descendants — so Shift+Tab would otherwise land on the page behind.
-  const items = [
-    dialogRef.value,
-    ...Array.from(
-      dialogRef.value?.querySelectorAll(
-        'textarea, input, button, [href], [tabindex]:not([tabindex="-1"])',
-      ) || [],
-    ),
-  ].filter((el) => el && !el.disabled)
-  if (!items.length) return
-  const first = items[0]
-  const last = items[items.length - 1]
-  if (e.shiftKey && document.activeElement === first) {
-    e.preventDefault()
-    last.focus()
-  } else if (!e.shiftKey && document.activeElement === last) {
-    e.preventDefault()
-    first.focus()
-  }
-}
-
 watch(
   () => props.target,
   (target) => {
     draft.value = ''
     error.value = ''
     notes.value = []
-    window[target ? 'addEventListener' : 'removeEventListener']('keydown', onKeydown)
-    if (target) {
-      load()
-      // Focus the dialog, not the composer: autofocusing the field would scroll a phone past
-      // the notes the operator opened this to read.
-      nextTick(() => dialogRef.value?.focus())
-    }
+    if (target) load()
   },
 )
-
-onUnmounted(() => window.removeEventListener('keydown', onKeydown))
 </script>
 
 <template>
-  <div
-    v-if="target"
-    class="fixed inset-0 z-50 flex items-end justify-center bg-ink/50 p-4 sm:items-center"
-    @click.self="$emit('close')"
-  >
-    <div
-      ref="dialogRef"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="notes-title"
-      tabindex="-1"
-      class="w-full max-w-md rounded-3xl bg-paper p-6 focus:outline-none"
-    >
-      <h2 id="notes-title" class="font-display text-lg font-bold text-ink">Notes</h2>
-      <p class="mt-0.5 truncate text-sm text-ink/60">
-        {{ target.customer_name }} · {{ target.invoice }}
-      </p>
+  <!-- focus="panel": the operator opened this to READ; don't scroll them past the notes. -->
+  <BaseDialog :open="Boolean(target)" labelledby="notes-title" focus="panel" @close="$emit('close')">
+    <h2 id="notes-title" class="font-display text-lg font-bold text-ink">Notes</h2>
+    <p class="mt-0.5 truncate text-sm text-ink/60">
+      {{ target.customer_name }} · {{ target.invoice }}
+    </p>
 
-      <p v-if="loading" class="py-6 text-center text-sm text-ink/50">Loading…</p>
-      <div v-else-if="notes.length" class="mt-4 flex max-h-56 flex-col gap-2 overflow-y-auto">
-        <div v-for="note in notes" :key="note.name" class="rounded-xl bg-white p-3">
-          <div class="flex justify-between gap-2 text-[11px] font-semibold text-ink/55">
-            <span class="truncate">{{ note.author }}</span>
-            <span class="shrink-0">{{ formatDateTime(note.creation) }}</span>
-          </div>
-          <p class="mt-0.5 whitespace-pre-wrap break-words text-sm text-ink">{{ note.content }}</p>
+    <p v-if="loading" class="py-6 text-center text-sm text-ink/50">Loading…</p>
+    <div v-else-if="notes.length" class="mt-4 flex max-h-56 flex-col gap-2 overflow-y-auto">
+      <div v-for="note in notes" :key="note.name" class="rounded-xl bg-white p-3">
+        <div class="flex justify-between gap-2 text-[11px] font-semibold text-ink/55">
+          <span class="truncate">{{ note.author }}</span>
+          <span class="shrink-0">{{ formatDateTime(note.creation) }}</span>
         </div>
-      </div>
-      <p v-else class="py-6 text-center text-sm text-ink/50">No notes yet.</p>
-
-      <textarea
-        v-model="draft"
-        rows="3"
-        :maxlength="MAX"
-        aria-label="Add a note"
-        placeholder="Add a note about collecting this invoice…"
-        class="mt-4 w-full rounded-xl border border-hairline bg-white px-3 py-2 text-sm text-ink placeholder:text-ink/50 focus:border-mpesa focus:outline-none focus:ring-2 focus:ring-mpesa/40"
-      />
-      <p v-if="error" class="mt-2 text-sm text-danger">{{ error }}</p>
-
-      <div class="mt-3 flex items-center justify-between gap-3">
-        <span class="font-mono text-[11px] tabular-nums text-ink/50">{{ draft.length }} / {{ MAX }}</span>
-        <div class="flex gap-2">
-          <button
-            type="button"
-            class="h-11 rounded-xl border border-hairline bg-white px-4 font-medium text-ink"
-            @click="$emit('close')"
-          >
-            Close
-          </button>
-          <button
-            type="button"
-            class="h-11 rounded-xl bg-mpesa px-5 font-semibold text-white disabled:opacity-40"
-            :disabled="!canSave"
-            :aria-busy="saving"
-            @click="save"
-          >
-            {{ saving ? 'Saving…' : 'Save note' }}
-          </button>
-        </div>
+        <p class="mt-0.5 whitespace-pre-wrap break-words text-sm text-ink">{{ note.content }}</p>
       </div>
     </div>
-  </div>
+    <p v-else class="py-6 text-center text-sm text-ink/50">No notes yet.</p>
+
+    <textarea
+      v-model="draft"
+      rows="3"
+      :maxlength="MAX"
+      aria-label="Add a note"
+      placeholder="Add a note about collecting this invoice…"
+      class="mt-4 w-full rounded-xl border border-hairline bg-white px-3 py-2 text-sm text-ink placeholder:text-ink/50 focus:border-mpesa focus:outline-none focus:ring-2 focus:ring-mpesa/40"
+    />
+    <p v-if="error" class="mt-2 text-sm text-danger">{{ error }}</p>
+
+    <div class="mt-3 flex items-center justify-between gap-3">
+      <span class="font-mono text-[11px] tabular-nums text-ink/50">{{ draft.length }} / {{ MAX }}</span>
+      <div class="flex gap-2">
+        <button
+          type="button"
+          class="h-11 rounded-xl border border-hairline bg-white px-4 font-medium text-ink"
+          @click="$emit('close')"
+        >
+          Close
+        </button>
+        <button
+          type="button"
+          class="h-11 rounded-xl bg-mpesa px-5 font-semibold text-white disabled:opacity-40"
+          :disabled="!canSave"
+          :aria-busy="saving"
+          @click="save"
+        >
+          {{ saving ? 'Saving…' : 'Save note' }}
+        </button>
+      </div>
+    </div>
+  </BaseDialog>
 </template>

--- a/frontend/src/components/PromptDialog.vue
+++ b/frontend/src/components/PromptDialog.vue
@@ -7,6 +7,7 @@ import {
   saveCustomerContact,
 } from '@/data/collection'
 import { formatKES } from '@/utils/format'
+import BaseDialog from '@/components/BaseDialog.vue'
 
 // One M-Pesa STK prompt for a target (a single invoice or a bundle request). The number and
 // the amount are shown so the operator confirms both before charging. On success a "money
@@ -24,7 +25,7 @@ const busy = ref(false)
 const message = ref(null) // { tone, text }
 const paid = ref(false)
 const receipt = ref('')
-const dialogRef = ref(null)
+const doneRef = ref(null)
 let pollTimer = null
 let returnTimer = null
 
@@ -36,38 +37,19 @@ const toneBox = {
 }
 const waiting = computed(() => busy.value && message.value?.tone === 'info')
 
-// Close on Escape and trap Tab within the dialog (keyboard/AT users can't wander to the
-// page behind the modal). On the success screen, Escape acknowledges rather than abandons.
-function onKeydown(e) {
-  if (e.key === 'Escape') return paid.value ? finishPaid() : emit('close')
-  if (e.key !== 'Tab') return
-  const items = Array.from(
-    dialogRef.value?.querySelectorAll('input, button, [href], [tabindex]:not([tabindex="-1"])') || [],
-  ).filter((el) => !el.disabled)
-  if (!items.length) return
-  const first = items[0]
-  const last = items[items.length - 1]
-  if (e.shiftKey && document.activeElement === first) {
-    e.preventDefault()
-    last.focus()
-  } else if (!e.shiftKey && document.activeElement === last) {
-    e.preventDefault()
-    first.focus()
-  }
-}
+// On the success screen a dismiss acknowledges the payment rather than abandoning it.
+const onDismiss = () => (paid.value ? finishPaid() : emit('close'))
 
 watch(
   () => props.target,
-  (target) => {
-    phone.value = target?.phone || ''
+  () => {
+    phone.value = props.target?.phone || ''
     busy.value = false
     message.value = null
     paid.value = false
     receipt.value = ''
     stopPolling()
     clearReturn()
-    window[target ? 'addEventListener' : 'removeEventListener']('keydown', onKeydown)
-    if (target) nextTick(() => dialogRef.value?.querySelector('input')?.focus())
   },
 )
 
@@ -121,7 +103,7 @@ function startPolling(request) {
         receipt.value = state.detail || ''
         paid.value = true
         returnTimer = setTimeout(finishPaid, RETURN_AFTER_MS)
-        nextTick(() => dialogRef.value?.querySelector('button')?.focus())
+        nextTick(() => doneRef.value?.focus())
       } else if (state.partial) {
         settle('warn', state.detail || 'Paid, but the amount differs — the team will reconcile it.')
         emit('changed')
@@ -169,23 +151,11 @@ function clearReturn() {
 onUnmounted(() => {
   stopPolling()
   clearReturn()
-  window.removeEventListener('keydown', onKeydown)
 })
 </script>
 
 <template>
-  <div
-    v-if="target"
-    class="fixed inset-0 z-50 flex items-end justify-center bg-ink/50 p-4 sm:items-center"
-    @click.self="paid ? finishPaid() : $emit('close')"
-  >
-    <div
-      ref="dialogRef"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="prompt-title"
-      class="w-full max-w-md rounded-3xl bg-paper p-6"
-    >
+  <BaseDialog :open="Boolean(target)" labelledby="prompt-title" @close="onDismiss">
       <!-- Success: money received -->
       <div v-if="paid" class="text-center">
         <div class="mx-auto grid h-16 w-16 place-items-center rounded-full bg-landed/15">
@@ -207,6 +177,7 @@ onUnmounted(() => {
         </p>
         <p v-if="receipt" class="mx-auto mt-3 max-w-xs text-xs text-ink/60">{{ receipt }}</p>
         <button
+          ref="doneRef"
           type="button"
           class="mt-6 h-12 w-full rounded-xl bg-ink font-semibold text-paper transition active:scale-[.98]"
           @click="finishPaid"
@@ -266,7 +237,6 @@ onUnmounted(() => {
             {{ busy ? 'Waiting…' : 'Send prompt' }}
           </button>
         </div>
-      </template>
-    </div>
-  </div>
+    </template>
+  </BaseDialog>
 </template>

--- a/frontend/src/data/collection.js
+++ b/frontend/src/data/collection.js
@@ -20,6 +20,7 @@ const API = {
   saveContact: 'ipay.ipay.main.utils.ipay_redirect.save_customer_contact',
   invoiceNotes: 'ipay.ipay.main.utils.ipay_redirect.invoice_notes',
   addInvoiceNote: 'ipay.ipay.main.utils.ipay_redirect.add_invoice_note',
+  recordCheque: 'ipay.ipay.main.utils.ipay_redirect.record_cheque',
   paymentState: 'ipay.ipay.main.utils.ipay_redirect.payment_state',
   createBundle: 'ipay.ipay.main.utils.ipay_redirect.create_bundle',
   requestDetail: 'ipay.ipay.main.utils.ipay_redirect.request_detail',
@@ -109,6 +110,17 @@ export const saveCustomerContact = (request, phone) =>
 // Collection notes on an invoice — plain text; the server escapes on write and unescapes here.
 export const fetchInvoiceNotes = (invoice) => call(API.invoiceNotes, { invoice }, 'GET')
 export const addInvoiceNote = (invoice, note) => call(API.addInvoiceNote, { invoice, note })
+
+// A collected cheque becomes a DRAFT Payment Entry for the accounts team to submit. No invoices
+// records it on account. `photo` is a downscaled data URL; the server attaches it to the entry.
+export const recordCheque = ({ customer, amount, chequeNo, photo, invoices = [] }) =>
+  call(API.recordCheque, {
+    customer,
+    amount,
+    cheque_no: chequeNo,
+    photo,
+    invoices: JSON.stringify(invoices),
+  })
 
 export const paymentState = (request) => call(API.paymentState, { request }, 'GET')
 

--- a/frontend/src/pages/CustomerDetail.vue
+++ b/frontend/src/pages/CustomerDetail.vue
@@ -2,11 +2,13 @@
 import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { createBundle, fetchCustomerCollection } from '@/data/collection'
+import { formatKES } from '@/utils/format'
 import { useResumeRefresh } from '@/composables/useResumeRefresh'
 import { useInvoiceSelection } from '@/composables/useInvoiceSelection'
 import InvoiceCard from '@/components/InvoiceCard.vue'
 import PromptDialog from '@/components/PromptDialog.vue'
 import NotesDialog from '@/components/NotesDialog.vue'
+import ChequeDialog from '@/components/ChequeDialog.vue'
 import CustomerMoneyHeader from '@/components/CustomerMoneyHeader.vue'
 import CollectBar from '@/components/CollectBar.vue'
 import ErrorRetry from '@/components/ErrorRetry.vue'
@@ -18,6 +20,7 @@ const driver = route.query.driver || '' // scope the detail to the driver picked
 
 const customerName = ref('')
 const invoices = ref([])
+const chequeOnAccount = ref(0)
 const enableRedirect = ref(false)
 const canBundle = ref(false)
 const mpesaMax = ref(0)
@@ -27,6 +30,7 @@ const creatingBundle = ref(false)
 const collectError = ref(false)
 const prompting = ref(null)
 const noting = ref(null)
+const chequing = ref(null)
 
 const { selected, isSelected, toggleSelect, clearSelection, dropSelected, selectedTotal } =
   useInvoiceSelection()
@@ -65,6 +69,7 @@ async function load() {
     enableRedirect.value = Boolean(data.enable_redirect)
     canBundle.value = Boolean(data.can_bundle)
     mpesaMax.value = data.mpesa_max || 0
+    chequeOnAccount.value = Number(data.cheque_on_account || 0)
   } catch {
     loadError.value = true
   } finally {
@@ -117,6 +122,20 @@ function onPaid(name) {
   if (!invoices.value.length) toList()
 }
 
+// A cheque covers the ticked invoices; nothing ticked records it against the customer instead.
+function chequeFor(names, outstanding) {
+  chequing.value = { customer, customer_name: customerName.value, invoices: names, outstanding }
+}
+
+// Mark the cards in place rather than reloading, which would clear the ticked set underneath.
+function onChequeRecorded({ invoices: names, amount }) {
+  if (!names.length) chequeOnAccount.value += amount
+  invoices.value.forEach((inv) => {
+    if (names.includes(inv.name)) inv.awaiting_cheque = true
+  })
+  clearSelection()
+}
+
 // Patch the card in place: reloading the list would clear a ticked bundle and reset paging.
 function onNoteSaved({ invoice, count, latest }) {
   const inv = invoices.value.find((i) => i.name === invoice)
@@ -155,9 +174,16 @@ onMounted(load)
         :mpesa-max="mpesaMax"
         :collect-error="collectError"
         :show-tick-hint="selectable && !selected.length"
+        :show-cheque="invoices.length > 0"
         @collect="collectNow"
         @clear="clearSelection"
+        @cheque="chequeFor(selected.map((i) => i.name), selected.length ? selectedTotal : total)"
       />
+
+      <p v-if="chequeOnAccount" class="-mt-2 rounded-xl bg-ink/5 px-3 py-2.5 text-[13px] text-ink/75">
+        {{ formatKES(chequeOnAccount) }} already collected by cheque, with accounts to bank. It is
+        not tied to an invoice, so check before collecting again.
+      </p>
 
       <input
         v-if="invoices.length > 1"
@@ -186,6 +212,7 @@ onMounted(load)
           :actions-disabled="selected.length > 0"
           @prompt="promptInvoice(inv)"
           @notes="noting = { invoice: inv.name, customer_name: inv.customer_name }"
+          @cheque="chequeFor([inv.name], Number(inv.outstanding_amount || 0))"
           @toggle-select="toggleSelect(inv)"
         />
       </div>
@@ -193,5 +220,6 @@ onMounted(load)
 
     <PromptDialog :target="prompting" @close="prompting = null" @paid="onPaid" @changed="load" />
     <NotesDialog :target="noting" @close="noting = null" @saved="onNoteSaved" />
+    <ChequeDialog :target="chequing" @close="chequing = null" @recorded="onChequeRecorded" />
   </main>
 </template>

--- a/frontend/src/pages/PagedCustomerDetail.vue
+++ b/frontend/src/pages/PagedCustomerDetail.vue
@@ -6,11 +6,13 @@ import {
   fetchInternalCustomerInvoices,
   fetchSalesCustomerInvoices,
 } from '@/data/collection'
+import { formatKES } from '@/utils/format'
 import { useResumeRefresh } from '@/composables/useResumeRefresh'
 import { useInvoiceSelection } from '@/composables/useInvoiceSelection'
 import InvoiceCard from '@/components/InvoiceCard.vue'
 import PromptDialog from '@/components/PromptDialog.vue'
 import NotesDialog from '@/components/NotesDialog.vue'
+import ChequeDialog from '@/components/ChequeDialog.vue'
 import CustomerMoneyHeader from '@/components/CustomerMoneyHeader.vue'
 import CollectBar from '@/components/CollectBar.vue'
 import ErrorRetry from '@/components/ErrorRetry.vue'
@@ -49,6 +51,7 @@ const scopeQuery = () =>
 const customerName = ref('')
 const invoices = ref([])
 const total = ref(0)
+const chequeOnAccount = ref(0)
 const count = ref(0)
 const hasMore = ref(false)
 const enableRedirect = ref(false)
@@ -61,6 +64,7 @@ const creatingBundle = ref(false)
 const collectError = ref(false)
 const prompting = ref(null)
 const noting = ref(null)
+const chequing = ref(null)
 
 const search = ref('')
 let searchTimer = null
@@ -104,6 +108,7 @@ async function load(reset = true) {
     count.value = data.invoice_count
     enableRedirect.value = Boolean(data.enable_redirect)
     mpesaMax.value = data.mpesa_max || 0
+    chequeOnAccount.value = Number(data.cheque_on_account || 0)
     invoices.value = reset ? data.invoices || [] : [...invoices.value, ...(data.invoices || [])]
     hasMore.value = Boolean(data.has_more)
   } catch {
@@ -177,6 +182,20 @@ function onPaid(name) {
   else if (!invoices.value.length) load(true)
 }
 
+// A cheque covers the ticked invoices; nothing ticked records it against the customer instead.
+function chequeFor(names, outstanding) {
+  chequing.value = { customer, customer_name: customerName.value, invoices: names, outstanding }
+}
+
+// Mark the cards in place rather than reloading, which would clear the ticked set underneath.
+function onChequeRecorded({ invoices: names, amount }) {
+  if (!names.length) chequeOnAccount.value += amount
+  invoices.value.forEach((inv) => {
+    if (names.includes(inv.name)) inv.awaiting_cheque = true
+  })
+  clearSelection()
+}
+
 // Patch the card in place: reloading the list would clear a ticked bundle and reset paging.
 function onNoteSaved({ invoice, count, latest }) {
   const inv = invoices.value.find((i) => i.name === invoice)
@@ -220,9 +239,16 @@ onMounted(() => load(true))
         :mpesa-max="mpesaMax"
         :collect-error="collectError"
         :show-tick-hint="selectable && !selected.length"
+        :show-cheque="count > 0"
         @collect="collectNow"
         @clear="clearSelection"
+        @cheque="chequeFor(selected.map((i) => i.name), selected.length ? selectedTotal : total)"
       />
+
+      <p v-if="chequeOnAccount" class="-mt-2 rounded-xl bg-ink/5 px-3 py-2.5 text-[13px] text-ink/75">
+        {{ formatKES(chequeOnAccount) }} already collected by cheque, with accounts to bank. It is
+        not tied to an invoice, so check before collecting again.
+      </p>
 
       <input
         v-model="search"
@@ -252,6 +278,7 @@ onMounted(() => load(true))
             :actions-disabled="selected.length > 0"
             @prompt="promptInvoice(inv)"
             @notes="noting = { invoice: inv.name, customer_name: inv.customer_name }"
+            @cheque="chequeFor([inv.name], Number(inv.outstanding_amount || 0))"
             @toggle-select="toggleSelect(inv)"
           />
         </div>
@@ -269,6 +296,7 @@ onMounted(() => load(true))
 
       <PromptDialog :target="prompting" @close="prompting = null" @paid="onPaid" @changed="load(true)" />
       <NotesDialog :target="noting" @close="noting = null" @saved="onNoteSaved" />
+      <ChequeDialog :target="chequing" @close="chequing = null" @recorded="onChequeRecorded" />
     </template>
   </main>
 </template>

--- a/ipay/ipay/doctype/ipay_settings/ipay_settings.json
+++ b/ipay/ipay/doctype/ipay_settings/ipay_settings.json
@@ -95,10 +95,10 @@
    "options": "Account"
   },
   {
-   "description": "Fallback account for collected cheques, used only when the Cheque Mode of Payment has no account set for the company. Cheques must never book to cash.",
+   "description": "Account collected cheques are booked to, as undeposited funds. Required before a cheque can be recorded — cheques must never book to cash.",
    "fieldname": "cheque_account",
    "fieldtype": "Link",
-   "label": "Cheque Account (fallback)",
+   "label": "Cheque Account",
    "options": "Account"
   },
   {

--- a/ipay/ipay/doctype/ipay_settings/ipay_settings.json
+++ b/ipay/ipay/doctype/ipay_settings/ipay_settings.json
@@ -17,6 +17,7 @@
   "mpesa_max_amount",
   "payment_link_ttl_days",
   "cash_account",
+  "cheque_account",
   "alert_email",
   "last_reconcile_run",
   "restrict_sales_managers"
@@ -91,6 +92,13 @@
    "fieldname": "cash_account",
    "fieldtype": "Link",
    "label": "Cash Account (fallback)",
+   "options": "Account"
+  },
+  {
+   "description": "Fallback account for collected cheques, used only when the Cheque Mode of Payment has no account set for the company. Cheques must never book to cash.",
+   "fieldname": "cheque_account",
+   "fieldtype": "Link",
+   "label": "Cheque Account (fallback)",
    "options": "Account"
   },
   {

--- a/ipay/ipay/main/utils/constants.py
+++ b/ipay/ipay/main/utils/constants.py
@@ -32,6 +32,11 @@ ACTIVE_BUNDLE_WINDOW_MIN = 30
 COLLECTION_NOTE_SUBJECT = "iPay Collection Note"
 COLLECTION_NOTE_MAX_LENGTH = 500
 
+# The Mode of Payment a collected cheque is recorded under — what marks a draft Payment Entry as
+# "a cheque a collector took", both when writing one and when flagging the invoices it covers.
+CHEQUE_MODE = "Cheque"
+CHEQUE_NO_MAX_LENGTH = 30
+
 
 def note_filters(reference_name):
     """Comment filters for the collection notes on one invoice, or on a list of them."""

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -14,6 +14,8 @@ from ipay.ipay.main.utils.constants import (
     note_filters,
     note_text,
     ACTIVE_BUNDLE_WINDOW_MIN,
+    CHEQUE_MODE,
+    CHEQUE_NO_MAX_LENGTH,
     COLLECTION_NOTE_MAX_LENGTH,
     COLLECTION_NOTE_SUBJECT,
 )
@@ -35,9 +37,6 @@ ALL_OPERATOR_ROLES = OPERATOR_ROLES | {"iPay Collector", "Sales User", "Sales Ma
 # Bundling several invoices into one prompt: operators, sales users and sales managers
 # (who chase a customer's whole balance). Field collectors stay one invoice at a time.
 BUNDLER_ROLES = OPERATOR_ROLES | {"Sales User", "Sales Manager"}
-
-CHEQUE_MODE = "Cheque"
-CHEQUE_NO_MAX_LENGTH = 30
 
 
 def _require_full_operator():

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -3,7 +3,9 @@ import hmac
 import hashlib
 
 import frappe
+from frappe.utils.file_manager import save_file
 
+from ipay.ipay.main.utils.make_payment_entry import allocate_references
 from ipay.ipay.main.utils.reconcile_payments import reconcile_request
 from ipay.ipay.main.utils.ipay_logs import create_log_entry
 from ipay.ipay.main.utils.constants import (
@@ -33,6 +35,9 @@ ALL_OPERATOR_ROLES = OPERATOR_ROLES | {"iPay Collector", "Sales User", "Sales Ma
 # Bundling several invoices into one prompt: operators, sales users and sales managers
 # (who chase a customer's whole balance). Field collectors stay one invoice at a time.
 BUNDLER_ROLES = OPERATOR_ROLES | {"Sales User", "Sales Manager"}
+
+CHEQUE_MODE = "Cheque"
+CHEQUE_NO_MAX_LENGTH = 30
 
 
 def _require_full_operator():
@@ -870,6 +875,130 @@ def add_invoice_note(invoice, note):
             "content": note_content(text),
         }
     ).insert(ignore_permissions=True)
+
+
+def _require_customer_access(customer):
+    """A scoped actor may only act on a customer they hold an outstanding invoice for — an
+    on-account cheque names no invoice, so nothing else would scope it."""
+    from ipay.ipay.main.utils.collector import can_access_invoice
+
+    for invoice in frappe.get_all(
+        "Sales Invoice",
+        filters={"customer": customer, "docstatus": 1, "outstanding_amount": [">", 0]},
+        pluck="name",
+    ):
+        if can_access_invoice(invoice):
+            return
+    frappe.throw("You are not assigned to this customer.", frappe.PermissionError)
+
+
+def _cheque_account(company):
+    """Cheques land in the undeposited-cheque account, never cash."""
+    account = frappe.db.get_value(
+        "Mode of Payment Account", {"parent": CHEQUE_MODE, "company": company}, "default_account"
+    ) or frappe.db.get_single_value("iPay Settings", "cheque_account")
+    if not account:
+        frappe.throw(
+            f"No cheque account is configured for {company}. Set a Default Account on Mode of "
+            f"Payment {CHEQUE_MODE}, or set iPay Settings → Cheque Account (fallback)."
+        )
+    return account
+
+
+def _cheque_company(customer):
+    """On-account cheques name no invoice, so take the company from the customer's own book."""
+    company = frappe.db.get_value(
+        "Sales Invoice", {"customer": customer, "docstatus": 1}, "company", order_by="posting_date desc"
+    )
+    if not company:
+        frappe.throw("This customer has no invoices to book a cheque against.")
+    return company
+
+
+@frappe.whitelist(methods=["POST"])
+def record_cheque(customer, amount, cheque_no, photo, invoices=None, cheque_date=None):
+    """Record a collected cheque as a DRAFT Payment Entry — the accounts team submits it, never us.
+
+    Ticked invoices allocate against them; none means an on-account credit."""
+    _require_operator()
+
+    invoice_names = frappe.parse_json(invoices) if isinstance(invoices, str) else list(invoices or [])
+    for invoice in invoice_names:
+        _require_invoice_access(invoice)
+    if not invoice_names:
+        _require_customer_access(customer)
+
+    amount = frappe.utils.flt(amount)
+    if amount <= 0:
+        frappe.throw("Enter the cheque amount.")
+    number = (cheque_no or "").strip()
+    if not number:
+        frappe.throw("Enter the cheque number.")
+    if len(number) > CHEQUE_NO_MAX_LENGTH:
+        frappe.throw(f"Keep the cheque number under {CHEQUE_NO_MAX_LENGTH} characters.")
+    if not photo:
+        frappe.throw("Attach a photo of the cheque.")
+
+    if invoice_names:
+        invoices_data, references, remaining = allocate_references(invoice_names, amount)
+        if any(si.customer != customer for si in invoices_data):
+            frappe.throw("Those invoices do not all belong to this customer.")
+        company = invoices_data[0].company
+    else:
+        references, remaining = [], amount
+        company = _cheque_company(customer)
+
+    payment_entry = frappe.new_doc("Payment Entry")
+    payment_entry.payment_type = "Receive"
+    payment_entry.company = company
+    payment_entry.posting_date = frappe.utils.today()
+    payment_entry.mode_of_payment = CHEQUE_MODE
+    payment_entry.party_type = "Customer"
+    payment_entry.party = customer
+    payment_entry.paid_to = _cheque_account(company)
+    payment_entry.paid_amount = amount
+    payment_entry.received_amount = amount
+    payment_entry.source_exchange_rate = 1.0
+    payment_entry.target_exchange_rate = 1.0
+    payment_entry.unallocated_amount = remaining
+    # Namespaced by customer: two customers may share a cheque number, one customer may not reuse it.
+    payment_entry.reference_no = f"{number}-{customer}"
+    payment_entry.reference_date = cheque_date or frappe.utils.today()
+    payment_entry.custom_remarks = 1
+    allocated_to = ", ".join(r["reference_name"] for r in references) or "account"
+    payment_entry.remarks = (
+        f"Cheque {number} for KES {amount} collected from {customer} against {allocated_to}\n"
+        f"Recorded from iPay Collect by {frappe.session.user}"
+    )
+    for ref in references:
+        payment_entry.append("references", ref)
+
+    # ERPNext's own validation calls frappe.has_permission("Payment Entry"), which ignore_permissions
+    # cannot bypass and iPay roles never hold — the guards above are the authorisation instead.
+    collector = frappe.session.user
+    frappe.set_user("Administrator")
+    try:
+        payment_entry.insert(ignore_permissions=True)
+        # insert() always stamps the session user, so the collector is restored as owner after it.
+        payment_entry.db_set("owner", collector, update_modified=False)
+        # Attached after the insert, or a rejected Payment Entry strands the written file.
+        save_file(
+            f"cheque-{number}.jpg", photo, "Payment Entry", payment_entry.name,
+            decode=True, is_private=1,
+        )
+    except frappe.UniqueValidationError:
+        frappe.throw(f"Cheque {number} is already recorded for this customer.")
+    except OSError:
+        # A corrupt photo arrives as an unreadable image, not a validation error.
+        frappe.throw("That photo could not be read. Take it again.")
+    finally:
+        frappe.set_user(collector)
+
+    return {
+        "payment_entry": payment_entry.name,
+        "amount": amount,
+        "allocated": frappe.utils.flt(amount - remaining),
+    }
 
 
 @frappe.whitelist(allow_guest=True, methods=["POST"])

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -893,15 +893,12 @@ def _require_customer_access(customer):
 
 
 def _cheque_account(company):
-    """Cheques land in the undeposited-cheque account, never cash."""
-    account = frappe.db.get_value(
-        "Mode of Payment Account", {"parent": CHEQUE_MODE, "company": company}, "default_account"
-    ) or frappe.db.get_single_value("iPay Settings", "cheque_account")
+    """Where collected cheques are booked — set once in iPay Settings, and never cash."""
+    account = frappe.db.get_single_value("iPay Settings", "cheque_account")
     if not account:
-        frappe.throw(
-            f"No cheque account is configured for {company}. Set a Default Account on Mode of "
-            f"Payment {CHEQUE_MODE}, or set iPay Settings → Cheque Account (fallback)."
-        )
+        frappe.throw("No cheque account is configured. Set iPay Settings → Cheque Account.")
+    if frappe.db.get_value("Account", account, "company") != company:
+        frappe.throw(f"The cheque account in iPay Settings does not belong to {company}.")
     return account
 
 

--- a/ipay/ipay/main/utils/make_payment_entry.py
+++ b/ipay/ipay/main/utils/make_payment_entry.py
@@ -5,6 +5,75 @@ import json
 logger = logging.getLogger(__name__)
 
 
+def allocate_references(invoice_names, amount):
+    """Split `amount` across invoices oldest-first, per payment term where the invoice has them.
+
+    Returns (invoices, references, remaining) — `remaining` is unallocated customer credit. Shared
+    by every rail: allocation belongs to the invoices, not to how the money arrived."""
+    flt = frappe.utils.flt
+
+    # Read outstanding live, so an invoice settled elsewhere meanwhile is skipped.
+    invoices = sorted(
+        (
+            frappe.db.get_value(
+                "Sales Invoice",
+                name,
+                ["name", "outstanding_amount", "posting_date", "customer", "customer_name", "company"],
+                as_dict=True,
+            )
+            for name in invoice_names
+        ),
+        key=lambda si: (si.posting_date, si.name),
+    )
+
+    remaining = flt(amount)
+    references = []
+    for si in invoices:
+        if remaining <= 0:
+            break
+        if flt(si.outstanding_amount) <= 0:
+            continue
+
+        # Invoices with payment terms must allocate per term (oldest due first) and carry the
+        # payment_term on the reference; others take a single reference.
+        terms = [
+            t
+            for t in frappe.get_all(
+                "Payment Schedule",
+                filters={"parent": si.name, "parenttype": "Sales Invoice"},
+                fields=["payment_term", "outstanding"],
+                order_by="due_date asc",
+            )
+            if flt(t.outstanding) > 0
+        ]
+        if terms:
+            for term in terms:
+                if remaining <= 0:
+                    break
+                allocated = min(remaining, flt(term.outstanding))
+                references.append(
+                    {
+                        "reference_doctype": "Sales Invoice",
+                        "reference_name": si.name,
+                        "payment_term": term.payment_term,
+                        "allocated_amount": allocated,
+                    }
+                )
+                remaining = flt(remaining - allocated)
+        else:
+            allocated = min(remaining, flt(si.outstanding_amount))
+            references.append(
+                {
+                    "reference_doctype": "Sales Invoice",
+                    "reference_name": si.name,
+                    "allocated_amount": allocated,
+                }
+            )
+            remaining = flt(remaining - allocated)
+
+    return invoices, references, remaining
+
+
 # NOT @frappe.whitelist: this is an internal helper called only by
 # finalize_payment (server-side). Exposing it let any authenticated user POST a
 # forged response_data (fake transaction_code + amount) and submit a Payment
@@ -68,68 +137,9 @@ def make_payment_entry(user_id, customer_email, inv, response_data, ipay_request
         if not invoice_names:
             invoice_names = [inv]
 
-        # Pull live invoice data and allocate oldest-first against current
-        # outstanding (so an invoice paid elsewhere meanwhile is skipped).
-        invoices = sorted(
-            (
-                frappe.db.get_value(
-                    "Sales Invoice",
-                    name,
-                    ["name", "outstanding_amount", "posting_date", "customer", "customer_name", "company"],
-                    as_dict=True,
-                )
-                for name in invoice_names
-            ),
-            key=lambda si: (si.posting_date, si.name),
-        )
-        primary = invoices[0]
-
         transaction_amount = flt(response_data.get("transaction_amount", 0))
-        remaining = transaction_amount
-        references = []
-        for si in invoices:
-            if remaining <= 0:
-                break
-            if flt(si.outstanding_amount) <= 0:
-                continue
-
-            # Invoices with payment terms must allocate per term (oldest due
-            # first) and carry the payment_term on the reference; others take a
-            # single reference.
-            terms = [
-                t
-                for t in frappe.get_all(
-                    "Payment Schedule",
-                    filters={"parent": si.name, "parenttype": "Sales Invoice"},
-                    fields=["payment_term", "outstanding"],
-                    order_by="due_date asc",
-                )
-                if flt(t.outstanding) > 0
-            ]
-            if terms:
-                for term in terms:
-                    if remaining <= 0:
-                        break
-                    allocated = min(remaining, flt(term.outstanding))
-                    references.append(
-                        {
-                            "reference_doctype": "Sales Invoice",
-                            "reference_name": si.name,
-                            "payment_term": term.payment_term,
-                            "allocated_amount": allocated,
-                        }
-                    )
-                    remaining = flt(remaining - allocated)
-            else:
-                allocated = min(remaining, flt(si.outstanding_amount))
-                references.append(
-                    {
-                        "reference_doctype": "Sales Invoice",
-                        "reference_name": si.name,
-                        "allocated_amount": allocated,
-                    }
-                )
-                remaining = flt(remaining - allocated)
+        invoices, references, remaining = allocate_references(invoice_names, transaction_amount)
+        primary = invoices[0]
 
         # If nothing could be allocated (every invoice was already settled
         # elsewhere), the money is still real — record it as unallocated credit,

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -314,9 +314,9 @@ def _annotate_awaiting_cheque(invoices):
     rows = frappe.get_all(
         "Payment Entry Reference",
         filters={"reference_doctype": "Sales Invoice", "reference_name": ["in", names], "docstatus": 0},
-        fields=["parent", "reference_name"],
+        fields=["parent", "reference_name", "allocated_amount"],
     )
-    drafts = set()
+    covered = {}
     if rows:
         cheques = set(
             frappe.get_all(
@@ -329,9 +329,13 @@ def _annotate_awaiting_cheque(invoices):
                 pluck="name",
             )
         )
-        drafts = {r.reference_name for r in rows if r.parent in cheques}
+        for row in rows:
+            if row.parent in cheques:
+                covered[row.reference_name] = covered.get(row.reference_name, 0) + flt(row.allocated_amount)
+    # The amount rides along: a cheque may cover only part of the invoice, and "awaiting" without
+    # a figure would read as though the whole balance were settled.
     for inv in invoices:
-        inv.awaiting_cheque = inv.name in drafts
+        inv.awaiting_cheque = flt(covered.get(inv.name, 0))
 
 
 def _cheque_on_account(customer):

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -3,7 +3,12 @@ from frappe.utils import add_to_date, cint, flt, now_datetime, today
 
 from ipay.ipay.main.utils.prepaid import all_prepaid_invoice_names, prepaid_invoice_names
 from ipay.ipay.main.utils.collector import OPERATOR_ROLES, collector_scope, is_collector_only
-from ipay.ipay.main.utils.constants import ACTIVE_BUNDLE_WINDOW_MIN, note_filters, note_text
+from ipay.ipay.main.utils.constants import (
+    ACTIVE_BUNDLE_WINDOW_MIN,
+    CHEQUE_MODE,
+    note_filters,
+    note_text,
+)
 from ipay.ipay.main.utils.sales import (
     SALES_MANAGER_ROLES,
     SALES_ROLE,
@@ -227,6 +232,7 @@ def _customer_invoices(user, customer, driver=None):
     _annotate_customer_phone(invoices)
     _annotate_sales_person(invoices)
     _annotate_notes(invoices)
+    _annotate_awaiting_cheque(invoices)
     return invoices
 
 
@@ -296,6 +302,54 @@ def _annotate_notes(invoices):
     for inv in invoices:
         inv.note_count = counts.get(inv.name, 0)
         inv.note_latest = note_text(latest.get(inv.name) or "")
+
+
+def _annotate_awaiting_cheque(invoices):
+    """Flag invoices a collected cheque already covers, batched. A cheque sits as a DRAFT Payment
+    Entry until accounts submit it, and a draft does not reduce outstanding — so without this the
+    invoice still looks unpaid and would be charged a second time."""
+    names = [inv.name for inv in invoices]
+    if not names:
+        return
+    rows = frappe.get_all(
+        "Payment Entry Reference",
+        filters={"reference_doctype": "Sales Invoice", "reference_name": ["in", names], "docstatus": 0},
+        fields=["parent", "reference_name"],
+    )
+    drafts = set()
+    if rows:
+        cheques = set(
+            frappe.get_all(
+                "Payment Entry",
+                filters={
+                    "name": ["in", list({r.parent for r in rows})],
+                    "docstatus": 0,
+                    "mode_of_payment": CHEQUE_MODE,
+                },
+                pluck="name",
+            )
+        )
+        drafts = {r.reference_name for r in rows if r.parent in cheques}
+    for inv in invoices:
+        inv.awaiting_cheque = inv.name in drafts
+
+
+def _cheque_on_account(customer):
+    """What a customer has handed over in cheques that name no invoice. Nothing marks those
+    invoices, so this is the only thing standing between an on-account cheque and collecting
+    the same money twice."""
+    amounts = frappe.get_all(
+        "Payment Entry",
+        filters={
+            "party_type": "Customer",
+            "party": customer,
+            "docstatus": 0,
+            "mode_of_payment": CHEQUE_MODE,
+            "total_allocated_amount": 0,
+        },
+        pluck="unallocated_amount",
+    )
+    return flt(sum(amounts))
 
 
 def get_context(context):
@@ -437,6 +491,7 @@ def customer_collection(customer, driver=None):
         "customer": customer,
         "customer_name": invoices[0].customer_name if invoices else customer,
         "invoices": invoices,
+        "cheque_on_account": _cheque_on_account(customer),
         **_settings_flags(),
         "can_bundle": not is_collector_only(frappe.session.user),
     }
@@ -520,9 +575,11 @@ def _drill_down(invoices, customer, start, page_length, search):
     _annotate_customer_phone(page)
     _annotate_sales_person(page)
     _annotate_notes(page)
+    _annotate_awaiting_cheque(page)
     return {
         "customer": customer,
         "customer_name": frappe.db.get_value("Customer", customer, "customer_name") or customer,
+        "cheque_on_account": _cheque_on_account(customer),
         "invoices": page,
         "invoice_count": count,
         "total_outstanding": total,


### PR DESCRIPTION
The promised follow-up to #85 + #86. Both branched off `main` independently, so neither could see the other's definition and `CHEQUE_MODE` / `CHEQUE_NO_MAX_LENGTH` landed twice — in `constants.py` (the marker) and `ipay_redirect.py` (the writer).

Same values, so nothing was broken, but the writer and the marker must agree on what a collected cheque looks like. Two copies is exactly how they drift apart later.

`ipay_redirect.py` now imports both from `constants.py`, alongside the collection-note constants it already shares.

Verified on dev: all three modules parse, no definition remains in `ipay_redirect.py`, and the end-to-end flow is unchanged — cheque recorded as a draft owned by the collector, booked to `Undeposited Cheque - TSL`, photo attached, the card returns `awaiting_cheque` at 700.0, and the on-account total still drives the notice.