### PR TITLE
feat(ipay): cheque collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Without an iPay account, this application cannot process mobile money transactio
 -  **Automatic STK Push to Customer's Mobile Phone**: Instantly send a payment request directly to the customer's mobile device, minimizing errors and reducing the steps required to complete a transaction.
 -  **Real-Time Payment Verification**: Verify payments as they happen, ensuring immediate confirmation and reducing delays in processing.
 -  **Secure Transaction Logging**: Maintain a tamper-proof, detailed record of all payment transactions, including timestamps, amounts, and statuses, for compliance and auditing purposes.
+-  **Cheque Collection**: Collectors record a customer's cheque as a draft Payment Entry for the accounts team to submit — see [docs/cheque-collection.md](docs/cheque-collection.md) for how it works, the settings, and the operational notes.
 
 ## Payment Workflow
 

--- a/docs/cheque-collection.md
+++ b/docs/cheque-collection.md
@@ -1,0 +1,121 @@
+# Cheque Collection
+
+A collector records a customer's cheque from the Collect app. The app **never submits** the
+payment — it writes a **draft** Payment Entry with the cheque photo attached, and the accounts
+team reviews and submits it. Until they do, no money is considered received.
+
+---
+
+## Settings
+
+All under **iPay Settings**.
+
+| Setting | What it does |
+|---|---|
+| **Allow Cheque Collection** | Master switch. Off (default) → no cheque option appears anywhere. |
+| **Cheque Per Invoice** | On (default) → a cheque can be attached to specific invoices. Off → every cheque is customer-level (on account, no invoice attached); the per-invoice buttons disappear. |
+| **Cheque Account** | The account collected cheques are booked to (undeposited funds). **Required** before any cheque can be recorded — cheques never book to cash. |
+
+The cheque option only shows in the app when **Allow Cheque Collection is on *and* a Cheque Account
+is set**. Toggling these takes effect on the next app load (reload / reopen the PWA).
+
+---
+
+## How a cheque is recorded
+
+1. **Capture** — photograph the cheque (required), enter the amount and the cheque number.
+2. **Confirm** — a summary that reads differently for each mode (see below), with the draft caveat.
+3. **Recorded** — a confirmation that says *recorded*, never *paid*.
+
+Two modes, decided by whether invoices were ticked (only when *Cheque Per Invoice* is on):
+
+- **Against invoices** — the cheque references the ticked invoices, allocated oldest-first. Those
+  cards show an amber *"awaiting cheque"* notice and lose their prompt buttons.
+- **On account** — nothing ticked (or *Cheque Per Invoice* is off). The cheque references no
+  invoice; the customer header carries an amber *on-account* notice. Accounts decide later which
+  invoices it settles.
+
+## After recording — why it can't be collected twice
+
+A draft Payment Entry does **not** reduce an invoice's outstanding, so a collected cheque leaves
+its invoices looking unpaid. The app therefore blocks re-charging them: an invoice a cheque covers
+is refused on **every** rail — M-Pesa prompt, hosted checkout, the payment link, and bundling —
+until the draft is submitted or cancelled. The on-account figure on the customer header is the
+equivalent guard for cheques that name no invoice.
+
+## What accounts receives
+
+A draft Payment Entry shaped like the ones they already create by hand:
+
+- `docstatus = 0` (Draft), `mode_of_payment = Cheque`, booked to the Cheque Account.
+- `reference_no = <cheque number>-<customer>` (see *Reference number format* below).
+- Invoice references (allocated oldest-first) for a per-invoice cheque; none for an on-account one.
+- The cheque photo attached as a private file.
+- Owner = the collector who recorded it.
+
+---
+
+## Known limitations & operational notes
+
+These are deliberate trade-offs, documented so the accounts/ops team knows the process. They are
+tracked for possible future work in issue **#88**.
+
+### A bounced or un-actioned cheque
+Once a cheque is recorded, its invoices cannot be collected in the app until the draft is dealt
+with. There is **no automatic expiry** — this is intentional (a cheque marker means money was
+taken, and auto-expiring it could re-open collection of money that really was collected).
+
+**If a cheque bounces or was recorded in error:** accounts should **cancel or delete the draft
+Payment Entry**. That immediately returns the invoice to the collection list.
+
+### Correcting a mistaken cheque
+`reference_no` has a unique index, so a **cancelled** cheque still holds its number and the same
+number can't be re-recorded for that customer.
+
+**To re-record a cheque entered wrongly (wrong amount, etc.):** **delete** the draft rather than
+cancelling it — deleting frees the number so it can be re-entered. (A genuine replacement cheque
+has a different number, so this only matters for correcting a data-entry mistake.)
+
+### A cheque that won't submit because the balance changed
+A per-invoice cheque's allocation is fixed when the collector records it. If the customer part-pays
+those invoices another way (e.g. M-Pesa) before accounts submit the cheque, the draft's allocation
+may exceed the reduced outstanding and ERPNext will refuse to submit it.
+
+**Accounts should adjust the references on the draft** (standard ERPNext) before submitting.
+
+### Reference number format
+Accounts see `reference_no` as `001894-Customer Name`, not the bare `001894`. This is deliberate:
+cheque numbers are short and repeat across banks, and the unique index would otherwise refuse two
+different customers' cheque 001894. **Confirm this format is acceptable to the accounts team** — if
+not, the alternative is to capture the bank (e.g. `KCB/001894`).
+
+### Invoices whose payment schedule is stale
+A few invoices have a payment schedule whose terms sum to **less** than the invoice still owes
+(a data inconsistency). A full payment on such an invoice allocates what the terms allow and leaves
+the rest as **customer credit** — the invoice keeps showing the small balance. This cannot be fixed
+in the payment code (ERPNext will not let any allocation clear it); the fix is to **correct the
+invoice's payment schedule**. Rare, and currently none exist.
+
+### Restricted sales managers and the on-account figure
+When *Restrict Sales Managers to Their Own Book* is on, a sales manager is confined to their own
+customers on the sales page — but the on-account cheque figure is not scoped for them there. This
+is a minor consistency gap, not an exposure: a sales manager can already read any customer's
+figure through the internal page.
+
+---
+
+## For developers
+
+- The app never submits a cheque Payment Entry; it inserts a **draft** (`docstatus 0`).
+- iPay roles hold no Payment Entry permission — `record_cheque` inserts as Administrator inside a
+  `try/finally`, with the collector restored as `owner`. The guards (`_require_operator`,
+  `_require_invoice_access`, `_require_customer_access`) are the authorisation.
+- Collect invoices use **Cash on Delivery / End of Day** templates, both with
+  `allocate_payment_based_on_payment_terms = 1`. On these, ERPNext **rejects a Payment Entry
+  reference that has no payment term** — so allocation must always carry a payment term, and the
+  stale-schedule shortfall above cannot be forced onto the invoice.
+- The "already covered by a cheque" question is answered once, in
+  `ipay/ipay/main/utils/cheque.py::awaiting_cheque_amounts`, and reused by the card markers and the
+  charge guards so they cannot drift.
+- Settings flags (`allow_cheque`, `cheque_per_invoice`, `enable_redirect`) are read **fresh**, not
+  through the doc cache, so toggles take effect immediately.

--- a/frontend/src/components/BaseDialog.vue
+++ b/frontend/src/components/BaseDialog.vue
@@ -1,0 +1,76 @@
+<script setup>
+import { nextTick, onUnmounted, ref, watch } from 'vue'
+
+// The app's modal shell: backdrop, panel, Escape and a Tab trap. Every dialog is built on this
+// so the trap exists once — it was copied by hand before and the copies drifted apart.
+const props = defineProps({
+  open: Boolean,
+  labelledby: { type: String, required: true },
+  // Where focus lands on open. 'panel' leaves a phone at the top of the content rather than
+  // scrolling to the first field.
+  focus: { type: String, default: 'input' },
+})
+const emit = defineEmits(['close'])
+
+const panel = ref(null)
+
+// Escape and the backdrop both just report intent; the caller decides what closing means.
+function onKeydown(e) {
+  if (e.key === 'Escape') return emit('close')
+  if (e.key !== 'Tab') return
+  // The panel leads the list: it holds focus on open, and querySelectorAll sees only its
+  // descendants — without it Shift+Tab lands on the page behind.
+  const items = [
+    panel.value,
+    ...Array.from(
+      panel.value?.querySelectorAll(
+        'textarea, input, select, button, [href], [tabindex]:not([tabindex="-1"])',
+      ) || [],
+    ),
+  ].filter((el) => el && !el.disabled)
+  if (!items.length) return
+  const first = items[0]
+  const last = items[items.length - 1]
+  if (e.shiftKey && document.activeElement === first) {
+    e.preventDefault()
+    last.focus()
+  } else if (!e.shiftKey && document.activeElement === last) {
+    e.preventDefault()
+    first.focus()
+  }
+}
+
+watch(
+  () => props.open,
+  (open) => {
+    window[open ? 'addEventListener' : 'removeEventListener']('keydown', onKeydown)
+    if (open)
+      nextTick(() =>
+        (props.focus === 'input' ? panel.value?.querySelector('input') : panel.value)?.focus(),
+      )
+  },
+)
+
+onUnmounted(() => window.removeEventListener('keydown', onKeydown))
+
+defineExpose({ panel })
+</script>
+
+<template>
+  <div
+    v-if="open"
+    class="fixed inset-0 z-50 flex items-end justify-center bg-ink/50 p-4 sm:items-center"
+    @click.self="$emit('close')"
+  >
+    <div
+      ref="panel"
+      role="dialog"
+      aria-modal="true"
+      :aria-labelledby="labelledby"
+      tabindex="-1"
+      class="w-full max-w-md rounded-3xl bg-paper p-6 focus:outline-none"
+    >
+      <slot />
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/ChequeDialog.vue
+++ b/frontend/src/components/ChequeDialog.vue
@@ -9,8 +9,8 @@ const JPEG_QUALITY = 0.8
 const NUMBER_MAX = 30
 const SAVE_TIMEOUT_MS = 30000 // a stalled request must not trap the dialog, since close is blocked while saving
 
-// `target` is { customer, customer_name, invoices, outstanding } or null. An empty `invoices`
-// records the cheque on account, against no invoice.
+// `target` is { customer, customer_name, invoices: [{name, amount}], outstanding } or null. An
+// empty `invoices` records the cheque on account, against no invoice.
 const props = defineProps({ target: { type: Object, default: null } })
 const emit = defineEmits(['close', 'recorded'])
 
@@ -23,11 +23,17 @@ const saving = ref(false)
 const done = ref(false)
 const error = ref('')
 
-const invoiceCount = computed(() => props.target?.invoices?.length || 0)
+const invoices = computed(() => props.target?.invoices || [])
+const onAccount = computed(() => invoices.value.length === 0)
+// Nothing ticked means "attach nothing", never "the whole balance" — the confirm screen spells
+// this out, so the wording here stays neutral about what it settles.
 const covers = computed(() =>
-  invoiceCount.value
-    ? `${invoiceCount.value} invoice${invoiceCount.value === 1 ? '' : 's'}`
-    : 'On account',
+  onAccount.value
+    ? 'On account'
+    : `${invoices.value.length} invoice${invoices.value.length === 1 ? '' : 's'} selected`,
+)
+const settles = computed(() =>
+  onAccount.value ? 'No invoice' : `${invoices.value.length} invoice${invoices.value.length === 1 ? '' : 's'}`,
 )
 const amountValue = computed(() => Number(amount.value) || 0)
 const canReview = computed(() => Boolean(photo.value) && amountValue.value > 0 && Boolean(number.value.trim()))
@@ -89,6 +95,7 @@ async function save() {
   // Capture the target before awaiting: it is what we record and emit, and it must not change
   // under us if the dialog is reopened for another invoice mid-save.
   const target = props.target
+  const names = (target.invoices || []).map((inv) => inv.name)
   saving.value = true
   error.value = ''
   try {
@@ -97,7 +104,7 @@ async function save() {
       amount: amountValue.value,
       chequeNo: number.value.trim(),
       photo: photo.value,
-      invoices: target.invoices || [],
+      invoices: names,
     })
     // Bound the wait: a hung request would otherwise leave saving true forever, and close is
     // blocked while saving. On timeout we cannot know the outcome, so tell them to check first.
@@ -108,11 +115,7 @@ async function save() {
     done.value = true
     // covered maps each invoice to the amount this cheque put against it, so the card shows the
     // real figure rather than a placeholder.
-    emit('recorded', {
-      invoices: target.invoices || [],
-      amount: amountValue.value,
-      covered: res?.covered || {},
-    })
+    emit('recorded', { invoices: names, amount: amountValue.value, covered: res?.covered || {} })
   } catch (e) {
     error.value = e?.timedOut
       ? 'That took too long. Check the invoice before recording it again.'
@@ -139,50 +142,76 @@ watch(
 </script>
 
 <template>
-  <BaseDialog
-    :open="Boolean(target)"
-    labelledby="cheque-title"
-    focus="panel"
-    @close="onClose"
-  >
-    <h2 id="cheque-title" class="font-display text-lg font-bold text-ink">
-      {{ done ? 'Cheque recorded' : reviewing ? 'Check this is right' : 'Collect a cheque' }}
-    </h2>
-    <p class="mt-0.5 truncate text-sm text-ink/60">{{ target?.customer_name }} · {{ covers }}</p>
-
-    <!-- Recorded: say plainly that no money has moved yet, so nobody treats it as paid. -->
+  <BaseDialog :open="Boolean(target)" labelledby="cheque-title" focus="panel" @close="onClose">
+    <!-- Recorded: the app's success screen, reworded — it says recorded, never paid. -->
     <template v-if="done">
-      <p class="mt-4 rounded-xl bg-paper p-4 text-sm text-ink/80">
-        {{ formatKES(amountValue) }} — cheque {{ number }}. Accounts will bank it and confirm the
-        payment. The invoice stays open until it clears.
+      <div class="mx-auto grid h-14 w-14 place-items-center rounded-full bg-landed/15 text-2xl text-landed">
+        ✓
+      </div>
+      <h2 id="cheque-title" class="mt-3 text-center font-display text-lg font-bold text-ink">
+        Cheque recorded
+      </h2>
+      <p class="text-center text-sm text-ink/60">Sent to accounts to bank and submit</p>
+      <p class="mt-2 text-center font-mono text-3xl font-semibold tabular-nums text-landed">
+        {{ formatKES(amountValue) }}
+      </p>
+      <p class="mt-1 text-center text-sm text-ink/60">
+        Cheque {{ number }} · {{ target?.customer_name }}
       </p>
       <button
         type="button"
-        class="mt-4 h-12 w-full rounded-xl bg-ink font-semibold text-white"
+        class="mt-5 h-12 w-full rounded-xl bg-ink font-semibold text-white"
         @click="$emit('close')"
       >
         Done
       </button>
     </template>
 
+    <!-- Confirm: the only irreversible step, and it reads differently for each mode. -->
     <template v-else-if="reviewing">
-      <img :src="photo" alt="The cheque photo" class="mt-4 max-h-40 w-full rounded-xl object-contain" />
-      <dl class="mt-3 divide-y divide-hairline rounded-xl bg-paper px-3">
-        <div class="flex justify-between gap-3 py-2.5">
-          <dt class="text-sm text-ink/60">Amount</dt>
-          <dd class="font-mono text-base font-semibold tabular-nums text-ink">
-            {{ formatKES(amountValue) }}
-          </dd>
+      <p class="text-[11px] font-bold uppercase tracking-wider text-ink/50">Confirm</p>
+      <h2 id="cheque-title" class="mt-0.5 truncate font-display text-lg font-bold text-ink">
+        {{ target?.customer_name }}
+      </h2>
+      <p class="mt-1 font-mono text-2xl font-semibold tabular-nums text-ink">{{ formatKES(amountValue) }}</p>
+
+      <dl class="mt-4 rounded-xl bg-white px-3">
+        <div class="flex justify-between gap-3 border-b border-hairline py-2.5 text-sm">
+          <dt class="text-ink/60">Cheque number</dt>
+          <dd class="font-mono font-semibold text-ink">{{ number }}</dd>
         </div>
-        <div class="flex justify-between gap-3 py-2.5">
-          <dt class="text-sm text-ink/60">Cheque number</dt>
-          <dd class="font-mono text-sm font-semibold text-ink">{{ number }}</dd>
+        <div class="flex justify-between gap-3 border-b border-hairline py-2.5 text-sm">
+          <dt class="text-ink/60">Banked to</dt>
+          <dd class="font-medium text-ink">Undeposited Cheque</dd>
         </div>
-        <div class="flex justify-between gap-3 py-2.5">
-          <dt class="text-sm text-ink/60">Covers</dt>
-          <dd class="text-sm font-medium text-ink">{{ covers }}</dd>
+        <div class="flex justify-between gap-3 py-2.5 text-sm">
+          <dt class="text-ink/60">Settles</dt>
+          <dd class="font-medium text-ink">{{ settles }}</dd>
         </div>
       </dl>
+
+      <div v-if="!onAccount" class="mt-2 rounded-xl bg-white px-3">
+        <div
+          v-for="inv in invoices"
+          :key="inv.name"
+          class="flex justify-between gap-3 border-b border-hairline py-2 text-sm last:border-0"
+        >
+          <span class="truncate font-mono text-ink/70">{{ inv.name }}</span>
+          <span class="shrink-0 font-mono font-semibold tabular-nums text-ink">{{ formatKES(inv.amount) }}</span>
+        </div>
+      </div>
+
+      <p v-if="onAccount" class="mt-3 rounded-xl bg-ink/5 px-3 py-2.5 text-xs text-ink/70">
+        Recorded against the customer only. Accounts will decide which invoices it settles.
+      </p>
+      <p class="mt-2 rounded-xl bg-owed/10 px-3 py-2.5 text-xs font-medium text-owed">
+        {{
+          onAccount
+            ? 'Saved as a draft. Nothing is marked paid until accounts submits it.'
+            : 'Saved as a draft. These invoices stay outstanding until accounts submits it.'
+        }}
+      </p>
+
       <p v-if="error" class="mt-2 text-sm text-danger">{{ error }}</p>
       <div class="mt-4 flex gap-2">
         <button
@@ -201,12 +230,21 @@ watch(
           :aria-busy="saving"
           @click="save"
         >
-          {{ saving ? 'Recording…' : 'Record cheque' }}
+          {{ saving ? 'Saving…' : 'Save for accounts' }}
         </button>
       </div>
     </template>
 
+    <!-- Capture: photo, amount and number on one screen — no branching or server call between. -->
     <template v-else>
+      <p class="text-[11px] font-bold uppercase tracking-wider text-ink/50">Cheque collection</p>
+      <h2 id="cheque-title" class="mt-0.5 truncate font-display text-lg font-bold text-ink">
+        {{ target?.customer_name }}
+      </h2>
+      <p class="mt-0.5 truncate text-sm text-ink/60">
+        {{ covers }}<template v-if="target?.outstanding"> · {{ formatKES(target.outstanding) }}</template>
+      </p>
+
       <button
         v-if="!photo"
         type="button"
@@ -243,7 +281,7 @@ watch(
       <input ref="fileInput" type="file" accept="image/*" capture="environment" class="sr-only" @change="onPick" />
 
       <label class="mt-3 block text-xs font-semibold text-ink/60" for="cheque-amount">
-        Amount on the cheque
+        Cheque amount
       </label>
       <input
         id="cheque-amount"
@@ -254,7 +292,10 @@ watch(
         placeholder="0"
         class="mt-1 h-12 w-full rounded-xl border border-hairline bg-white px-3 font-mono text-base tabular-nums text-ink focus:border-ink focus:outline-none focus:ring-2 focus:ring-ink/20"
       />
-      <p v-if="target?.outstanding" class="mt-1 text-xs text-ink/50">
+      <p v-if="amountValue > 0" class="mt-1 font-mono text-xs tabular-nums text-ink/50">
+        {{ formatKES(amountValue) }}
+      </p>
+      <p v-else-if="target?.outstanding" class="mt-1 text-xs text-ink/50">
         Outstanding {{ formatKES(target.outstanding) }} — enter what the cheque says.
       </p>
 
@@ -272,14 +313,13 @@ watch(
       />
 
       <p v-if="error" class="mt-2 text-sm text-danger">{{ error }}</p>
-
       <div class="mt-4 flex gap-2">
         <button
           type="button"
           class="h-12 shrink-0 rounded-xl border border-hairline px-5 font-medium text-ink"
           @click="$emit('close')"
         >
-          Cancel
+          Close
         </button>
         <button
           type="button"
@@ -287,7 +327,7 @@ watch(
           :disabled="!canReview"
           @click="reviewing = true"
         >
-          Review
+          Continue
         </button>
       </div>
     </template>

--- a/frontend/src/components/ChequeDialog.vue
+++ b/frontend/src/components/ChequeDialog.vue
@@ -1,0 +1,231 @@
+<script setup>
+import { computed, ref, watch } from 'vue'
+import { recordCheque } from '@/data/collection'
+import { formatKES } from '@/utils/format'
+import BaseDialog from '@/components/BaseDialog.vue'
+
+const MAX_DIMENSION = 1600 // a phone photo is 3-8 MB; the cheque only has to be readable
+const JPEG_QUALITY = 0.8
+const NUMBER_MAX = 30
+
+// `target` is { customer, customer_name, invoices, outstanding } or null. An empty `invoices`
+// records the cheque on account, against no invoice.
+const props = defineProps({ target: { type: Object, default: null } })
+const emit = defineEmits(['close', 'recorded'])
+
+const photo = ref('') // downscaled data URL, exactly what the server stores
+const amount = ref('')
+const number = ref('')
+const reviewing = ref(false)
+const saving = ref(false)
+const done = ref(false)
+const error = ref('')
+
+const invoiceCount = computed(() => props.target?.invoices?.length || 0)
+const covers = computed(() =>
+  invoiceCount.value
+    ? `${invoiceCount.value} invoice${invoiceCount.value === 1 ? '' : 's'}`
+    : 'On account',
+)
+const amountValue = computed(() => Number(amount.value) || 0)
+const canReview = computed(() => Boolean(photo.value) && amountValue.value > 0 && Boolean(number.value.trim()))
+
+// Shrink in the browser: a full-size photo would blow the upload cap and a slow line.
+function downscale(file) {
+  return new Promise((resolve, reject) => {
+    const image = new Image()
+    image.onerror = () => reject(new Error('unreadable'))
+    image.onload = () => {
+      const scale = Math.min(1, MAX_DIMENSION / Math.max(image.width, image.height))
+      const canvas = document.createElement('canvas')
+      canvas.width = Math.round(image.width * scale)
+      canvas.height = Math.round(image.height * scale)
+      canvas.getContext('2d').drawImage(image, 0, 0, canvas.width, canvas.height)
+      resolve(canvas.toDataURL('image/jpeg', JPEG_QUALITY))
+      URL.revokeObjectURL(image.src)
+    }
+    image.src = URL.createObjectURL(file)
+  })
+}
+
+async function onPick(event) {
+  const file = event.target.files?.[0]
+  if (!file) return
+  error.value = ''
+  try {
+    photo.value = await downscale(file)
+  } catch {
+    error.value = "That photo couldn't be read. Try again."
+  }
+}
+
+async function save() {
+  if (saving.value) return
+  saving.value = true
+  error.value = ''
+  try {
+    await recordCheque({
+      customer: props.target.customer,
+      amount: amountValue.value,
+      chequeNo: number.value.trim(),
+      photo: photo.value,
+      invoices: props.target.invoices || [],
+    })
+    done.value = true
+    emit('recorded', { invoices: props.target.invoices || [], amount: amountValue.value })
+  } catch (e) {
+    error.value = e?.messages?.[0] || "Couldn't record the cheque."
+    reviewing.value = false // back to the form, with everything they typed still there
+  } finally {
+    saving.value = false
+  }
+}
+
+watch(
+  () => props.target,
+  () => {
+    photo.value = ''
+    amount.value = ''
+    number.value = ''
+    reviewing.value = false
+    saving.value = false
+    done.value = false
+    error.value = ''
+  },
+)
+</script>
+
+<template>
+  <BaseDialog
+    :open="Boolean(target)"
+    labelledby="cheque-title"
+    focus="panel"
+    @close="$emit('close')"
+  >
+    <h2 id="cheque-title" class="font-display text-lg font-bold text-ink">
+      {{ done ? 'Cheque recorded' : reviewing ? 'Check this is right' : 'Collect a cheque' }}
+    </h2>
+    <p class="mt-0.5 truncate text-sm text-ink/60">{{ target?.customer_name }} · {{ covers }}</p>
+
+    <!-- Recorded: say plainly that no money has moved yet, so nobody treats it as paid. -->
+    <template v-if="done">
+      <p class="mt-4 rounded-xl bg-paper p-4 text-sm text-ink/80">
+        {{ formatKES(amountValue) }} — cheque {{ number }}. Accounts will bank it and confirm the
+        payment. The invoice stays open until it clears.
+      </p>
+      <button
+        type="button"
+        class="mt-4 h-12 w-full rounded-xl bg-ink font-semibold text-white"
+        @click="$emit('close')"
+      >
+        Done
+      </button>
+    </template>
+
+    <template v-else-if="reviewing">
+      <img :src="photo" alt="The cheque photo" class="mt-4 max-h-40 w-full rounded-xl object-contain" />
+      <dl class="mt-3 divide-y divide-hairline rounded-xl bg-paper px-3">
+        <div class="flex justify-between gap-3 py-2.5">
+          <dt class="text-sm text-ink/60">Amount</dt>
+          <dd class="font-mono text-base font-semibold tabular-nums text-ink">
+            {{ formatKES(amountValue) }}
+          </dd>
+        </div>
+        <div class="flex justify-between gap-3 py-2.5">
+          <dt class="text-sm text-ink/60">Cheque number</dt>
+          <dd class="font-mono text-sm font-semibold text-ink">{{ number }}</dd>
+        </div>
+        <div class="flex justify-between gap-3 py-2.5">
+          <dt class="text-sm text-ink/60">Covers</dt>
+          <dd class="text-sm font-medium text-ink">{{ covers }}</dd>
+        </div>
+      </dl>
+      <p v-if="error" class="mt-2 text-sm text-danger">{{ error }}</p>
+      <div class="mt-4 flex gap-2">
+        <button
+          type="button"
+          class="h-12 shrink-0 rounded-xl border border-hairline px-5 font-medium text-ink"
+          :disabled="saving"
+          @click="reviewing = false"
+        >
+          Back
+        </button>
+        <!-- Never bg-mpesa: green is the M-Pesa rail, and no money moves here. -->
+        <button
+          type="button"
+          class="h-12 flex-1 rounded-xl bg-ink font-semibold text-white disabled:opacity-40"
+          :disabled="saving"
+          :aria-busy="saving"
+          @click="save"
+        >
+          {{ saving ? 'Recording…' : 'Record cheque' }}
+        </button>
+      </div>
+    </template>
+
+    <template v-else>
+      <label
+        class="mt-4 grid h-32 w-full cursor-pointer place-items-center overflow-hidden rounded-xl border border-dashed border-hairline bg-paper text-sm font-medium text-ink/60"
+      >
+        <img v-if="photo" :src="photo" alt="The cheque photo" class="h-full w-full object-contain" />
+        <span v-else class="flex flex-col items-center gap-1">
+          <svg viewBox="0 0 24 24" class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="1.6">
+            <path d="M3 8.5h4L8.5 6h7L17 8.5h4v10H3z" stroke-linejoin="round" />
+            <circle cx="12" cy="13" r="3.2" />
+          </svg>
+          Photograph the cheque
+        </span>
+        <input type="file" accept="image/*" capture="environment" class="sr-only" @change="onPick" />
+      </label>
+
+      <label class="mt-3 block text-xs font-semibold text-ink/60" for="cheque-amount">
+        Amount on the cheque
+      </label>
+      <input
+        id="cheque-amount"
+        v-model="amount"
+        type="number"
+        inputmode="decimal"
+        min="0"
+        placeholder="0"
+        class="mt-1 h-12 w-full rounded-xl border border-hairline bg-white px-3 font-mono text-base tabular-nums text-ink focus:border-ink focus:outline-none focus:ring-2 focus:ring-ink/20"
+      />
+      <p v-if="target?.outstanding" class="mt-1 text-xs text-ink/50">
+        Outstanding {{ formatKES(target.outstanding) }} — enter what the cheque says.
+      </p>
+
+      <label class="mt-3 block text-xs font-semibold text-ink/60" for="cheque-number">
+        Cheque number
+      </label>
+      <input
+        id="cheque-number"
+        v-model="number"
+        type="text"
+        inputmode="numeric"
+        :maxlength="NUMBER_MAX"
+        placeholder="001894"
+        class="mt-1 h-12 w-full rounded-xl border border-hairline bg-white px-3 font-mono text-base text-ink focus:border-ink focus:outline-none focus:ring-2 focus:ring-ink/20"
+      />
+
+      <p v-if="error" class="mt-2 text-sm text-danger">{{ error }}</p>
+
+      <div class="mt-4 flex gap-2">
+        <button
+          type="button"
+          class="h-12 shrink-0 rounded-xl border border-hairline px-5 font-medium text-ink"
+          @click="$emit('close')"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          class="h-12 flex-1 rounded-xl bg-ink font-semibold text-white disabled:opacity-40"
+          :disabled="!canReview"
+          @click="reviewing = true"
+        >
+          Review
+        </button>
+      </div>
+    </template>
+  </BaseDialog>
+</template>

--- a/frontend/src/components/ChequeDialog.vue
+++ b/frontend/src/components/ChequeDialog.vue
@@ -14,6 +14,7 @@ const props = defineProps({ target: { type: Object, default: null } })
 const emit = defineEmits(['close', 'recorded'])
 
 const photo = ref('') // downscaled data URL, exactly what the server stores
+const fileInput = ref(null)
 const amount = ref('')
 const number = ref('')
 const reviewing = ref(false)
@@ -48,8 +49,24 @@ function downscale(file) {
   })
 }
 
+function pickPhoto() {
+  fileInput.value?.click()
+}
+
+function clearFileInput() {
+  // Reset the input so choosing the same file again still fires change.
+  if (fileInput.value) fileInput.value.value = ''
+}
+
+function removePhoto() {
+  photo.value = ''
+  error.value = ''
+  clearFileInput()
+}
+
 async function onPick(event) {
   const file = event.target.files?.[0]
+  clearFileInput()
   if (!file) return
   error.value = ''
   try {
@@ -101,6 +118,7 @@ watch(
   () => props.target,
   () => {
     photo.value = ''
+    clearFileInput()
     amount.value = ''
     number.value = ''
     reviewing.value = false
@@ -180,19 +198,40 @@ watch(
     </template>
 
     <template v-else>
-      <label
-        class="mt-4 grid h-32 w-full cursor-pointer place-items-center overflow-hidden rounded-xl border border-dashed border-hairline bg-paper text-sm font-medium text-ink/60"
+      <button
+        v-if="!photo"
+        type="button"
+        class="mt-4 grid h-32 w-full place-items-center rounded-xl border border-dashed border-hairline bg-paper text-sm font-medium text-ink/60"
+        @click="pickPhoto"
       >
-        <img v-if="photo" :src="photo" alt="The cheque photo" class="h-full w-full object-contain" />
-        <span v-else class="flex flex-col items-center gap-1">
+        <span class="flex flex-col items-center gap-1">
           <svg viewBox="0 0 24 24" class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="1.6">
             <path d="M3 8.5h4L8.5 6h7L17 8.5h4v10H3z" stroke-linejoin="round" />
             <circle cx="12" cy="13" r="3.2" />
           </svg>
           Photograph the cheque
         </span>
-        <input type="file" accept="image/*" capture="environment" class="sr-only" @change="onPick" />
-      </label>
+      </button>
+      <div v-else class="mt-4">
+        <img :src="photo" alt="The cheque photo" class="h-32 w-full rounded-xl border border-hairline bg-paper object-contain" />
+        <div class="mt-2 flex gap-2">
+          <button
+            type="button"
+            class="h-10 flex-1 rounded-xl border border-hairline text-sm font-medium text-ink"
+            @click="pickPhoto"
+          >
+            Retake
+          </button>
+          <button
+            type="button"
+            class="h-10 flex-1 rounded-xl border border-hairline text-sm font-medium text-danger"
+            @click="removePhoto"
+          >
+            Remove
+          </button>
+        </div>
+      </div>
+      <input ref="fileInput" type="file" accept="image/*" capture="environment" class="sr-only" @change="onPick" />
 
       <label class="mt-3 block text-xs font-semibold text-ink/60" for="cheque-amount">
         Amount on the cheque

--- a/frontend/src/components/ChequeDialog.vue
+++ b/frontend/src/components/ChequeDialog.vue
@@ -59,20 +59,30 @@ async function onPick(event) {
   }
 }
 
+// A record in flight must never be abandoned: closing here would strand the cheque with no
+// marker and the driver would re-prompt for money already collected.
+function onClose() {
+  if (saving.value) return
+  emit('close')
+}
+
 async function save() {
   if (saving.value) return
+  // Capture the target before awaiting: it is what we record and emit, and it must not change
+  // under us if the dialog is reopened for another invoice mid-save.
+  const target = props.target
   saving.value = true
   error.value = ''
   try {
     await recordCheque({
-      customer: props.target.customer,
+      customer: target.customer,
       amount: amountValue.value,
       chequeNo: number.value.trim(),
       photo: photo.value,
-      invoices: props.target.invoices || [],
+      invoices: target.invoices || [],
     })
     done.value = true
-    emit('recorded', { invoices: props.target.invoices || [], amount: amountValue.value })
+    emit('recorded', { invoices: target.invoices || [], amount: amountValue.value })
   } catch (e) {
     error.value = e?.messages?.[0] || "Couldn't record the cheque."
     reviewing.value = false // back to the form, with everything they typed still there
@@ -100,7 +110,7 @@ watch(
     :open="Boolean(target)"
     labelledby="cheque-title"
     focus="panel"
-    @close="$emit('close')"
+    @close="onClose"
   >
     <h2 id="cheque-title" class="font-display text-lg font-bold text-ink">
       {{ done ? 'Cheque recorded' : reviewing ? 'Check this is right' : 'Collect a cheque' }}

--- a/frontend/src/components/ChequeDialog.vue
+++ b/frontend/src/components/ChequeDialog.vue
@@ -7,6 +7,7 @@ import BaseDialog from '@/components/BaseDialog.vue'
 const MAX_DIMENSION = 1600 // a phone photo is 3-8 MB; the cheque only has to be readable
 const JPEG_QUALITY = 0.8
 const NUMBER_MAX = 30
+const SAVE_TIMEOUT_MS = 30000 // a stalled request must not trap the dialog, since close is blocked while saving
 
 // `target` is { customer, customer_name, invoices, outstanding } or null. An empty `invoices`
 // records the cheque on account, against no invoice.
@@ -91,13 +92,19 @@ async function save() {
   saving.value = true
   error.value = ''
   try {
-    const res = await recordCheque({
+    const record = recordCheque({
       customer: target.customer,
       amount: amountValue.value,
       chequeNo: number.value.trim(),
       photo: photo.value,
       invoices: target.invoices || [],
     })
+    // Bound the wait: a hung request would otherwise leave saving true forever, and close is
+    // blocked while saving. On timeout we cannot know the outcome, so tell them to check first.
+    const res = await Promise.race([
+      record,
+      new Promise((_, reject) => setTimeout(() => reject({ timedOut: true }), SAVE_TIMEOUT_MS)),
+    ])
     done.value = true
     // covered maps each invoice to the amount this cheque put against it, so the card shows the
     // real figure rather than a placeholder.
@@ -107,7 +114,9 @@ async function save() {
       covered: res?.covered || {},
     })
   } catch (e) {
-    error.value = e?.messages?.[0] || "Couldn't record the cheque."
+    error.value = e?.timedOut
+      ? 'That took too long. Check the invoice before recording it again.'
+      : e?.messages?.[0] || "Couldn't record the cheque."
     reviewing.value = false // back to the form, with everything they typed still there
   } finally {
     saving.value = false

--- a/frontend/src/components/ChequeDialog.vue
+++ b/frontend/src/components/ChequeDialog.vue
@@ -74,7 +74,7 @@ async function save() {
   saving.value = true
   error.value = ''
   try {
-    await recordCheque({
+    const res = await recordCheque({
       customer: target.customer,
       amount: amountValue.value,
       chequeNo: number.value.trim(),
@@ -82,7 +82,13 @@ async function save() {
       invoices: target.invoices || [],
     })
     done.value = true
-    emit('recorded', { invoices: target.invoices || [], amount: amountValue.value })
+    // covered maps each invoice to the amount this cheque put against it, so the card shows the
+    // real figure rather than a placeholder.
+    emit('recorded', {
+      invoices: target.invoices || [],
+      amount: amountValue.value,
+      covered: res?.covered || {},
+    })
   } catch (e) {
     error.value = e?.messages?.[0] || "Couldn't record the cheque."
     reviewing.value = false // back to the form, with everything they typed still there

--- a/frontend/src/components/ChequeDueBanner.vue
+++ b/frontend/src/components/ChequeDueBanner.vue
@@ -1,0 +1,76 @@
+<script setup>
+import { formatKES } from '@/utils/format'
+
+// Cheques accounts have flagged to collect. Two shapes, one banner:
+//  - `dues` (a list): the collect-list banner — each customer is a link into their page.
+//  - `due` (one object): the customer-page notice, with a button to collect it right now.
+// Renders nothing when there is neither, so callers can drop it in unconditionally.
+defineProps({
+  dues: { type: Array, default: () => [] },
+  due: { type: Object, default: null },
+  // Routing context for the list links — the same the customer cards are built from.
+  routeName: { type: String, default: 'Customer' },
+  driver: { type: String, default: '' },
+  paymentTerm: { type: String, default: '' },
+  salesPerson: { type: String, default: '' },
+})
+defineEmits(['collect'])
+</script>
+
+<template>
+  <!-- List mode: the cheques routed here, each a link into the customer. -->
+  <div v-if="dues.length" class="rounded-2xl border border-owed/30 bg-owed/10 px-3 py-3">
+    <p class="flex items-center gap-2 font-mono text-xs font-bold uppercase tracking-wide text-owed">
+      <span class="grid h-[18px] min-w-[18px] place-items-center rounded-full bg-owed px-1.5 text-[11px] text-white">
+        {{ dues.length }}
+      </span>
+      Cheque{{ dues.length === 1 ? '' : 's' }} to collect
+    </p>
+    <div class="mt-2 flex flex-col gap-2">
+      <router-link
+        v-for="d in dues"
+        :key="d.name"
+        :to="{
+          name: routeName,
+          params: { customer: d.customer },
+          query: {
+            ...(driver ? { driver } : {}),
+            ...(paymentTerm ? { payment_term: paymentTerm } : {}),
+            ...(salesPerson ? { sales_person: salesPerson } : {}),
+          },
+        }"
+        class="flex items-center justify-between gap-3 rounded-xl border border-owed/20 bg-white/70 px-3 py-2 transition-colors active:bg-white"
+      >
+        <span class="min-w-0 flex-1 truncate text-[13px] font-semibold text-ink">
+          {{ d.customer_name || d.customer }}
+        </span>
+        <span class="flex shrink-0 items-center gap-2">
+          <span class="font-mono text-xs font-semibold tabular-nums text-owed">
+            {{ d.expected_amount ? formatKES(d.expected_amount) : 'amount TBC' }}
+          </span>
+          <svg viewBox="0 0 20 20" class="h-4 w-4 text-owed/70" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="m7.5 5 5 5-5 5" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </span>
+      </router-link>
+    </div>
+  </div>
+
+  <!-- Customer mode: the single flagged cheque, with the collect action. -->
+  <div v-else-if="due" class="rounded-2xl border border-owed/30 bg-owed/10 px-4 py-3">
+    <p class="font-mono text-xs font-bold uppercase tracking-wide text-owed">Accounts flagged a cheque</p>
+    <p v-if="due.expected_amount || due.notes" class="mt-1.5 text-[13px] leading-relaxed text-owed">
+      <template v-if="due.expected_amount">
+        Expected <span class="font-mono font-semibold tabular-nums">{{ formatKES(due.expected_amount) }}</span>.
+      </template>
+      <span v-if="due.notes" class="opacity-90">{{ due.notes }}</span>
+    </p>
+    <button
+      type="button"
+      class="mt-2.5 h-11 w-full rounded-xl bg-ink text-sm font-semibold text-paper transition active:scale-[.98]"
+      @click="$emit('collect')"
+    >
+      Collect the cheque
+    </button>
+  </div>
+</template>

--- a/frontend/src/components/CollectBar.vue
+++ b/frontend/src/components/CollectBar.vue
@@ -14,8 +14,9 @@ defineProps({
   mpesaMax: { type: Number, default: 0 },
   collectError: Boolean,
   showTickHint: Boolean,
+  showCheque: Boolean, // cheque collection is offered even where bundling is not
 })
-defineEmits(['collect', 'clear'])
+defineEmits(['collect', 'clear', 'cheque'])
 </script>
 
 <template>
@@ -53,4 +54,13 @@ defineEmits(['collect', 'clear'])
   <p v-if="showTickHint" class="-mt-2 px-1 text-xs text-ink/60">
     Tick invoices to collect only some.
   </p>
+  <!-- Deliberately quiet: cheques are the exception, and M-Pesa stays the obvious action. -->
+  <button
+    v-if="showCheque"
+    type="button"
+    class="h-11 rounded-xl border border-hairline bg-white text-sm font-medium text-ink/70 transition active:bg-paper"
+    @click="$emit('cheque')"
+  >
+    {{ selectedCount ? `Cheque for ${selectedCount} — ${formatKES(selectedTotal)}` : 'Collect a cheque' }}
+  </button>
 </template>

--- a/frontend/src/components/CollectBar.vue
+++ b/frontend/src/components/CollectBar.vue
@@ -15,6 +15,7 @@ defineProps({
   collectError: Boolean,
   showTickHint: Boolean,
   showCheque: Boolean, // cheque collection is offered even where bundling is not
+  chequePerInvoice: Boolean, // off: the cheque is customer-level, so the label never names invoices
 })
 defineEmits(['collect', 'clear', 'cheque'])
 </script>
@@ -61,6 +62,6 @@ defineEmits(['collect', 'clear', 'cheque'])
     class="h-11 rounded-xl border border-hairline bg-white text-sm font-medium text-ink/70 transition active:bg-paper"
     @click="$emit('cheque')"
   >
-    {{ selectedCount ? `Cheque for ${selectedCount} — ${formatKES(selectedTotal)}` : 'Collect a cheque' }}
+    {{ selectedCount && chequePerInvoice ? `Cheque for ${selectedCount} — ${formatKES(selectedTotal)}` : 'Collect a cheque' }}
   </button>
 </template>

--- a/frontend/src/components/CustomerListShell.vue
+++ b/frontend/src/components/CustomerListShell.vue
@@ -1,6 +1,7 @@
 <script setup>
 import RoundHeader from '@/components/RoundHeader.vue'
 import CustomerCard from '@/components/CustomerCard.vue'
+import ChequeDueBanner from '@/components/ChequeDueBanner.vue'
 import ErrorRetry from '@/components/ErrorRetry.vue'
 
 // The shared customer-list screen (field /collect and internal /collect/internal): title,
@@ -24,6 +25,7 @@ defineProps({
   cardDriver: { type: String, default: '' },
   cardPaymentTerm: { type: String, default: '' },
   cardSalesPerson: { type: String, default: '' },
+  chequeDues: { type: Array, default: () => [] }, // cheques accounts flagged to collect here
 })
 defineEmits(['retry'])
 </script>
@@ -46,6 +48,15 @@ defineEmits(['retry'])
     <div class="flex flex-col gap-2 sm:flex-row">
       <slot name="filters" />
     </div>
+
+    <!-- Cheques accounts flagged to collect — links into each customer's page. -->
+    <ChequeDueBanner
+      :dues="chequeDues"
+      :route-name="cardRouteName"
+      :driver="cardDriver"
+      :payment-term="cardPaymentTerm"
+      :sales-person="cardSalesPerson"
+    />
 
     <div v-if="listLoading" class="grid grid-cols-1 gap-3 md:grid-cols-2">
       <div v-for="n in 6" :key="n" class="h-20 animate-pulse rounded-xl bg-ink/5" />

--- a/frontend/src/components/InvoiceCard.vue
+++ b/frontend/src/components/InvoiceCard.vue
@@ -125,7 +125,7 @@ async function payViaIpay() {
          would take the money twice — the actions go away entirely until accounts clear it. -->
     <p
       v-if="invoice.awaiting_cheque"
-      class="mt-2 flex items-center gap-2 rounded-xl bg-ink/5 px-3 py-2.5 text-[13px] font-medium text-ink/75"
+      class="mt-2 flex items-center gap-2 rounded-xl bg-owed/10 px-3 py-2.5 text-[13px] font-medium text-owed"
     >
       <svg viewBox="0 0 20 20" class="h-4 w-4 shrink-0" fill="none" stroke="currentColor" stroke-width="1.7">
         <rect x="2.5" y="5" width="15" height="10" rx="1.5" />

--- a/frontend/src/components/InvoiceCard.vue
+++ b/frontend/src/components/InvoiceCard.vue
@@ -11,7 +11,7 @@ const props = defineProps({
   actionsDisabled: Boolean,
   mpesaMax: { type: Number, default: 0 }, // M-Pesa ceiling; 0 = no cap
 })
-defineEmits(['prompt', 'toggle-select', 'notes'])
+defineEmits(['prompt', 'toggle-select', 'notes', 'cheque'])
 
 const checkoutBusy = ref(false)
 
@@ -114,30 +114,53 @@ async function payViaIpay() {
       </span>
     </button>
 
-    <div class="mt-2 flex gap-2">
-      <button
-        v-if="!mpesaBlocked"
-        type="button"
-        class="h-12 flex-1 rounded-xl bg-mpesa font-semibold text-white transition active:scale-[.98] disabled:opacity-40"
-        :disabled="actionsDisabled"
-        @click="$emit('prompt')"
-      >
-        Prompt M-Pesa
-      </button>
-      <button
-        v-if="enableRedirect"
-        type="button"
-        class="h-12 flex-1 rounded-xl border border-hairline px-4 font-medium text-ink transition active:scale-[.98] disabled:opacity-40"
-        :disabled="actionsDisabled || checkoutBusy"
-        :aria-busy="checkoutBusy"
-        @click="payViaIpay"
-      >
-        {{ checkoutBusy ? 'Opening…' : 'Card / other' }}
-      </button>
-    </div>
-    <p v-if="mpesaBlocked" class="mt-2 text-xs text-owed">
-      M-Pesa isn't available over {{ formatKES(mpesaMax) }}.
-      {{ enableRedirect ? 'Use Card / other.' : 'Card checkout is off — contact the internal team.' }}
+    <!-- A cheque is recorded but not yet banked, so the invoice is still open. Charging it again
+         would take the money twice — the actions go away entirely until accounts clear it. -->
+    <p
+      v-if="invoice.awaiting_cheque"
+      class="mt-2 flex items-center gap-2 rounded-xl bg-ink/5 px-3 py-2.5 text-[13px] font-medium text-ink/75"
+    >
+      <svg viewBox="0 0 20 20" class="h-4 w-4 shrink-0" fill="none" stroke="currentColor" stroke-width="1.7">
+        <rect x="2.5" y="5" width="15" height="10" rx="1.5" />
+        <path d="M2.5 9h15" />
+      </svg>
+      Awaiting cheque — with accounts to bank.
     </p>
+
+    <template v-else>
+      <div class="mt-2 flex gap-2">
+        <button
+          v-if="!mpesaBlocked"
+          type="button"
+          class="h-12 flex-1 rounded-xl bg-mpesa font-semibold text-white transition active:scale-[.98] disabled:opacity-40"
+          :disabled="actionsDisabled"
+          @click="$emit('prompt')"
+        >
+          Prompt M-Pesa
+        </button>
+        <button
+          v-if="enableRedirect"
+          type="button"
+          class="h-12 flex-1 rounded-xl border border-hairline px-4 font-medium text-ink transition active:scale-[.98] disabled:opacity-40"
+          :disabled="actionsDisabled || checkoutBusy"
+          :aria-busy="checkoutBusy"
+          @click="payViaIpay"
+        >
+          {{ checkoutBusy ? 'Opening…' : 'Card / other' }}
+        </button>
+        <button
+          type="button"
+          class="h-12 shrink-0 rounded-xl border border-hairline px-4 text-sm font-medium text-ink/70 transition active:scale-[.98] disabled:opacity-40"
+          :disabled="actionsDisabled"
+          @click="$emit('cheque')"
+        >
+          Cheque
+        </button>
+      </div>
+      <p v-if="mpesaBlocked" class="mt-2 text-xs text-owed">
+        M-Pesa isn't available over {{ formatKES(mpesaMax) }}.
+        {{ enableRedirect ? 'Use Card / other.' : 'Card checkout is off — contact the internal team.' }}
+      </p>
+    </template>
   </article>
 </template>

--- a/frontend/src/components/InvoiceCard.vue
+++ b/frontend/src/components/InvoiceCard.vue
@@ -20,8 +20,8 @@ const mpesaBlocked = computed(
   () => props.mpesaMax > 0 && Number(props.invoice.outstanding_amount || 0) > props.mpesaMax,
 )
 
-// A cheque can cover part of an invoice. Prompting is still suppressed — charging the whole
-// balance would take the cheque's share twice — so the shortfall is named instead of hidden.
+// A cheque can cover part of an invoice; the whole invoice is held until accounts bank it, so
+// the notice names the balance that reopens then rather than implying it is collectable now.
 const chequeIsPartial = computed(
   () => Number(props.invoice.awaiting_cheque || 0) < Number(props.invoice.outstanding_amount || 0),
 )
@@ -133,8 +133,8 @@ async function payViaIpay() {
       <span>
         Cheque for {{ formatKES(invoice.awaiting_cheque) }} with accounts to bank.
         <template v-if="chequeIsPartial">
-          {{ formatKES(Number(invoice.outstanding_amount) - invoice.awaiting_cheque) }} of this
-          invoice is still owed — collect it with the rest of the round.
+          The {{ formatKES(Number(invoice.outstanding_amount) - invoice.awaiting_cheque) }} balance
+          reopens once they bank it.
         </template>
       </span>
     </p>

--- a/frontend/src/components/InvoiceCard.vue
+++ b/frontend/src/components/InvoiceCard.vue
@@ -6,6 +6,7 @@ import { startCheckout } from '@/data/collection'
 const props = defineProps({
   invoice: { type: Object, required: true },
   enableRedirect: Boolean,
+  allowCheque: Boolean,
   selectable: Boolean,
   selected: Boolean,
   actionsDisabled: Boolean,
@@ -161,6 +162,7 @@ async function payViaIpay() {
           {{ checkoutBusy ? 'Opening…' : 'Card / other' }}
         </button>
         <button
+          v-if="allowCheque"
           type="button"
           class="h-12 shrink-0 rounded-xl border border-hairline px-4 text-sm font-medium text-ink/70 transition active:scale-[.98] disabled:opacity-40"
           :disabled="actionsDisabled"

--- a/frontend/src/components/InvoiceCard.vue
+++ b/frontend/src/components/InvoiceCard.vue
@@ -20,6 +20,12 @@ const mpesaBlocked = computed(
   () => props.mpesaMax > 0 && Number(props.invoice.outstanding_amount || 0) > props.mpesaMax,
 )
 
+// A cheque can cover part of an invoice. Prompting is still suppressed — charging the whole
+// balance would take the cheque's share twice — so the shortfall is named instead of hidden.
+const chequeIsPartial = computed(
+  () => Number(props.invoice.awaiting_cheque || 0) < Number(props.invoice.outstanding_amount || 0),
+)
+
 // The row truncates the note visually; a screen reader gets the count and the note itself.
 const noteLabel = computed(() => {
   const count = props.invoice.note_count || 0
@@ -124,7 +130,13 @@ async function payViaIpay() {
         <rect x="2.5" y="5" width="15" height="10" rx="1.5" />
         <path d="M2.5 9h15" />
       </svg>
-      Awaiting cheque — with accounts to bank.
+      <span>
+        Cheque for {{ formatKES(invoice.awaiting_cheque) }} with accounts to bank.
+        <template v-if="chequeIsPartial">
+          {{ formatKES(Number(invoice.outstanding_amount) - invoice.awaiting_cheque) }} of this
+          invoice is still owed — collect it with the rest of the round.
+        </template>
+      </span>
     </p>
 
     <template v-else>

--- a/frontend/src/components/InvoiceCard.vue
+++ b/frontend/src/components/InvoiceCard.vue
@@ -7,6 +7,7 @@ const props = defineProps({
   invoice: { type: Object, required: true },
   enableRedirect: Boolean,
   allowCheque: Boolean,
+  chequePerInvoice: Boolean,
   selectable: Boolean,
   selected: Boolean,
   actionsDisabled: Boolean,
@@ -162,7 +163,7 @@ async function payViaIpay() {
           {{ checkoutBusy ? 'Opening…' : 'Card / other' }}
         </button>
         <button
-          v-if="allowCheque"
+          v-if="allowCheque && chequePerInvoice"
           type="button"
           class="h-12 shrink-0 rounded-xl border border-hairline px-4 text-sm font-medium text-ink/70 transition active:scale-[.98] disabled:opacity-40"
           :disabled="actionsDisabled"

--- a/frontend/src/components/NotesDialog.vue
+++ b/frontend/src/components/NotesDialog.vue
@@ -1,16 +1,15 @@
 <script setup>
-import { computed, nextTick, onUnmounted, ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { addInvoiceNote, fetchInvoiceNotes } from '@/data/collection'
 import { formatDateTime } from '@/utils/format'
+import BaseDialog from '@/components/BaseDialog.vue'
 
 const MAX = 500
 
-// `target` is { invoice, customer_name } or null — mirrors PromptDialog's null-able prop, which
-// is what arms and disarms the keydown listener below.
+// `target` is { invoice, customer_name } or null — null closes the dialog.
 const props = defineProps({ target: { type: Object, default: null } })
 const emit = defineEmits(['close', 'saved'])
 
-const dialogRef = ref(null)
 const notes = ref([])
 const draft = ref('')
 const loading = ref(false)
@@ -55,114 +54,67 @@ async function save() {
   }
 }
 
-// Close on Escape and trap Tab within the dialog. `textarea` matters here — PromptDialog's
-// selector omits it because it has none.
-function onKeydown(e) {
-  if (e.key === 'Escape') return emit('close')
-  if (e.key !== 'Tab') return
-  // The dialog itself leads the list: it holds focus on open, and querySelectorAll would
-  // only see its descendants — so Shift+Tab would otherwise land on the page behind.
-  const items = [
-    dialogRef.value,
-    ...Array.from(
-      dialogRef.value?.querySelectorAll(
-        'textarea, input, button, [href], [tabindex]:not([tabindex="-1"])',
-      ) || [],
-    ),
-  ].filter((el) => el && !el.disabled)
-  if (!items.length) return
-  const first = items[0]
-  const last = items[items.length - 1]
-  if (e.shiftKey && document.activeElement === first) {
-    e.preventDefault()
-    last.focus()
-  } else if (!e.shiftKey && document.activeElement === last) {
-    e.preventDefault()
-    first.focus()
-  }
-}
-
 watch(
   () => props.target,
   (target) => {
     draft.value = ''
     error.value = ''
     notes.value = []
-    window[target ? 'addEventListener' : 'removeEventListener']('keydown', onKeydown)
-    if (target) {
-      load()
-      // Focus the dialog, not the composer: autofocusing the field would scroll a phone past
-      // the notes the operator opened this to read.
-      nextTick(() => dialogRef.value?.focus())
-    }
+    if (target) load()
   },
 )
-
-onUnmounted(() => window.removeEventListener('keydown', onKeydown))
 </script>
 
 <template>
-  <div
-    v-if="target"
-    class="fixed inset-0 z-50 flex items-end justify-center bg-ink/50 p-4 sm:items-center"
-    @click.self="$emit('close')"
-  >
-    <div
-      ref="dialogRef"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="notes-title"
-      tabindex="-1"
-      class="w-full max-w-md rounded-3xl bg-paper p-6 focus:outline-none"
-    >
-      <h2 id="notes-title" class="font-display text-lg font-bold text-ink">Notes</h2>
-      <p class="mt-0.5 truncate text-sm text-ink/60">
-        {{ target.customer_name }} · {{ target.invoice }}
-      </p>
+  <!-- focus="panel": the operator opened this to READ; don't scroll them past the notes. -->
+  <BaseDialog :open="Boolean(target)" labelledby="notes-title" focus="panel" @close="$emit('close')">
+    <h2 id="notes-title" class="font-display text-lg font-bold text-ink">Notes</h2>
+    <p class="mt-0.5 truncate text-sm text-ink/60">
+      {{ target.customer_name }} · {{ target.invoice }}
+    </p>
 
-      <p v-if="loading" class="py-6 text-center text-sm text-ink/50">Loading…</p>
-      <div v-else-if="notes.length" class="mt-4 flex max-h-56 flex-col gap-2 overflow-y-auto">
-        <div v-for="note in notes" :key="note.name" class="rounded-xl bg-white p-3">
-          <div class="flex justify-between gap-2 text-[11px] font-semibold text-ink/55">
-            <span class="truncate">{{ note.author }}</span>
-            <span class="shrink-0">{{ formatDateTime(note.creation) }}</span>
-          </div>
-          <p class="mt-0.5 whitespace-pre-wrap break-words text-sm text-ink">{{ note.content }}</p>
+    <p v-if="loading" class="py-6 text-center text-sm text-ink/50">Loading…</p>
+    <div v-else-if="notes.length" class="mt-4 flex max-h-56 flex-col gap-2 overflow-y-auto">
+      <div v-for="note in notes" :key="note.name" class="rounded-xl bg-white p-3">
+        <div class="flex justify-between gap-2 text-[11px] font-semibold text-ink/55">
+          <span class="truncate">{{ note.author }}</span>
+          <span class="shrink-0">{{ formatDateTime(note.creation) }}</span>
         </div>
-      </div>
-      <p v-else class="py-6 text-center text-sm text-ink/50">No notes yet.</p>
-
-      <textarea
-        v-model="draft"
-        rows="3"
-        :maxlength="MAX"
-        aria-label="Add a note"
-        placeholder="Add a note about collecting this invoice…"
-        class="mt-4 w-full rounded-xl border border-hairline bg-white px-3 py-2 text-sm text-ink placeholder:text-ink/50 focus:border-mpesa focus:outline-none focus:ring-2 focus:ring-mpesa/40"
-      />
-      <p v-if="error" class="mt-2 text-sm text-danger">{{ error }}</p>
-
-      <div class="mt-3 flex items-center justify-between gap-3">
-        <span class="font-mono text-[11px] tabular-nums text-ink/50">{{ draft.length }} / {{ MAX }}</span>
-        <div class="flex gap-2">
-          <button
-            type="button"
-            class="h-11 rounded-xl border border-hairline bg-white px-4 font-medium text-ink"
-            @click="$emit('close')"
-          >
-            Close
-          </button>
-          <button
-            type="button"
-            class="h-11 rounded-xl bg-mpesa px-5 font-semibold text-white disabled:opacity-40"
-            :disabled="!canSave"
-            :aria-busy="saving"
-            @click="save"
-          >
-            {{ saving ? 'Saving…' : 'Save note' }}
-          </button>
-        </div>
+        <p class="mt-0.5 whitespace-pre-wrap break-words text-sm text-ink">{{ note.content }}</p>
       </div>
     </div>
-  </div>
+    <p v-else class="py-6 text-center text-sm text-ink/50">No notes yet.</p>
+
+    <textarea
+      v-model="draft"
+      rows="3"
+      :maxlength="MAX"
+      aria-label="Add a note"
+      placeholder="Add a note about collecting this invoice…"
+      class="mt-4 w-full rounded-xl border border-hairline bg-white px-3 py-2 text-sm text-ink placeholder:text-ink/50 focus:border-mpesa focus:outline-none focus:ring-2 focus:ring-mpesa/40"
+    />
+    <p v-if="error" class="mt-2 text-sm text-danger">{{ error }}</p>
+
+    <div class="mt-3 flex items-center justify-between gap-3">
+      <span class="font-mono text-[11px] tabular-nums text-ink/50">{{ draft.length }} / {{ MAX }}</span>
+      <div class="flex gap-2">
+        <button
+          type="button"
+          class="h-11 rounded-xl border border-hairline bg-white px-4 font-medium text-ink"
+          @click="$emit('close')"
+        >
+          Close
+        </button>
+        <button
+          type="button"
+          class="h-11 rounded-xl bg-mpesa px-5 font-semibold text-white disabled:opacity-40"
+          :disabled="!canSave"
+          :aria-busy="saving"
+          @click="save"
+        >
+          {{ saving ? 'Saving…' : 'Save note' }}
+        </button>
+      </div>
+    </div>
+  </BaseDialog>
 </template>

--- a/frontend/src/components/PromptDialog.vue
+++ b/frontend/src/components/PromptDialog.vue
@@ -7,6 +7,7 @@ import {
   saveCustomerContact,
 } from '@/data/collection'
 import { formatKES } from '@/utils/format'
+import BaseDialog from '@/components/BaseDialog.vue'
 
 // One M-Pesa STK prompt for a target (a single invoice or a bundle request). The number and
 // the amount are shown so the operator confirms both before charging. On success a "money
@@ -24,7 +25,7 @@ const busy = ref(false)
 const message = ref(null) // { tone, text }
 const paid = ref(false)
 const receipt = ref('')
-const dialogRef = ref(null)
+const doneRef = ref(null)
 let pollTimer = null
 let returnTimer = null
 
@@ -36,38 +37,19 @@ const toneBox = {
 }
 const waiting = computed(() => busy.value && message.value?.tone === 'info')
 
-// Close on Escape and trap Tab within the dialog (keyboard/AT users can't wander to the
-// page behind the modal). On the success screen, Escape acknowledges rather than abandons.
-function onKeydown(e) {
-  if (e.key === 'Escape') return paid.value ? finishPaid() : emit('close')
-  if (e.key !== 'Tab') return
-  const items = Array.from(
-    dialogRef.value?.querySelectorAll('input, button, [href], [tabindex]:not([tabindex="-1"])') || [],
-  ).filter((el) => !el.disabled)
-  if (!items.length) return
-  const first = items[0]
-  const last = items[items.length - 1]
-  if (e.shiftKey && document.activeElement === first) {
-    e.preventDefault()
-    last.focus()
-  } else if (!e.shiftKey && document.activeElement === last) {
-    e.preventDefault()
-    first.focus()
-  }
-}
+// On the success screen a dismiss acknowledges the payment rather than abandoning it.
+const onDismiss = () => (paid.value ? finishPaid() : emit('close'))
 
 watch(
   () => props.target,
-  (target) => {
-    phone.value = target?.phone || ''
+  () => {
+    phone.value = props.target?.phone || ''
     busy.value = false
     message.value = null
     paid.value = false
     receipt.value = ''
     stopPolling()
     clearReturn()
-    window[target ? 'addEventListener' : 'removeEventListener']('keydown', onKeydown)
-    if (target) nextTick(() => dialogRef.value?.querySelector('input')?.focus())
   },
 )
 
@@ -121,7 +103,7 @@ function startPolling(request) {
         receipt.value = state.detail || ''
         paid.value = true
         returnTimer = setTimeout(finishPaid, RETURN_AFTER_MS)
-        nextTick(() => dialogRef.value?.querySelector('button')?.focus())
+        nextTick(() => doneRef.value?.focus())
       } else if (state.partial) {
         settle('warn', state.detail || 'Paid, but the amount differs — the team will reconcile it.')
         emit('changed')
@@ -169,23 +151,11 @@ function clearReturn() {
 onUnmounted(() => {
   stopPolling()
   clearReturn()
-  window.removeEventListener('keydown', onKeydown)
 })
 </script>
 
 <template>
-  <div
-    v-if="target"
-    class="fixed inset-0 z-50 flex items-end justify-center bg-ink/50 p-4 sm:items-center"
-    @click.self="paid ? finishPaid() : $emit('close')"
-  >
-    <div
-      ref="dialogRef"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="prompt-title"
-      class="w-full max-w-md rounded-3xl bg-paper p-6"
-    >
+  <BaseDialog :open="Boolean(target)" labelledby="prompt-title" @close="onDismiss">
       <!-- Success: money received -->
       <div v-if="paid" class="text-center">
         <div class="mx-auto grid h-16 w-16 place-items-center rounded-full bg-landed/15">
@@ -207,6 +177,7 @@ onUnmounted(() => {
         </p>
         <p v-if="receipt" class="mx-auto mt-3 max-w-xs text-xs text-ink/60">{{ receipt }}</p>
         <button
+          ref="doneRef"
           type="button"
           class="mt-6 h-12 w-full rounded-xl bg-ink font-semibold text-paper transition active:scale-[.98]"
           @click="finishPaid"
@@ -266,7 +237,6 @@ onUnmounted(() => {
             {{ busy ? 'Waiting…' : 'Send prompt' }}
           </button>
         </div>
-      </template>
-    </div>
-  </div>
+    </template>
+  </BaseDialog>
 </template>

--- a/frontend/src/data/collection.js
+++ b/frontend/src/data/collection.js
@@ -20,6 +20,7 @@ const API = {
   saveContact: 'ipay.ipay.main.utils.ipay_redirect.save_customer_contact',
   invoiceNotes: 'ipay.ipay.main.utils.ipay_redirect.invoice_notes',
   addInvoiceNote: 'ipay.ipay.main.utils.ipay_redirect.add_invoice_note',
+  recordCheque: 'ipay.ipay.main.utils.ipay_redirect.record_cheque',
   paymentState: 'ipay.ipay.main.utils.ipay_redirect.payment_state',
   createBundle: 'ipay.ipay.main.utils.ipay_redirect.create_bundle',
   requestDetail: 'ipay.ipay.main.utils.ipay_redirect.request_detail',
@@ -109,6 +110,17 @@ export const saveCustomerContact = (request, phone) =>
 // Collection notes on an invoice — plain text; the server escapes on write and unescapes here.
 export const fetchInvoiceNotes = (invoice) => call(API.invoiceNotes, { invoice }, 'GET')
 export const addInvoiceNote = (invoice, note) => call(API.addInvoiceNote, { invoice, note })
+
+// A collected cheque becomes a DRAFT Payment Entry for the accounts team to submit. No invoices
+// records it on account. `photo` is a downscaled data URL; the server attaches it to the entry.
+export const recordCheque = ({ customer, amount, chequeNo, photo, invoices = [] }) =>
+  call(API.recordCheque, {
+    customer,
+    amount,
+    cheque_no: chequeNo,
+    photo,
+    invoices: JSON.stringify(invoices),
+  })
 
 export const paymentState = (request) => call(API.paymentState, { request }, 'GET')
 

--- a/frontend/src/pages/Collect.vue
+++ b/frontend/src/pages/Collect.vue
@@ -9,6 +9,7 @@ const route = useRoute()
 
 const customers = ref([])
 const drivers = ref([])
+const chequeDues = ref([])
 const listLoading = ref(true)
 const loadError = ref(false)
 
@@ -45,6 +46,7 @@ async function loadCustomers() {
     const data = await fetchCollectionCustomers(driver.value)
     customers.value = data.customers || []
     drivers.value = data.drivers || []
+    chequeDues.value = data.cheque_dues || []
   } catch {
     loadError.value = true
   } finally {
@@ -81,6 +83,7 @@ onMounted(refreshAll)
     :list-loading="listLoading"
     :load-error="loadError"
     :customers="filtered"
+    :cheque-dues="chequeDues"
     :empty-message="emptyMessage"
     :card-driver="driver"
     @retry="loadCustomers"

--- a/frontend/src/pages/CustomerDetail.vue
+++ b/frontend/src/pages/CustomerDetail.vue
@@ -2,11 +2,13 @@
 import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { createBundle, fetchCustomerCollection } from '@/data/collection'
+import { formatKES } from '@/utils/format'
 import { useResumeRefresh } from '@/composables/useResumeRefresh'
 import { useInvoiceSelection } from '@/composables/useInvoiceSelection'
 import InvoiceCard from '@/components/InvoiceCard.vue'
 import PromptDialog from '@/components/PromptDialog.vue'
 import NotesDialog from '@/components/NotesDialog.vue'
+import ChequeDialog from '@/components/ChequeDialog.vue'
 import CustomerMoneyHeader from '@/components/CustomerMoneyHeader.vue'
 import CollectBar from '@/components/CollectBar.vue'
 import ErrorRetry from '@/components/ErrorRetry.vue'
@@ -18,6 +20,7 @@ const driver = route.query.driver || '' // scope the detail to the driver picked
 
 const customerName = ref('')
 const invoices = ref([])
+const chequeOnAccount = ref(0)
 const enableRedirect = ref(false)
 const canBundle = ref(false)
 const mpesaMax = ref(0)
@@ -27,6 +30,7 @@ const creatingBundle = ref(false)
 const collectError = ref(false)
 const prompting = ref(null)
 const noting = ref(null)
+const chequing = ref(null)
 
 const { selected, isSelected, toggleSelect, clearSelection, dropSelected, selectedTotal } =
   useInvoiceSelection()
@@ -65,6 +69,7 @@ async function load() {
     enableRedirect.value = Boolean(data.enable_redirect)
     canBundle.value = Boolean(data.can_bundle)
     mpesaMax.value = data.mpesa_max || 0
+    chequeOnAccount.value = Number(data.cheque_on_account || 0)
   } catch {
     loadError.value = true
   } finally {
@@ -117,6 +122,20 @@ function onPaid(name) {
   if (!invoices.value.length) toList()
 }
 
+// A cheque covers the ticked invoices; nothing ticked records it against the customer instead.
+function chequeFor(names, outstanding) {
+  chequing.value = { customer, customer_name: customerName.value, invoices: names, outstanding }
+}
+
+// Mark the cards in place rather than reloading, which would clear the ticked set underneath.
+function onChequeRecorded({ invoices: names, amount }) {
+  if (!names.length) chequeOnAccount.value += amount
+  invoices.value.forEach((inv) => {
+    if (names.includes(inv.name)) inv.awaiting_cheque = true
+  })
+  clearSelection()
+}
+
 // Patch the card in place: reloading the list would clear a ticked bundle and reset paging.
 function onNoteSaved({ invoice, count, latest }) {
   const inv = invoices.value.find((i) => i.name === invoice)
@@ -155,9 +174,16 @@ onMounted(load)
         :mpesa-max="mpesaMax"
         :collect-error="collectError"
         :show-tick-hint="selectable && !selected.length"
+        :show-cheque="invoices.length > 0"
         @collect="collectNow"
         @clear="clearSelection"
+        @cheque="chequeFor(selected.map((i) => i.name), selected.length ? selectedTotal : total)"
       />
+
+      <p v-if="chequeOnAccount" class="-mt-2 rounded-xl bg-ink/5 px-3 py-2.5 text-[13px] text-ink/75">
+        {{ formatKES(chequeOnAccount) }} already collected by cheque, with accounts to bank. It is
+        not tied to an invoice, so check before collecting again.
+      </p>
 
       <input
         v-if="invoices.length > 1"
@@ -186,6 +212,7 @@ onMounted(load)
           :actions-disabled="selected.length > 0"
           @prompt="promptInvoice(inv)"
           @notes="noting = { invoice: inv.name, customer_name: inv.customer_name }"
+          @cheque="chequeFor([inv.name], Number(inv.outstanding_amount || 0))"
           @toggle-select="toggleSelect(inv)"
         />
       </div>
@@ -193,5 +220,6 @@ onMounted(load)
 
     <PromptDialog :target="prompting" @close="prompting = null" @paid="onPaid" @changed="load" />
     <NotesDialog :target="noting" @close="noting = null" @saved="onNoteSaved" />
+    <ChequeDialog :target="chequing" @close="chequing = null" @recorded="onChequeRecorded" />
   </main>
 </template>

--- a/frontend/src/pages/CustomerDetail.vue
+++ b/frontend/src/pages/CustomerDetail.vue
@@ -36,16 +36,25 @@ const { selected, isSelected, toggleSelect, clearSelection, dropSelected, select
   useInvoiceSelection()
 // Ticking a subset only makes sense at 3+ invoices — 1 has nothing to bundle and 2 are
 // already covered by "Collect all".
-const selectable = computed(() => canBundle.value && invoices.value.length > 2)
+const selectable = computed(() => canBundle.value && collectable.value.length > 2)
 
 const total = computed(() =>
   invoices.value.reduce((sum, inv) => sum + Number(inv.outstanding_amount || 0), 0),
 )
 
+// A cheque already in hand is not banked yet, so the invoice still shows its full balance —
+// but charging it again would take the money twice. It stays listed, it just cannot be collected.
+const collectable = computed(() => invoices.value.filter((inv) => !inv.awaiting_cheque))
+const collectableTotal = computed(() =>
+  collectable.value.reduce((sum, inv) => sum + Number(inv.outstanding_amount || 0), 0),
+)
+
 // A bundle is charged as one M-Pesa STK (or hosted checkout). Over the cap with no card
 // fallback it can't be paid and would hide the invoices ~30 min — block it and let the
 // operator collect invoices individually instead.
-const bundleAmount = computed(() => (selected.value.length ? selectedTotal.value : total.value))
+const bundleAmount = computed(() =>
+  selected.value.length ? selectedTotal.value : collectableTotal.value,
+)
 const bundleBlocked = computed(
   () => !enableRedirect.value && mpesaMax.value > 0 && bundleAmount.value > mpesaMax.value,
 )
@@ -111,7 +120,7 @@ async function collect(names) {
   }
 }
 const collectNow = () =>
-  collect((selected.value.length ? selected.value : invoices.value).map((inv) => inv.name))
+  collect((selected.value.length ? selected.value : collectable.value).map((inv) => inv.name))
 
 const toList = () => router.push({ name: 'Collect', query: driver ? { driver } : {} })
 
@@ -165,10 +174,10 @@ onMounted(load)
       <CustomerMoneyHeader :name="customerName" :total="total" :count="invoices.length" />
 
       <CollectBar
-        :show-bar="canBundle && invoices.length > 1"
+        :show-bar="canBundle && collectable.length > 1"
         :selected-count="selected.length"
         :selected-total="selectedTotal"
-        :total="total"
+        :total="collectableTotal"
         :creating-bundle="creatingBundle"
         :bundle-blocked="bundleBlocked"
         :mpesa-max="mpesaMax"
@@ -207,7 +216,7 @@ onMounted(load)
           :invoice="inv"
           :enable-redirect="enableRedirect"
           :mpesa-max="mpesaMax"
-          :selectable="selectable"
+          :selectable="selectable && !inv.awaiting_cheque"
           :selected="isSelected(inv)"
           :actions-disabled="selected.length > 0"
           @prompt="promptInvoice(inv)"

--- a/frontend/src/pages/CustomerDetail.vue
+++ b/frontend/src/pages/CustomerDetail.vue
@@ -9,6 +9,7 @@ import InvoiceCard from '@/components/InvoiceCard.vue'
 import PromptDialog from '@/components/PromptDialog.vue'
 import NotesDialog from '@/components/NotesDialog.vue'
 import ChequeDialog from '@/components/ChequeDialog.vue'
+import ChequeDueBanner from '@/components/ChequeDueBanner.vue'
 import CustomerMoneyHeader from '@/components/CustomerMoneyHeader.vue'
 import CollectBar from '@/components/CollectBar.vue'
 import ErrorRetry from '@/components/ErrorRetry.vue'
@@ -20,6 +21,7 @@ const driver = route.query.driver || '' // scope the detail to the driver picked
 
 const customerName = ref('')
 const invoices = ref([])
+const chequeDue = ref(null) // a cheque accounts flagged to collect from this customer
 const chequeOnAccount = ref(0)
 const enableRedirect = ref(false)
 const allowCheque = ref(false)
@@ -75,8 +77,13 @@ async function load() {
   clearSelection()
   try {
     const data = await fetchCustomerCollection(customer, driver)
-    customerName.value = data.customer_name || customer
     invoices.value = data.invoices || []
+    chequeDue.value = data.cheque_due || null
+    // With no outstanding invoice the server can only echo the id; the flagged cheque carries the name.
+    customerName.value =
+      (invoices.value.length ? data.customer_name : chequeDue.value?.customer_name) ||
+      data.customer_name ||
+      customer
     enableRedirect.value = Boolean(data.enable_redirect)
     allowCheque.value = Boolean(data.allow_cheque)
     chequePerInvoice.value = data.cheque_per_invoice !== false
@@ -148,12 +155,18 @@ function chequeFor(rows, outstanding) {
   chequing.value = { customer, customer_name: customerName.value, invoices: rows, outstanding }
 }
 
+// A flagged cheque records on account; suggest the expected amount if accounts gave one.
+function collectFlaggedCheque() {
+  chequeFor([], Number(chequeDue.value?.expected_amount || 0) || total.value)
+}
+
 // Mark the cards in place rather than reloading, which would clear the ticked set underneath.
 function onChequeRecorded({ invoices: names, amount, covered }) {
   if (!names.length) chequeOnAccount.value += amount
   invoices.value.forEach((inv) => {
     if (covered[inv.name]) inv.awaiting_cheque = covered[inv.name]
   })
+  chequeDue.value = null // the flagged cheque is now collected — drop its banner
   clearSelection()
 }
 
@@ -184,6 +197,8 @@ onMounted(load)
 
     <template v-else>
       <CustomerMoneyHeader :name="customerName" :total="total" :count="invoices.length" />
+
+      <ChequeDueBanner :due="chequeDue" @collect="collectFlaggedCheque" />
 
       <CollectBar
         :show-bar="canBundle && collectable.length > 1"

--- a/frontend/src/pages/CustomerDetail.vue
+++ b/frontend/src/pages/CustomerDetail.vue
@@ -22,6 +22,7 @@ const customerName = ref('')
 const invoices = ref([])
 const chequeOnAccount = ref(0)
 const enableRedirect = ref(false)
+const allowCheque = ref(false)
 const canBundle = ref(false)
 const mpesaMax = ref(0)
 const loading = ref(true)
@@ -76,6 +77,7 @@ async function load() {
     customerName.value = data.customer_name || customer
     invoices.value = data.invoices || []
     enableRedirect.value = Boolean(data.enable_redirect)
+    allowCheque.value = Boolean(data.allow_cheque)
     canBundle.value = Boolean(data.can_bundle)
     mpesaMax.value = data.mpesa_max || 0
     chequeOnAccount.value = Number(data.cheque_on_account || 0)
@@ -183,7 +185,7 @@ onMounted(load)
         :mpesa-max="mpesaMax"
         :collect-error="collectError"
         :show-tick-hint="selectable && !selected.length"
-        :show-cheque="invoices.length > 0"
+        :show-cheque="allowCheque && invoices.length > 0"
         @collect="collectNow"
         @clear="clearSelection"
         @cheque="chequeFor(selected.map((i) => i.name), selected.length ? selectedTotal : total)"
@@ -219,6 +221,7 @@ onMounted(load)
           :selectable="selectable && !inv.awaiting_cheque"
           :selected="isSelected(inv)"
           :actions-disabled="selected.length > 0"
+          :allow-cheque="allowCheque"
           @prompt="promptInvoice(inv)"
           @notes="noting = { invoice: inv.name, customer_name: inv.customer_name }"
           @cheque="chequeFor([inv.name], Number(inv.outstanding_amount || 0))"

--- a/frontend/src/pages/CustomerDetail.vue
+++ b/frontend/src/pages/CustomerDetail.vue
@@ -23,6 +23,7 @@ const invoices = ref([])
 const chequeOnAccount = ref(0)
 const enableRedirect = ref(false)
 const allowCheque = ref(false)
+const chequePerInvoice = ref(true)
 const canBundle = ref(false)
 const mpesaMax = ref(0)
 const loading = ref(true)
@@ -78,6 +79,7 @@ async function load() {
     invoices.value = data.invoices || []
     enableRedirect.value = Boolean(data.enable_redirect)
     allowCheque.value = Boolean(data.allow_cheque)
+    chequePerInvoice.value = data.cheque_per_invoice !== false
     canBundle.value = Boolean(data.can_bundle)
     mpesaMax.value = data.mpesa_max || 0
     chequeOnAccount.value = Number(data.cheque_on_account || 0)
@@ -134,6 +136,14 @@ function onPaid(name) {
 }
 
 // A cheque covers the ticked invoices; nothing ticked records it against the customer instead.
+function chequeFromBar() {
+  // Per-invoice off -> the bar records a customer-level cheque, so no invoice rows go with it.
+  const rows = chequePerInvoice.value
+    ? selected.value.map((i) => ({ name: i.name, amount: Number(i.outstanding_amount || 0) }))
+    : []
+  chequeFor(rows, rows.length ? selectedTotal.value : total.value)
+}
+
 function chequeFor(rows, outstanding) {
   chequing.value = { customer, customer_name: customerName.value, invoices: rows, outstanding }
 }
@@ -186,9 +196,10 @@ onMounted(load)
         :collect-error="collectError"
         :show-tick-hint="selectable && !selected.length"
         :show-cheque="allowCheque && invoices.length > 0"
+        :cheque-per-invoice="chequePerInvoice"
         @collect="collectNow"
         @clear="clearSelection"
-        @cheque="chequeFor(selected.map((i) => ({ name: i.name, amount: Number(i.outstanding_amount || 0) })), selected.length ? selectedTotal : total)"
+        @cheque="chequeFromBar"
       />
 
       <p v-if="chequeOnAccount" class="-mt-2 rounded-xl bg-owed/10 px-3 py-2.5 text-[13px] font-medium text-owed">
@@ -222,6 +233,7 @@ onMounted(load)
           :selected="isSelected(inv)"
           :actions-disabled="selected.length > 0"
           :allow-cheque="allowCheque"
+          :cheque-per-invoice="chequePerInvoice"
           @prompt="promptInvoice(inv)"
           @notes="noting = { invoice: inv.name, customer_name: inv.customer_name }"
           @cheque="chequeFor([{ name: inv.name, amount: Number(inv.outstanding_amount || 0) }], Number(inv.outstanding_amount || 0))"

--- a/frontend/src/pages/CustomerDetail.vue
+++ b/frontend/src/pages/CustomerDetail.vue
@@ -134,8 +134,8 @@ function onPaid(name) {
 }
 
 // A cheque covers the ticked invoices; nothing ticked records it against the customer instead.
-function chequeFor(names, outstanding) {
-  chequing.value = { customer, customer_name: customerName.value, invoices: names, outstanding }
+function chequeFor(rows, outstanding) {
+  chequing.value = { customer, customer_name: customerName.value, invoices: rows, outstanding }
 }
 
 // Mark the cards in place rather than reloading, which would clear the ticked set underneath.
@@ -188,10 +188,10 @@ onMounted(load)
         :show-cheque="allowCheque && invoices.length > 0"
         @collect="collectNow"
         @clear="clearSelection"
-        @cheque="chequeFor(selected.map((i) => i.name), selected.length ? selectedTotal : total)"
+        @cheque="chequeFor(selected.map((i) => ({ name: i.name, amount: Number(i.outstanding_amount || 0) })), selected.length ? selectedTotal : total)"
       />
 
-      <p v-if="chequeOnAccount" class="-mt-2 rounded-xl bg-ink/5 px-3 py-2.5 text-[13px] text-ink/75">
+      <p v-if="chequeOnAccount" class="-mt-2 rounded-xl bg-owed/10 px-3 py-2.5 text-[13px] font-medium text-owed">
         {{ formatKES(chequeOnAccount) }} already collected by cheque, with accounts to bank. It is
         not tied to an invoice, so check before collecting again.
       </p>
@@ -224,7 +224,7 @@ onMounted(load)
           :allow-cheque="allowCheque"
           @prompt="promptInvoice(inv)"
           @notes="noting = { invoice: inv.name, customer_name: inv.customer_name }"
-          @cheque="chequeFor([inv.name], Number(inv.outstanding_amount || 0))"
+          @cheque="chequeFor([{ name: inv.name, amount: Number(inv.outstanding_amount || 0) }], Number(inv.outstanding_amount || 0))"
           @toggle-select="toggleSelect(inv)"
         />
       </div>

--- a/frontend/src/pages/CustomerDetail.vue
+++ b/frontend/src/pages/CustomerDetail.vue
@@ -139,10 +139,10 @@ function chequeFor(names, outstanding) {
 }
 
 // Mark the cards in place rather than reloading, which would clear the ticked set underneath.
-function onChequeRecorded({ invoices: names, amount }) {
+function onChequeRecorded({ invoices: names, amount, covered }) {
   if (!names.length) chequeOnAccount.value += amount
   invoices.value.forEach((inv) => {
-    if (names.includes(inv.name)) inv.awaiting_cheque = true
+    if (covered[inv.name]) inv.awaiting_cheque = covered[inv.name]
   })
   clearSelection()
 }

--- a/frontend/src/pages/InternalCollect.vue
+++ b/frontend/src/pages/InternalCollect.vue
@@ -20,6 +20,7 @@ const statsLoading = ref(false)
 
 const search = ref('')
 const drivers = ref([])
+const chequeDues = ref([])
 const driver = ref(route.query.driver || '') // restored when returning from a detail page
 const paymentTerms = ref([])
 const paymentTerm = ref(route.query.payment_term || '')
@@ -46,6 +47,7 @@ async function loadCustomers() {
     const data = await fetchInternalCustomers(driver.value, paymentTerm.value, salesPerson.value)
     customers.value = data.customers || []
     drivers.value = data.drivers || []
+    chequeDues.value = data.cheque_dues || []
     paymentTerms.value = data.payment_terms || []
     salesPersons.value = data.sales_persons || []
   } catch (e) {
@@ -89,6 +91,7 @@ onMounted(refreshAll)
     :load-error="loadError"
     :not-permitted="notPermitted"
     :customers="filtered"
+    :cheque-dues="chequeDues"
     :empty-message="emptyMessage"
     card-route-name="InternalCustomer"
     :card-driver="driver"

--- a/frontend/src/pages/PagedCustomerDetail.vue
+++ b/frontend/src/pages/PagedCustomerDetail.vue
@@ -199,10 +199,10 @@ function chequeFor(names, outstanding) {
 }
 
 // Mark the cards in place rather than reloading, which would clear the ticked set underneath.
-function onChequeRecorded({ invoices: names, amount }) {
+function onChequeRecorded({ invoices: names, amount, covered }) {
   if (!names.length) chequeOnAccount.value += amount
   invoices.value.forEach((inv) => {
-    if (names.includes(inv.name)) inv.awaiting_cheque = true
+    if (covered[inv.name]) inv.awaiting_cheque = covered[inv.name]
   })
   clearSelection()
 }

--- a/frontend/src/pages/PagedCustomerDetail.vue
+++ b/frontend/src/pages/PagedCustomerDetail.vue
@@ -55,6 +55,7 @@ const chequeOnAccount = ref(0)
 const count = ref(0)
 const hasMore = ref(false)
 const enableRedirect = ref(false)
+const allowCheque = ref(false)
 const mpesaMax = ref(0)
 
 const loading = ref(true)
@@ -116,6 +117,7 @@ async function load(reset = true) {
     total.value = data.total_outstanding
     count.value = data.invoice_count
     enableRedirect.value = Boolean(data.enable_redirect)
+    allowCheque.value = Boolean(data.allow_cheque)
     mpesaMax.value = data.mpesa_max || 0
     chequeOnAccount.value = Number(data.cheque_on_account || 0)
     invoices.value = reset ? data.invoices || [] : [...invoices.value, ...(data.invoices || [])]
@@ -248,7 +250,7 @@ onMounted(() => load(true))
         :mpesa-max="mpesaMax"
         :collect-error="collectError"
         :show-tick-hint="selectable && !selected.length"
-        :show-cheque="count > 0"
+        :show-cheque="allowCheque && count > 0"
         @collect="collectNow"
         @clear="clearSelection"
         @cheque="chequeFor(selected.map((i) => i.name), selected.length ? selectedTotal : total)"
@@ -285,6 +287,7 @@ onMounted(() => load(true))
             :selectable="selectable && !inv.awaiting_cheque"
             :selected="isSelected(inv)"
             :actions-disabled="selected.length > 0"
+            :allow-cheque="allowCheque"
             @prompt="promptInvoice(inv)"
             @notes="noting = { invoice: inv.name, customer_name: inv.customer_name }"
             @cheque="chequeFor([inv.name], Number(inv.outstanding_amount || 0))"

--- a/frontend/src/pages/PagedCustomerDetail.vue
+++ b/frontend/src/pages/PagedCustomerDetail.vue
@@ -77,9 +77,18 @@ const { selected, isSelected, toggleSelect, clearSelection, dropSelected, select
   useInvoiceSelection()
 const selectable = computed(() => count.value > 2)
 
+// A cheque already in hand is not banked yet, so the invoice still shows its full balance —
+// but charging it again would take the money twice. It stays listed, it just cannot be collected.
+const collectable = computed(() => invoices.value.filter((inv) => !inv.awaiting_cheque))
+const collectableTotal = computed(() =>
+  collectable.value.reduce((sum, inv) => sum + Number(inv.outstanding_amount || 0), 0),
+)
+
 // Over the M-Pesa cap with no card fallback a bundle can't be paid (and hides its invoices
 // ~30 min) — block it and let the operator collect invoices individually.
-const bundleAmount = computed(() => (selected.value.length ? selectedTotal.value : total.value))
+const bundleAmount = computed(() =>
+  selected.value.length ? selectedTotal.value : collectableTotal.value,
+)
 const bundleBlocked = computed(
   () => !enableRedirect.value && mpesaMax.value > 0 && bundleAmount.value > mpesaMax.value,
 )
@@ -159,12 +168,12 @@ async function collect(names) {
 }
 // Ticked a subset → collect those; nothing ticked → the whole loaded balance.
 const collectNow = () =>
-  collect((selected.value.length ? selected.value : invoices.value).map((inv) => inv.name))
+  collect((selected.value.length ? selected.value : collectable.value).map((inv) => inv.name))
 
 // "Collect all" only when the whole balance is on screen: no more pages AND no active
 // search (a search narrows the loaded rows, so "all" would bundle just the matches).
 const canCollectAll = computed(
-  () => !hasMore.value && invoices.value.length > 1 && !search.value.trim(),
+  () => !hasMore.value && collectable.value.length > 1 && !search.value.trim(),
 )
 
 const toList = () => router.push({ name: mode.list, query: scopeQuery() })
@@ -233,7 +242,7 @@ onMounted(() => load(true))
         :show-bar="selected.length > 0 || canCollectAll"
         :selected-count="selected.length"
         :selected-total="selectedTotal"
-        :total="total"
+        :total="collectableTotal"
         :creating-bundle="creatingBundle"
         :bundle-blocked="bundleBlocked"
         :mpesa-max="mpesaMax"
@@ -273,7 +282,7 @@ onMounted(() => load(true))
             :invoice="inv"
             :enable-redirect="enableRedirect"
             :mpesa-max="mpesaMax"
-            :selectable="selectable"
+            :selectable="selectable && !inv.awaiting_cheque"
             :selected="isSelected(inv)"
             :actions-disabled="selected.length > 0"
             @prompt="promptInvoice(inv)"

--- a/frontend/src/pages/PagedCustomerDetail.vue
+++ b/frontend/src/pages/PagedCustomerDetail.vue
@@ -13,6 +13,7 @@ import InvoiceCard from '@/components/InvoiceCard.vue'
 import PromptDialog from '@/components/PromptDialog.vue'
 import NotesDialog from '@/components/NotesDialog.vue'
 import ChequeDialog from '@/components/ChequeDialog.vue'
+import ChequeDueBanner from '@/components/ChequeDueBanner.vue'
 import CustomerMoneyHeader from '@/components/CustomerMoneyHeader.vue'
 import CollectBar from '@/components/CollectBar.vue'
 import ErrorRetry from '@/components/ErrorRetry.vue'
@@ -50,6 +51,7 @@ const scopeQuery = () =>
 
 const customerName = ref('')
 const invoices = ref([])
+const chequeDue = ref(null) // a cheque accounts flagged to collect from this customer
 const total = ref(0)
 const chequeOnAccount = ref(0)
 const count = ref(0)
@@ -114,7 +116,12 @@ async function load(reset = true) {
       salesPerson: route.query.sales_person || '',
     })
     if (seq !== loadSeq) return // a newer load/search superseded this response — drop it
-    customerName.value = data.customer_name || customer
+    chequeDue.value = data.cheque_due || null
+    // With no invoice for this customer the server can only echo the id; the flag carries the name.
+    customerName.value =
+      (data.invoice_count ? data.customer_name : chequeDue.value?.customer_name) ||
+      data.customer_name ||
+      customer
     total.value = data.total_outstanding
     count.value = data.invoice_count
     enableRedirect.value = Boolean(data.enable_redirect)
@@ -208,12 +215,18 @@ function chequeFor(rows, outstanding) {
   chequing.value = { customer, customer_name: customerName.value, invoices: rows, outstanding }
 }
 
+// A flagged cheque records on account; suggest the expected amount if accounts gave one.
+function collectFlaggedCheque() {
+  chequeFor([], Number(chequeDue.value?.expected_amount || 0) || total.value)
+}
+
 // Mark the cards in place rather than reloading, which would clear the ticked set underneath.
 function onChequeRecorded({ invoices: names, amount, covered }) {
   if (!names.length) chequeOnAccount.value += amount
   invoices.value.forEach((inv) => {
     if (covered[inv.name]) inv.awaiting_cheque = covered[inv.name]
   })
+  chequeDue.value = null // the flagged cheque is now collected — drop its banner
   clearSelection()
 }
 
@@ -249,6 +262,8 @@ onMounted(() => load(true))
         :count="count"
         :term="paymentTerm || 'all terms'"
       />
+
+      <ChequeDueBanner :due="chequeDue" @collect="collectFlaggedCheque" />
 
       <CollectBar
         :show-bar="selected.length > 0 || canCollectAll"

--- a/frontend/src/pages/PagedCustomerDetail.vue
+++ b/frontend/src/pages/PagedCustomerDetail.vue
@@ -56,6 +56,7 @@ const count = ref(0)
 const hasMore = ref(false)
 const enableRedirect = ref(false)
 const allowCheque = ref(false)
+const chequePerInvoice = ref(true)
 const mpesaMax = ref(0)
 
 const loading = ref(true)
@@ -118,6 +119,7 @@ async function load(reset = true) {
     count.value = data.invoice_count
     enableRedirect.value = Boolean(data.enable_redirect)
     allowCheque.value = Boolean(data.allow_cheque)
+    chequePerInvoice.value = data.cheque_per_invoice !== false
     mpesaMax.value = data.mpesa_max || 0
     chequeOnAccount.value = Number(data.cheque_on_account || 0)
     invoices.value = reset ? data.invoices || [] : [...invoices.value, ...(data.invoices || [])]
@@ -194,6 +196,14 @@ function onPaid(name) {
 }
 
 // A cheque covers the ticked invoices; nothing ticked records it against the customer instead.
+function chequeFromBar() {
+  // Per-invoice off -> the bar records a customer-level cheque, so no invoice rows go with it.
+  const rows = chequePerInvoice.value
+    ? selected.value.map((i) => ({ name: i.name, amount: Number(i.outstanding_amount || 0) }))
+    : []
+  chequeFor(rows, rows.length ? selectedTotal.value : total.value)
+}
+
 function chequeFor(rows, outstanding) {
   chequing.value = { customer, customer_name: customerName.value, invoices: rows, outstanding }
 }
@@ -251,9 +261,10 @@ onMounted(() => load(true))
         :collect-error="collectError"
         :show-tick-hint="selectable && !selected.length"
         :show-cheque="allowCheque && count > 0"
+        :cheque-per-invoice="chequePerInvoice"
         @collect="collectNow"
         @clear="clearSelection"
-        @cheque="chequeFor(selected.map((i) => ({ name: i.name, amount: Number(i.outstanding_amount || 0) })), selected.length ? selectedTotal : total)"
+        @cheque="chequeFromBar"
       />
 
       <p v-if="chequeOnAccount" class="-mt-2 rounded-xl bg-owed/10 px-3 py-2.5 text-[13px] font-medium text-owed">
@@ -288,6 +299,7 @@ onMounted(() => load(true))
             :selected="isSelected(inv)"
             :actions-disabled="selected.length > 0"
             :allow-cheque="allowCheque"
+            :cheque-per-invoice="chequePerInvoice"
             @prompt="promptInvoice(inv)"
             @notes="noting = { invoice: inv.name, customer_name: inv.customer_name }"
             @cheque="chequeFor([{ name: inv.name, amount: Number(inv.outstanding_amount || 0) }], Number(inv.outstanding_amount || 0))"

--- a/frontend/src/pages/PagedCustomerDetail.vue
+++ b/frontend/src/pages/PagedCustomerDetail.vue
@@ -6,11 +6,13 @@ import {
   fetchInternalCustomerInvoices,
   fetchSalesCustomerInvoices,
 } from '@/data/collection'
+import { formatKES } from '@/utils/format'
 import { useResumeRefresh } from '@/composables/useResumeRefresh'
 import { useInvoiceSelection } from '@/composables/useInvoiceSelection'
 import InvoiceCard from '@/components/InvoiceCard.vue'
 import PromptDialog from '@/components/PromptDialog.vue'
 import NotesDialog from '@/components/NotesDialog.vue'
+import ChequeDialog from '@/components/ChequeDialog.vue'
 import CustomerMoneyHeader from '@/components/CustomerMoneyHeader.vue'
 import CollectBar from '@/components/CollectBar.vue'
 import ErrorRetry from '@/components/ErrorRetry.vue'
@@ -49,6 +51,7 @@ const scopeQuery = () =>
 const customerName = ref('')
 const invoices = ref([])
 const total = ref(0)
+const chequeOnAccount = ref(0)
 const count = ref(0)
 const hasMore = ref(false)
 const enableRedirect = ref(false)
@@ -61,6 +64,7 @@ const creatingBundle = ref(false)
 const collectError = ref(false)
 const prompting = ref(null)
 const noting = ref(null)
+const chequing = ref(null)
 
 const search = ref('')
 let searchTimer = null
@@ -104,6 +108,7 @@ async function load(reset = true) {
     count.value = data.invoice_count
     enableRedirect.value = Boolean(data.enable_redirect)
     mpesaMax.value = data.mpesa_max || 0
+    chequeOnAccount.value = Number(data.cheque_on_account || 0)
     invoices.value = reset ? data.invoices || [] : [...invoices.value, ...(data.invoices || [])]
     hasMore.value = Boolean(data.has_more)
   } catch {
@@ -177,6 +182,20 @@ function onPaid(name) {
   else if (!invoices.value.length) load(true)
 }
 
+// A cheque covers the ticked invoices; nothing ticked records it against the customer instead.
+function chequeFor(names, outstanding) {
+  chequing.value = { customer, customer_name: customerName.value, invoices: names, outstanding }
+}
+
+// Mark the cards in place rather than reloading, which would clear the ticked set underneath.
+function onChequeRecorded({ invoices: names, amount }) {
+  if (!names.length) chequeOnAccount.value += amount
+  invoices.value.forEach((inv) => {
+    if (names.includes(inv.name)) inv.awaiting_cheque = true
+  })
+  clearSelection()
+}
+
 // Patch the card in place: reloading the list would clear a ticked bundle and reset paging.
 function onNoteSaved({ invoice, count, latest }) {
   const inv = invoices.value.find((i) => i.name === invoice)
@@ -220,9 +239,16 @@ onMounted(() => load(true))
         :mpesa-max="mpesaMax"
         :collect-error="collectError"
         :show-tick-hint="selectable && !selected.length"
+        :show-cheque="count > 0"
         @collect="collectNow"
         @clear="clearSelection"
+        @cheque="chequeFor(selected.map((i) => i.name), selected.length ? selectedTotal : total)"
       />
+
+      <p v-if="chequeOnAccount" class="-mt-2 rounded-xl bg-ink/5 px-3 py-2.5 text-[13px] text-ink/75">
+        {{ formatKES(chequeOnAccount) }} already collected by cheque, with accounts to bank. It is
+        not tied to an invoice, so check before collecting again.
+      </p>
 
       <input
         v-model="search"
@@ -252,6 +278,7 @@ onMounted(() => load(true))
             :actions-disabled="selected.length > 0"
             @prompt="promptInvoice(inv)"
             @notes="noting = { invoice: inv.name, customer_name: inv.customer_name }"
+            @cheque="chequeFor([inv.name], Number(inv.outstanding_amount || 0))"
             @toggle-select="toggleSelect(inv)"
           />
         </div>
@@ -269,6 +296,7 @@ onMounted(() => load(true))
 
       <PromptDialog :target="prompting" @close="prompting = null" @paid="onPaid" @changed="load(true)" />
       <NotesDialog :target="noting" @close="noting = null" @saved="onNoteSaved" />
+      <ChequeDialog :target="chequing" @close="chequing = null" @recorded="onChequeRecorded" />
     </template>
   </main>
 </template>

--- a/frontend/src/pages/PagedCustomerDetail.vue
+++ b/frontend/src/pages/PagedCustomerDetail.vue
@@ -194,8 +194,8 @@ function onPaid(name) {
 }
 
 // A cheque covers the ticked invoices; nothing ticked records it against the customer instead.
-function chequeFor(names, outstanding) {
-  chequing.value = { customer, customer_name: customerName.value, invoices: names, outstanding }
+function chequeFor(rows, outstanding) {
+  chequing.value = { customer, customer_name: customerName.value, invoices: rows, outstanding }
 }
 
 // Mark the cards in place rather than reloading, which would clear the ticked set underneath.
@@ -253,10 +253,10 @@ onMounted(() => load(true))
         :show-cheque="allowCheque && count > 0"
         @collect="collectNow"
         @clear="clearSelection"
-        @cheque="chequeFor(selected.map((i) => i.name), selected.length ? selectedTotal : total)"
+        @cheque="chequeFor(selected.map((i) => ({ name: i.name, amount: Number(i.outstanding_amount || 0) })), selected.length ? selectedTotal : total)"
       />
 
-      <p v-if="chequeOnAccount" class="-mt-2 rounded-xl bg-ink/5 px-3 py-2.5 text-[13px] text-ink/75">
+      <p v-if="chequeOnAccount" class="-mt-2 rounded-xl bg-owed/10 px-3 py-2.5 text-[13px] font-medium text-owed">
         {{ formatKES(chequeOnAccount) }} already collected by cheque, with accounts to bank. It is
         not tied to an invoice, so check before collecting again.
       </p>
@@ -290,7 +290,7 @@ onMounted(() => load(true))
             :allow-cheque="allowCheque"
             @prompt="promptInvoice(inv)"
             @notes="noting = { invoice: inv.name, customer_name: inv.customer_name }"
-            @cheque="chequeFor([inv.name], Number(inv.outstanding_amount || 0))"
+            @cheque="chequeFor([{ name: inv.name, amount: Number(inv.outstanding_amount || 0) }], Number(inv.outstanding_amount || 0))"
             @toggle-select="toggleSelect(inv)"
           />
         </div>

--- a/frontend/src/pages/RequestDetail.vue
+++ b/frontend/src/pages/RequestDetail.vue
@@ -11,6 +11,7 @@ import {
 } from '@/data/collection'
 import { formatKES } from '@/utils/format'
 import PromptDialog from '@/components/PromptDialog.vue'
+import ChequeDialog from '@/components/ChequeDialog.vue'
 import ErrorRetry from '@/components/ErrorRetry.vue'
 
 // The transient home for a request or bundle: live status, the invoices it
@@ -30,10 +31,15 @@ const checkoutBusy = ref(false)
 const copied = ref(false)
 const linkExpiry = ref(null)
 const prompting = ref(null)
+const chequing = ref(null)
 let pollTimer = null
 
 const SETTLED = ['Success', 'Underpaid', 'Overpaid', 'Cancelled']
-const promptable = computed(() => detail.value && !SETTLED.includes(detail.value.status))
+// A cheque already collected here makes the request unchargeable (the server refuses every rail),
+// so it drops out of promptable exactly like a settled one.
+const promptable = computed(
+  () => detail.value && !SETTLED.includes(detail.value.status) && !detail.value.awaiting_cheque,
+)
 
 // M-Pesa can't process a charge over the ceiling — hide the prompt, steer to the link/iPay.
 const mpesaBlocked = computed(
@@ -110,6 +116,23 @@ function onPaid() {
   }
   stopPolling()
   prompting.value = null // dismiss the success screen
+}
+
+function chequeNow() {
+  chequing.value = {
+    customer: detail.value.customer,
+    customer_name: detail.value.customer_name,
+    invoices: detail.value.invoices.map((inv) => inv.name),
+    outstanding: Number(detail.value.amount || 0),
+  }
+}
+
+// A cheque covers the request's invoices, so the whole request is now awaiting one — mark it so
+// the charge actions give way to the notice, without a reload.
+function onChequeRecorded({ covered }) {
+  const total = Object.values(covered || {}).reduce((sum, v) => sum + Number(v || 0), 0)
+  if (detail.value) detail.value.awaiting_cheque = total
+  stopPolling()
 }
 
 async function payViaIpay() {
@@ -330,9 +353,28 @@ onMounted(load)
             </button>
           </div>
         </div>
+
+        <!-- Deliberately quiet: cheques are the exception, M-Pesa stays the obvious action. -->
+        <button
+          v-if="detail.allow_cheque"
+          type="button"
+          class="h-11 rounded-xl border border-hairline bg-white text-sm font-medium text-ink/70 transition active:bg-paper"
+          @click="chequeNow"
+        >
+          Collect a cheque
+        </button>
       </template>
 
+      <p
+        v-else-if="detail.awaiting_cheque"
+        class="rounded-xl bg-ink/5 px-3 py-2.5 text-sm font-medium text-ink/75"
+      >
+        Cheque for {{ formatKES(detail.awaiting_cheque) }} collected — with accounts to bank. This
+        request can't be charged until it clears.
+      </p>
+
       <PromptDialog :target="prompting" @close="prompting = null" @paid="onPaid" />
+      <ChequeDialog :target="chequing" @close="chequing = null" @recorded="onChequeRecorded" />
     </template>
   </main>
 </template>

--- a/frontend/src/pages/RequestDetail.vue
+++ b/frontend/src/pages/RequestDetail.vue
@@ -32,13 +32,19 @@ const copied = ref(false)
 const linkExpiry = ref(null)
 const prompting = ref(null)
 const chequing = ref(null)
+const chequeRecorded = ref(false) // a cheque was just taken here — even on-account, don't also charge it
 let pollTimer = null
 
 const SETTLED = ['Success', 'Underpaid', 'Overpaid', 'Cancelled']
-// A cheque already collected here makes the request unchargeable (the server refuses every rail),
-// so it drops out of promptable exactly like a settled one.
+// A cheque already collected here makes the request unchargeable (the server refuses every rail for
+// a per-invoice cheque), so it drops out of promptable like a settled one. A cheque just taken on
+// this page also drops out, so an on-account one can't be double-charged from the same screen.
 const promptable = computed(
-  () => detail.value && !SETTLED.includes(detail.value.status) && !detail.value.awaiting_cheque,
+  () =>
+    detail.value &&
+    !SETTLED.includes(detail.value.status) &&
+    !detail.value.awaiting_cheque &&
+    !chequeRecorded.value,
 )
 
 // M-Pesa can't process a charge over the ceiling — hide the prompt, steer to the link/iPay.
@@ -132,11 +138,13 @@ function chequeNow() {
   }
 }
 
-// A cheque covers the request's invoices, so the whole request is now awaiting one — mark it so
-// the charge actions give way to the notice, without a reload.
+// A cheque was taken here — mark it so the charge actions give way to the notice, without a
+// reload. A per-invoice cheque also carries its covered amount; an on-account one covers nothing
+// specific, but it must still stop an immediate M-Pesa charge for the same request.
 function onChequeRecorded({ covered }) {
   const total = Object.values(covered || {}).reduce((sum, v) => sum + Number(v || 0), 0)
   if (detail.value) detail.value.awaiting_cheque = total
+  chequeRecorded.value = true
   stopPolling()
 }
 
@@ -376,6 +384,12 @@ onMounted(load)
       >
         Cheque for {{ formatKES(detail.awaiting_cheque) }} collected — with accounts to bank. This
         request can't be charged until it clears.
+      </p>
+      <p
+        v-else-if="chequeRecorded"
+        class="rounded-xl bg-owed/10 px-3 py-2.5 text-sm font-medium text-owed"
+      >
+        Cheque recorded against the customer — with accounts to bank. Don't also charge this request.
       </p>
 
       <PromptDialog :target="prompting" @close="prompting = null" @paid="onPaid" />

--- a/frontend/src/pages/RequestDetail.vue
+++ b/frontend/src/pages/RequestDetail.vue
@@ -122,7 +122,7 @@ function chequeNow() {
   chequing.value = {
     customer: detail.value.customer,
     customer_name: detail.value.customer_name,
-    invoices: detail.value.invoices.map((inv) => inv.name),
+    invoices: detail.value.invoices.map((inv) => ({ name: inv.name, amount: Number(inv.amount || 0) })),
     outstanding: Number(detail.value.amount || 0),
   }
 }
@@ -367,7 +367,7 @@ onMounted(load)
 
       <p
         v-else-if="detail.awaiting_cheque"
-        class="rounded-xl bg-ink/5 px-3 py-2.5 text-sm font-medium text-ink/75"
+        class="rounded-xl bg-owed/10 px-3 py-2.5 text-sm font-medium text-owed"
       >
         Cheque for {{ formatKES(detail.awaiting_cheque) }} collected — with accounts to bank. This
         request can't be charged until it clears.

--- a/frontend/src/pages/RequestDetail.vue
+++ b/frontend/src/pages/RequestDetail.vue
@@ -119,10 +119,15 @@ function onPaid() {
 }
 
 function chequeNow() {
+  // Per-invoice off -> record at the customer level, not against this request's invoices.
+  const invoices =
+    detail.value.cheque_per_invoice !== false
+      ? detail.value.invoices.map((inv) => ({ name: inv.name, amount: Number(inv.amount || 0) }))
+      : []
   chequing.value = {
     customer: detail.value.customer,
     customer_name: detail.value.customer_name,
-    invoices: detail.value.invoices.map((inv) => ({ name: inv.name, amount: Number(inv.amount || 0) })),
+    invoices,
     outstanding: Number(detail.value.amount || 0),
   }
 }

--- a/frontend/src/pages/SalesCollect.vue
+++ b/frontend/src/pages/SalesCollect.vue
@@ -13,6 +13,7 @@ const route = useRoute()
 // their manager sees every member's book and filters to one. The server resolves a locked
 // caller from their login, so nothing here can widen a user's scope.
 const customers = ref([])
+const chequeDues = ref([])
 const listLoading = ref(true)
 const loadError = ref(false)
 const unmapped = ref(false) // login has no Sales Person — the page explains rather than looking empty
@@ -48,6 +49,7 @@ async function loadCustomers() {
   try {
     const data = await fetchSalesCustomers(paymentTerm.value, salesPerson.value)
     customers.value = data.customers || []
+    chequeDues.value = data.cheque_dues || []
     paymentTerms.value = data.payment_terms || []
     salesPersons.value = data.sales_persons || []
     person.value = data.sales_person || ''
@@ -73,6 +75,7 @@ onMounted(loadCustomers)
     :list-loading="listLoading"
     :load-error="loadError"
     :customers="filtered"
+    :cheque-dues="chequeDues"
     :empty-message="emptyMessage"
     card-route-name="SalesCustomer"
     :card-payment-term="paymentTerm"

--- a/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.js
+++ b/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.js
@@ -1,0 +1,45 @@
+// Copyright (c) 2026, Gatura Njenga and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("iPay Cheque Collection", {
+	refresh(frm) {
+		// The one accounts action: confirm the physical cheque has arrived. Banking (submitting
+		// the Payment Entry) stays their normal step and is not duplicated here.
+		if (frm.doc.status === "Collected") {
+			frm
+				.add_custom_button(__("Mark Physical Copy Received"), () => {
+					frappe.confirm(
+						__("Confirm the physical cheque from {0} is in hand?", [
+							frm.doc.customer_name || frm.doc.customer,
+						]),
+						() => {
+							frappe
+								.call({
+									method: "ipay.ipay.main.utils.cheque_due.mark_cheque_received",
+									args: { pickup: frm.doc.name },
+									freeze: true,
+									freeze_message: __("Recording receipt…"),
+								})
+								.then(() => frm.reload_doc());
+						},
+					);
+				})
+				.addClass("btn-primary");
+		}
+
+		show_banked_state(frm);
+	},
+});
+
+function show_banked_state(frm) {
+	// Whether the money is banked is the Payment Entry's business, never a stored flag — read it
+	// live and show it, so accounts see at a glance what still needs depositing.
+	if (!frm.doc.payment_entry) return;
+	frappe.db.get_value("Payment Entry", frm.doc.payment_entry, "docstatus").then((r) => {
+		const banked = r && r.message && cint(r.message.docstatus) === 1;
+		frm.dashboard.add_indicator(
+			banked ? __("Banked") : __("Awaiting banking"),
+			banked ? "green" : "orange",
+		);
+	});
+}

--- a/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.json
+++ b/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.json
@@ -1,0 +1,215 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "CHQ-.YYYY.-.#####",
+ "creation": "2026-07-19 08:30:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "customer",
+  "customer_name",
+  "expected_amount",
+  "driver",
+  "notes",
+  "column_break_head",
+  "status",
+  "collection_section",
+  "payment_entry",
+  "cheque_no",
+  "amount_collected",
+  "column_break_coll",
+  "cheque_image",
+  "collected_by",
+  "collected_on",
+  "receipt_section",
+  "received_by",
+  "received_on"
+ ],
+ "fields": [
+  {
+   "fieldname": "customer",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Customer",
+   "options": "Customer",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "customer.customer_name",
+   "fieldname": "customer_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Customer Name",
+   "read_only": 1
+  },
+  {
+   "description": "What accounts expect the cheque to be for. A hint to the driver only — the actual amount is whatever is recorded.",
+   "fieldname": "expected_amount",
+   "fieldtype": "Currency",
+   "label": "Expected Amount"
+  },
+  {
+   "description": "The driver this cheque is routed to. They see it on their collect app; no one else's app does.",
+   "fieldname": "driver",
+   "fieldtype": "Link",
+   "in_standard_filter": 1,
+   "label": "Assigned Driver",
+   "options": "Driver",
+   "reqd": 1
+  },
+  {
+   "description": "Instruction shown to the driver on the customer page — e.g. \"MD signs cheques on Fridays\".",
+   "fieldname": "notes",
+   "fieldtype": "Small Text",
+   "label": "Notes for the Driver"
+  },
+  {
+   "fieldname": "column_break_head",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "Due",
+   "description": "Due → Collected → Physical copy received. Whether the money is banked is read from the linked Payment Entry, not stored here.",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "Due\nCollected\nReceived\nCancelled",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.status != 'Due'",
+   "fieldname": "collection_section",
+   "fieldtype": "Section Break",
+   "label": "Collection"
+  },
+  {
+   "description": "The draft cheque Payment Entry — the proof, and the source of the banked state.",
+   "fieldname": "payment_entry",
+   "fieldtype": "Link",
+   "label": "Payment Entry",
+   "options": "Payment Entry",
+   "read_only": 1
+  },
+  {
+   "fieldname": "cheque_no",
+   "fieldtype": "Data",
+   "label": "Cheque No",
+   "read_only": 1
+  },
+  {
+   "fieldname": "amount_collected",
+   "fieldtype": "Currency",
+   "label": "Amount Collected",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_coll",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "cheque_image",
+   "fieldtype": "Attach Image",
+   "label": "Cheque Image",
+   "read_only": 1
+  },
+  {
+   "fieldname": "collected_by",
+   "fieldtype": "Link",
+   "label": "Collected By",
+   "options": "User",
+   "read_only": 1
+  },
+  {
+   "fieldname": "collected_on",
+   "fieldtype": "Datetime",
+   "label": "Collected On",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.status == 'Received'",
+   "fieldname": "receipt_section",
+   "fieldtype": "Section Break",
+   "label": "Physical Copy Received"
+  },
+  {
+   "fieldname": "received_by",
+   "fieldtype": "Link",
+   "label": "Received By",
+   "options": "User",
+   "read_only": 1
+  },
+  {
+   "fieldname": "received_on",
+   "fieldtype": "Datetime",
+   "label": "Received On",
+   "read_only": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-07-19 08:30:00.000000",
+ "modified_by": "Administrator",
+ "module": "iPay",
+ "name": "iPay Cheque Collection",
+ "naming_rule": "Expression (old style)",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "iPay Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts User",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "customer_name",
+ "track_changes": 1
+}

--- a/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.json
+++ b/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.json
@@ -58,9 +58,9 @@
    "fieldtype": "Link",
    "in_standard_filter": 1,
    "label": "Assigned Driver",
+   "mandatory_depends_on": "eval:doc.status=='Due'",
    "options": "Driver",
-   "read_only_depends_on": "eval:doc.status != 'Due'",
-   "reqd": 1
+   "read_only_depends_on": "eval:doc.status != 'Due'"
   },
   {
    "description": "Instruction shown to the driver on the customer page — e.g. \"MD signs cheques on Fridays\".",

--- a/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.json
+++ b/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.json
@@ -157,7 +157,7 @@
  "links": [],
  "modified": "2026-07-19 08:30:00.000000",
  "modified_by": "Administrator",
- "module": "iPay",
+ "module": "Ipay",
  "name": "iPay Cheque Collection",
  "naming_rule": "Expression (old style)",
  "owner": "Administrator",

--- a/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.json
+++ b/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.json
@@ -34,6 +34,7 @@
    "in_standard_filter": 1,
    "label": "Customer",
    "options": "Customer",
+   "read_only_depends_on": "eval:doc.status != 'Due'",
    "reqd": 1
   },
   {
@@ -48,7 +49,8 @@
    "description": "What accounts expect the cheque to be for. A hint to the driver only — the actual amount is whatever is recorded.",
    "fieldname": "expected_amount",
    "fieldtype": "Currency",
-   "label": "Expected Amount"
+   "label": "Expected Amount",
+   "read_only_depends_on": "eval:doc.status != 'Due'"
   },
   {
    "description": "The driver this cheque is routed to. They see it on their collect app; no one else's app does.",
@@ -57,13 +59,15 @@
    "in_standard_filter": 1,
    "label": "Assigned Driver",
    "options": "Driver",
+   "read_only_depends_on": "eval:doc.status != 'Due'",
    "reqd": 1
   },
   {
    "description": "Instruction shown to the driver on the customer page — e.g. \"MD signs cheques on Fridays\".",
    "fieldname": "notes",
    "fieldtype": "Small Text",
-   "label": "Notes for the Driver"
+   "label": "Notes for the Driver",
+   "read_only_depends_on": "eval:doc.status != 'Due'"
   },
   {
    "fieldname": "column_break_head",

--- a/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.py
+++ b/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2026, Gatura Njenga and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class iPayChequeCollection(Document):
+	"""A cheque tracked from the moment accounts know it is due to the moment the physical copy
+	is in their hands. The lifecycle (Due -> Collected -> Received) and the assignment hand-off
+	live in ipay.ipay.main.utils.cheque_due; this controller only holds the record."""
+
+	pass

--- a/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.py
+++ b/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026, Gatura Njenga and contributors
 # For license information, please see license.txt
 
+import frappe
 from frappe.model.document import Document
 
 
@@ -9,4 +10,16 @@ class iPayChequeCollection(Document):
 	is in their hands. The lifecycle (Due -> Collected -> Received) and the assignment hand-off
 	live in ipay.ipay.main.utils.cheque_due; this controller only holds the record."""
 
-	pass
+	def validate(self):
+		"""A scheduled pickup must be able to reach a collector. Only Due is checked: once the
+		cheque is in, the record is a receipt trail and a system-created one has no driver at all.
+		Frappe evaluates mandatory_depends_on client-side only, so the rule is enforced here."""
+		if self.status != "Due":
+			return
+		if not self.driver:
+			frappe.throw("Assign a driver — a pickup with no driver reaches no collect app.")
+		if not frappe.db.get_value("Driver", self.driver, "user"):
+			frappe.throw(
+				f"Driver {self.driver} has no linked User, so this pickup would never appear "
+				"in the collect app. Set that driver's User field first."
+			)

--- a/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection_list.js
+++ b/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection_list.js
@@ -1,0 +1,16 @@
+// Copyright (c) 2026, Gatura Njenga and contributors
+// For license information, please see license.txt
+
+frappe.listview_settings["iPay Cheque Collection"] = {
+	add_fields: ["status"],
+	get_indicator(doc) {
+		// Colour the accounts queue by where the cheque is: still out, collected and on its way,
+		// physically in hand, or cancelled.
+		return {
+			Due: [__("Due"), "orange", "status,=,Due"],
+			Collected: [__("Collected"), "blue", "status,=,Collected"],
+			Received: [__("Physical copy received"), "green", "status,=,Received"],
+			Cancelled: [__("Cancelled"), "gray", "status,=,Cancelled"],
+		}[doc.status];
+	},
+};

--- a/ipay/ipay/doctype/ipay_settings/ipay_settings.json
+++ b/ipay/ipay/doctype/ipay_settings/ipay_settings.json
@@ -95,10 +95,10 @@
    "options": "Account"
   },
   {
-   "description": "Fallback account for collected cheques, used only when the Cheque Mode of Payment has no account set for the company. Cheques must never book to cash.",
+   "description": "Account collected cheques are booked to, as undeposited funds. Required before a cheque can be recorded — cheques must never book to cash.",
    "fieldname": "cheque_account",
    "fieldtype": "Link",
-   "label": "Cheque Account (fallback)",
+   "label": "Cheque Account",
    "options": "Account"
   },
   {

--- a/ipay/ipay/doctype/ipay_settings/ipay_settings.json
+++ b/ipay/ipay/doctype/ipay_settings/ipay_settings.json
@@ -17,6 +17,7 @@
   "mpesa_max_amount",
   "payment_link_ttl_days",
   "cash_account",
+  "cheque_account",
   "alert_email",
   "last_reconcile_run",
   "restrict_sales_managers"
@@ -91,6 +92,13 @@
    "fieldname": "cash_account",
    "fieldtype": "Link",
    "label": "Cash Account (fallback)",
+   "options": "Account"
+  },
+  {
+   "description": "Fallback account for collected cheques, used only when the Cheque Mode of Payment has no account set for the company. Cheques must never book to cash.",
+   "fieldname": "cheque_account",
+   "fieldtype": "Link",
+   "label": "Cheque Account (fallback)",
    "options": "Account"
   },
   {

--- a/ipay/ipay/doctype/ipay_settings/ipay_settings.json
+++ b/ipay/ipay/doctype/ipay_settings/ipay_settings.json
@@ -18,6 +18,7 @@
   "payment_link_ttl_days",
   "cash_account",
   "allow_cheque_collection",
+  "cheque_per_invoice",
   "cheque_account",
   "alert_email",
   "last_reconcile_run",
@@ -101,6 +102,14 @@
    "fieldname": "allow_cheque_collection",
    "fieldtype": "Check",
    "label": "Allow Cheque Collection"
+  },
+  {
+   "default": "1",
+   "depends_on": "allow_cheque_collection",
+   "description": "Allow a cheque to be attached to specific invoices. Off: every cheque is recorded at the customer level (on account, no invoice attached) and the accounts team decides which invoices it settles.",
+   "fieldname": "cheque_per_invoice",
+   "fieldtype": "Check",
+   "label": "Cheque Per Invoice"
   },
   {
    "description": "Account collected cheques are booked to, as undeposited funds. Required before a cheque can be recorded — cheques must never book to cash.",

--- a/ipay/ipay/doctype/ipay_settings/ipay_settings.json
+++ b/ipay/ipay/doctype/ipay_settings/ipay_settings.json
@@ -20,6 +20,7 @@
   "allow_cheque_collection",
   "cheque_per_invoice",
   "cheque_account",
+  "cheque_banking_assignee",
   "alert_email",
   "last_reconcile_run",
   "restrict_sales_managers"
@@ -117,6 +118,14 @@
    "fieldtype": "Link",
    "label": "Cheque Account",
    "options": "Account"
+  },
+  {
+   "depends_on": "allow_cheque_collection",
+   "description": "Who a collected cheque is assigned to for banking. Leave blank to assign to everyone holding the Accounts Manager role.",
+   "fieldname": "cheque_banking_assignee",
+   "fieldtype": "Link",
+   "label": "Cheque Banking Assignee",
+   "options": "User"
   },
   {
    "description": "Where money-at-risk alerts (a payment confirmed at iPay but not recorded) are emailed. Leave blank to log to Error Log only.",

--- a/ipay/ipay/doctype/ipay_settings/ipay_settings.json
+++ b/ipay/ipay/doctype/ipay_settings/ipay_settings.json
@@ -17,6 +17,7 @@
   "mpesa_max_amount",
   "payment_link_ttl_days",
   "cash_account",
+  "allow_cheque_collection",
   "cheque_account",
   "alert_email",
   "last_reconcile_run",
@@ -93,6 +94,13 @@
    "fieldtype": "Link",
    "label": "Cash Account (fallback)",
    "options": "Account"
+  },
+  {
+   "default": "0",
+   "description": "Let collectors record a cheque from the collect app. Off by default; a Cheque Account must also be set before a cheque can be recorded.",
+   "fieldname": "allow_cheque_collection",
+   "fieldtype": "Check",
+   "label": "Allow Cheque Collection"
   },
   {
    "description": "Account collected cheques are booked to, as undeposited funds. Required before a cheque can be recorded — cheques must never book to cash.",

--- a/ipay/ipay/main/main.py
+++ b/ipay/ipay/main/main.py
@@ -37,7 +37,13 @@ def lipana_mpesa(
     # cancelled request; this closes the operator/worker path too.
     state = frappe.db.get_value(
         "iPay Request", docid, ["docstatus", "status"], as_dict=True
-    ) or {}
+    )
+    # No request at all: it was deleted or split, or the transaction that created it rolled back
+    # after the job was already enqueued. An empty state used to pass the checks below and push
+    # an STK for a request that does not exist — never charge in that case.
+    if not state:
+        create_log_entry("INF", f"Skipping STK for {docid}: request no longer exists")
+        return {"status": "skipped", "message": "This request is no longer chargeable."}
     if state.get("docstatus") == 2 or state.get("status") in ("Success", "Underpaid", "Overpaid"):
         create_log_entry(
             "INF",

--- a/ipay/ipay/main/main.py
+++ b/ipay/ipay/main/main.py
@@ -46,6 +46,15 @@ def lipana_mpesa(
         )
         return {"status": "skipped", "message": "This request is no longer chargeable."}
 
+    # The desk "Prompt iPay" button reaches here directly, and a worker picks this up moments
+    # after enqueue — so this last line also stops a cheque collected in that gap. Every other
+    # rail is refused earlier; this is the one that bypasses them all.
+    from ipay.ipay.main.utils.ipay_redirect import _request_awaits_cheque, CHEQUE_HELD
+
+    if _request_awaits_cheque(docid):
+        create_log_entry("INF", f"Skipping STK for {docid}: a cheque has been collected")
+        return {"status": "skipped", "message": CHEQUE_HELD}
+
     # Enforce the M-Pesa STK ceiling on EVERY path — the desk button calls this directly,
     # bypassing _enqueue_stk's check. Over the cap M-Pesa can't process the charge.
     if payment_request_type == "Mpesa Express":

--- a/ipay/ipay/main/utils/cheque.py
+++ b/ipay/ipay/main/utils/cheque.py
@@ -1,0 +1,45 @@
+"""Which invoices a collected cheque already covers.
+
+A cheque is recorded as a DRAFT Payment Entry for the accounts team to submit, and a draft does
+not reduce outstanding — so the invoice still looks unpaid to every other query. This answers
+"is this money already in hand" once, for the marker on a card and the guard on a bundle.
+"""
+
+import frappe
+from frappe.utils import flt
+
+from ipay.ipay.main.utils.constants import CHEQUE_MODE
+
+
+def awaiting_cheque_amounts(sales_invoices):
+    """Map of Sales Invoice -> amount a draft cheque covers (two batched queries)."""
+    names = [name for name in (sales_invoices or []) if name]
+    if not names:
+        return {}
+
+    rows = frappe.get_all(
+        "Payment Entry Reference",
+        filters={"reference_doctype": "Sales Invoice", "reference_name": ["in", names], "docstatus": 0},
+        fields=["parent", "reference_name", "allocated_amount"],
+    )
+    if not rows:
+        return {}
+
+    # A draft reference alone is not a cheque — only the parent entry knows the mode.
+    cheques = set(
+        frappe.get_all(
+            "Payment Entry",
+            filters={
+                "name": ["in", list({row.parent for row in rows})],
+                "docstatus": 0,
+                "mode_of_payment": CHEQUE_MODE,
+            },
+            pluck="name",
+        )
+    )
+
+    covered = {}
+    for row in rows:
+        if row.parent in cheques:
+            covered[row.reference_name] = covered.get(row.reference_name, 0) + flt(row.allocated_amount)
+    return covered

--- a/ipay/ipay/main/utils/cheque_due.py
+++ b/ipay/ipay/main/utils/cheque_due.py
@@ -1,0 +1,184 @@
+"""The cheque pickup lifecycle: Due -> Collected -> Received.
+
+Accounts often know a cheque is coming that the driver in the field does not. A pickup lets them
+flag it, route it to a driver, and get it back with proof for banking. Every cheque a driver
+records is tracked this way — scheduled or not — so the physical copy can be followed from the
+field to the banking desk and none is ever lost in between.
+
+Whether the money is banked is the Payment Entry's business (draft vs submitted), never a second
+flag here — one source of truth for the ledger.
+"""
+
+import frappe
+from frappe.utils import now_datetime
+
+from ipay.ipay.main.utils.collector import my_driver_ids
+
+DOCTYPE = "iPay Cheque Collection"
+ACCOUNTS_ROLE = "Accounts Manager"
+# The roles allowed to confirm a physical cheque has arrived.
+RECEIPT_ROLES = {"Accounts Manager", "Accounts User", "iPay Manager", "System Manager"}
+DUE_FIELDS = ["name", "customer", "customer_name", "expected_amount", "notes"]
+
+
+def _oldest_open_due(customer, driver_ids):
+	"""The oldest Due pickup for this customer routed to one of `driver_ids` — the one a
+	collection completes. None when accounts scheduled nothing (an ad-hoc collection)."""
+	if not driver_ids:
+		return None
+	rows = frappe.get_all(
+		DOCTYPE,
+		filters={"customer": customer, "status": "Due", "driver": ["in", list(driver_ids)]},
+		pluck="name",
+		order_by="creation asc",
+		limit=1,
+	)
+	return rows[0] if rows else None
+
+
+def advance_or_create_on_collect(customer, payment_entry, cheque_no, amount, image_url, collector):
+	"""Track a just-recorded cheque. Completes the collector's oldest scheduled pickup for this
+	customer, or opens a fresh Collected record when none was scheduled — so every collected
+	cheque reaches the accounts receipt queue. Then hands it to accounts for banking.
+
+	Runs after the money is already saved; the caller must swallow any error so a tracking
+	failure can never undo a real cheque."""
+	driver_ids = my_driver_ids(collector)
+	proof = {
+		"status": "Collected",
+		"payment_entry": payment_entry,
+		"cheque_no": cheque_no,
+		"amount_collected": amount,
+		"cheque_image": image_url,
+		"collected_by": collector,
+		"collected_on": now_datetime(),
+	}
+	name = _oldest_open_due(customer, driver_ids)
+	if name:
+		doc = frappe.get_doc(DOCTYPE, name)
+		doc.update(proof)
+		doc.save(ignore_permissions=True)
+	else:
+		doc = frappe.get_doc({
+			"doctype": DOCTYPE,
+			"customer": customer,
+			# Ad-hoc collection has no scheduled driver: use the collector's own. A driver is
+			# mandatory for a human scheduling a pickup, so only the system record — created for
+			# a collector who maps to no Driver (an operator) — skips it.
+			"driver": driver_ids[0] if driver_ids else None,
+			**proof,
+		})
+		if not driver_ids:
+			doc.flags.ignore_mandatory = True
+		doc.insert(ignore_permissions=True)
+	reassign_to_accounts(doc)
+	return doc.name
+
+
+def _banking_assignees():
+	"""Who a collected cheque is handed to for banking: the configured user, else everyone
+	enabled who holds the Accounts Manager role. Never the system user."""
+	assignee = frappe.db.get_single_value("iPay Settings", "cheque_banking_assignee")
+	if assignee:
+		return [assignee] if assignee != "Administrator" else []
+	holders = [
+		u
+		for u in frappe.get_all(
+			"Has Role", filters={"role": ACCOUNTS_ROLE, "parenttype": "User"}, pluck="parent"
+		)
+		if u != "Administrator"
+	]
+	if not holders:
+		return []
+	return frappe.get_all(
+		"User", filters={"name": ["in", holders], "enabled": 1}, pluck="name"
+	)
+
+
+def reassign_to_accounts(doc):
+	"""Hand the pickup to the banking team via native assignment (their desk to-do), clearing
+	any earlier assignment first so it lands only with accounts."""
+	from frappe.desk.form import assign_to
+
+	assign_to.close_all_assignments(DOCTYPE, doc.name, ignore_permissions=True)
+	assignees = _banking_assignees()
+	if not assignees:
+		return
+	assign_to.add(
+		{
+			"doctype": DOCTYPE,
+			"name": doc.name,
+			"assign_to": assignees,
+			"description": f"Cheque collected from {doc.customer_name or doc.customer} "
+			f"— receive the physical copy and bank it.",
+		},
+		ignore_permissions=True,
+	)
+
+
+@frappe.whitelist()
+def mark_cheque_received(pickup):
+	"""Accounts confirm the physical cheque is in hand. Stamps who/when and clears the to-do.
+	The record is done here — banking (submitting the Payment Entry) stays the normal step."""
+	roles = set(frappe.get_roles())
+	if not (RECEIPT_ROLES & roles):
+		frappe.throw("Only the accounts team can receive a cheque.", frappe.PermissionError)
+
+	from frappe.desk.form import assign_to
+
+	doc = frappe.get_doc(DOCTYPE, pickup)
+	if doc.status != "Collected":
+		frappe.throw("Only a collected cheque can be marked received.")
+	doc.status = "Received"
+	doc.received_by = frappe.session.user
+	doc.received_on = now_datetime()
+	doc.save(ignore_permissions=True)
+	assign_to.close_all_assignments(DOCTYPE, doc.name, ignore_permissions=True)
+	return doc.status
+
+
+# --- Banner queries: which cheques are still to collect ---------------------------------------
+# Each collect surface feeds its banner from the scope it already enforces — the driver sees only
+# what is routed to them, operators see everything, sales sees its own book.
+
+def open_dues_for_driver(user):
+	"""Due pickups routed to this collector's driver(s) — the field app's banner."""
+	drivers = my_driver_ids(user)
+	if not drivers:
+		return []
+	return _due_rows({"driver": ["in", drivers]})
+
+
+def all_open_dues():
+	"""Every Due pickup — the internal (operator) banner."""
+	return _due_rows({})
+
+
+def open_dues_for_customers(customers):
+	"""Due pickups for a set of customers — the sales banner, scoped to the member's book."""
+	customers = list(customers or [])
+	if not customers:
+		return []
+	return _due_rows({"customer": ["in", customers]})
+
+
+def _due_rows(extra):
+	filters = {"status": "Due"}
+	filters.update(extra)
+	return frappe.get_all(DOCTYPE, filters=filters, fields=DUE_FIELDS, order_by="creation asc")
+
+
+def open_due_for_customer(customer, driver_ids=None):
+	"""The single open Due for one customer (optionally within a driver scope), oldest first —
+	what the customer-page banner shows, matching what a collection would complete. `driver_ids`
+	of None means any driver (operator/sales view); an empty list means the collector is routed
+	nothing, so nothing shows."""
+	filters = {"status": "Due", "customer": customer}
+	if driver_ids is not None:
+		if not driver_ids:
+			return None
+		filters["driver"] = ["in", list(driver_ids)]
+	rows = frappe.get_all(
+		DOCTYPE, filters=filters, fields=DUE_FIELDS, order_by="creation asc", limit=1
+	)
+	return rows[0] if rows else None

--- a/ipay/ipay/main/utils/cheque_due.py
+++ b/ipay/ipay/main/utils/cheque_due.py
@@ -146,17 +146,21 @@ def mark_cheque_received(pickup):
 # Each collect surface feeds its banner from the scope it already enforces — the driver sees only
 # what is routed to them, operators see everything, sales sees its own book.
 
-def open_dues_for_driver(user):
-	"""Due pickups routed to this collector's driver(s) — the field app's banner."""
+def open_dues_for_driver(user, driver=None):
+	"""Due pickups routed to this collector's driver(s) — the field app's banner. `driver`
+	narrows to one of their own, so the banner follows the page's driver filter; a driver that
+	is not theirs narrows to nothing rather than widening."""
 	drivers = my_driver_ids(user)
+	if driver:
+		drivers = [d for d in drivers if d == driver]
 	if not drivers:
 		return []
 	return _due_rows({"driver": ["in", drivers]})
 
 
-def all_open_dues():
-	"""Every Due pickup — the internal (operator) banner."""
-	return _due_rows({})
+def all_open_dues(driver=None):
+	"""Every Due pickup — the internal (operator) banner, narrowed to one driver on request."""
+	return _due_rows({"driver": driver} if driver else {})
 
 
 def open_dues_for_customers(customers):

--- a/ipay/ipay/main/utils/cheque_due.py
+++ b/ipay/ipay/main/utils/cheque_due.py
@@ -21,19 +21,26 @@ RECEIPT_ROLES = {"Accounts Manager", "Accounts User", "iPay Manager", "System Ma
 DUE_FIELDS = ["name", "customer", "customer_name", "expected_amount", "notes"]
 
 
-def _oldest_open_due(customer, driver_ids):
-	"""The oldest Due pickup for this customer routed to one of `driver_ids` — the one a
-	collection completes. None when accounts scheduled nothing (an ad-hoc collection)."""
-	if not driver_ids:
-		return None
+def _oldest_open_due(customer):
+	"""The oldest Due pickup for this customer — the one a collection completes, whoever brought
+	the cheque in. Deliberately not scoped to the recorder's driver: operators and sales users map
+	to no Driver at all, and the cheque is in the office however it arrived, so scoping here would
+	leave the pickup open and send someone after a cheque already collected.
+	None when accounts scheduled nothing (an ad-hoc collection)."""
 	rows = frappe.get_all(
 		DOCTYPE,
-		filters={"customer": customer, "status": "Due", "driver": ["in", list(driver_ids)]},
+		filters={"customer": customer, "status": "Due"},
 		pluck="name",
 		order_by="creation asc",
 		limit=1,
 	)
 	return rows[0] if rows else None
+
+
+def has_open_pickup(customer):
+	"""Has accounts flagged a cheque to collect from this customer? A grant to act on that
+	customer, not to see them — keep it to the collect action, never a display scope."""
+	return bool(frappe.db.exists(DOCTYPE, {"customer": customer, "status": "Due"}))
 
 
 def advance_or_create_on_collect(customer, payment_entry, cheque_no, amount, image_url, collector):
@@ -53,7 +60,7 @@ def advance_or_create_on_collect(customer, payment_entry, cheque_no, amount, ima
 		"collected_by": collector,
 		"collected_on": now_datetime(),
 	}
-	name = _oldest_open_due(customer, driver_ids)
+	name = _oldest_open_due(customer)
 	if name:
 		doc = frappe.get_doc(DOCTYPE, name)
 		doc.update(proof)
@@ -62,14 +69,12 @@ def advance_or_create_on_collect(customer, payment_entry, cheque_no, amount, ima
 		doc = frappe.get_doc({
 			"doctype": DOCTYPE,
 			"customer": customer,
-			# Ad-hoc collection has no scheduled driver: use the collector's own. A driver is
-			# mandatory for a human scheduling a pickup, so only the system record — created for
-			# a collector who maps to no Driver (an operator) — skips it.
+			# Ad-hoc collection has no scheduled driver: record the collector's own when they map
+			# to one. Operators and sales users map to none, and a record that is already Collected
+			# needs no driver — it is the receipt trail, not a dispatch.
 			"driver": driver_ids[0] if driver_ids else None,
 			**proof,
 		})
-		if not driver_ids:
-			doc.flags.ignore_mandatory = True
 		doc.insert(ignore_permissions=True)
 	reassign_to_accounts(doc)
 	return doc.name

--- a/ipay/ipay/main/utils/collector.py
+++ b/ipay/ipay/main/utils/collector.py
@@ -61,12 +61,23 @@ def _invoices_delivered_by(drivers):
 
 
 def collector_scope(user=None):
-    """The set of Sales Invoices and iPay Requests a collector may see.
+    """The set of Sales Invoices and iPay Requests a collector may see, cached for the life of
+    the request — access is checked once per invoice in a bundle, and the scope is several
+    unbounded reads (mirrors sales._cached_scope).
 
     invoices = driver-delivered ∪ assigned-request invoices (single + bundle).
     requests = explicitly-assigned ∪ requests covering a driver-delivered invoice.
     """
     user = user or frappe.session.user
+    cache = getattr(frappe.local, "ipay_collector_scope", None)
+    if cache is None:
+        cache = frappe.local.ipay_collector_scope = {}
+    if user not in cache:
+        cache[user] = _compute_collector_scope(user)
+    return cache[user]
+
+
+def _compute_collector_scope(user):
     invoices = _invoices_delivered_by(my_driver_ids(user))
     requests = set(my_assigned_requests(user))
 
@@ -105,6 +116,56 @@ def can_access_invoice(sales_invoice, user=None):
         if sales.can_access_invoice(sales_invoice, user):
             return True
     return not scoped
+
+
+def can_access_customer(customer, user=None):
+    """May this user act on a customer-level (on-account) cheque? Always True for a full operator;
+    a scoped actor must hold at least one of the customer's outstanding invoices. Checked against
+    the actor's own (bounded) book in one query — never by scanning the customer's every invoice,
+    which for a large customer was minutes of work per request."""
+    from ipay.ipay.main.utils import sales
+
+    user = user or frappe.session.user
+    scoped = False
+    if is_collector_only(user):
+        scoped = True
+        if _customer_has_scoped_invoice(customer, collector_scope(user)["invoices"]):
+            return True
+    if sales.is_sales_only(user):
+        scoped = True
+        if sales.can_access_customer(customer, user):
+            return True
+    if scoped:
+        return False
+    # Unscoped (full operator / Sales Manager): the old loop granted only when the customer had
+    # an outstanding invoice to grant on, so keep that — an on-account cheque still needs one.
+    return _customer_has_outstanding(customer)
+
+
+def _customer_has_outstanding(customer):
+    """True when the customer has any outstanding invoice at all."""
+    return bool(
+        frappe.db.exists(
+            "Sales Invoice",
+            {"customer": customer, "docstatus": 1, "outstanding_amount": [">", 0]},
+        )
+    )
+
+
+def _customer_has_scoped_invoice(customer, scope_invoices):
+    """True when one of `scope_invoices` is an outstanding invoice of `customer` — the same
+    accept test the per-invoice check applied, intersected in the database in one query."""
+    return bool(scope_invoices) and bool(
+        frappe.db.exists(
+            "Sales Invoice",
+            {
+                "name": ["in", list(scope_invoices)],
+                "customer": customer,
+                "docstatus": 1,
+                "outstanding_amount": [">", 0],
+            },
+        )
+    )
 
 
 def can_access_request(request_name, user=None):

--- a/ipay/ipay/main/utils/constants.py
+++ b/ipay/ipay/main/utils/constants.py
@@ -32,6 +32,11 @@ ACTIVE_BUNDLE_WINDOW_MIN = 30
 COLLECTION_NOTE_SUBJECT = "iPay Collection Note"
 COLLECTION_NOTE_MAX_LENGTH = 500
 
+# The Mode of Payment a collected cheque is recorded under — what marks a draft Payment Entry as
+# "a cheque a collector took", both when writing one and when flagging the invoices it covers.
+CHEQUE_MODE = "Cheque"
+CHEQUE_NO_MAX_LENGTH = 30
+
 
 def note_filters(reference_name):
     """Comment filters for the collection notes on one invoice, or on a list of them."""

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -14,6 +14,8 @@ from ipay.ipay.main.utils.constants import (
     note_filters,
     note_text,
     ACTIVE_BUNDLE_WINDOW_MIN,
+    CHEQUE_MODE,
+    CHEQUE_NO_MAX_LENGTH,
     COLLECTION_NOTE_MAX_LENGTH,
     COLLECTION_NOTE_SUBJECT,
 )
@@ -35,9 +37,6 @@ ALL_OPERATOR_ROLES = OPERATOR_ROLES | {"iPay Collector", "Sales User", "Sales Ma
 # Bundling several invoices into one prompt: operators, sales users and sales managers
 # (who chase a customer's whole balance). Field collectors stay one invoice at a time.
 BUNDLER_ROLES = OPERATOR_ROLES | {"Sales User", "Sales Manager"}
-
-CHEQUE_MODE = "Cheque"
-CHEQUE_NO_MAX_LENGTH = 30
 
 
 def _require_full_operator():

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -948,11 +948,17 @@ def add_invoice_note(invoice, note):
 
 def _require_customer_access(customer):
     """A scoped actor may only act on a customer they hold an outstanding invoice for — an
-    on-account cheque names no invoice, so nothing else would scope it."""
+    on-account cheque names no invoice, so nothing else would scope it.
+
+    A pickup accounts flagged is itself the instruction to collect from that customer, and a
+    flagged customer may have no outstanding invoice to be scoped by. Granted here at the action
+    rather than in can_access_customer, which also gates what a scoped actor may *see*."""
+    from ipay.ipay.main.utils.cheque_due import has_open_pickup
     from ipay.ipay.main.utils.collector import can_access_customer
 
-    if not can_access_customer(customer):
-        frappe.throw("You are not assigned to this customer.", frappe.PermissionError)
+    if can_access_customer(customer) or has_open_pickup(customer):
+        return
+    frappe.throw("You are not assigned to this customer.", frappe.PermissionError)
 
 
 def _cheque_account(company):

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -3,7 +3,9 @@ import hmac
 import hashlib
 
 import frappe
+from frappe.utils.file_manager import save_file
 
+from ipay.ipay.main.utils.make_payment_entry import allocate_references
 from ipay.ipay.main.utils.reconcile_payments import reconcile_request
 from ipay.ipay.main.utils.ipay_logs import create_log_entry
 from ipay.ipay.main.utils.constants import (
@@ -33,6 +35,9 @@ ALL_OPERATOR_ROLES = OPERATOR_ROLES | {"iPay Collector", "Sales User", "Sales Ma
 # Bundling several invoices into one prompt: operators, sales users and sales managers
 # (who chase a customer's whole balance). Field collectors stay one invoice at a time.
 BUNDLER_ROLES = OPERATOR_ROLES | {"Sales User", "Sales Manager"}
+
+CHEQUE_MODE = "Cheque"
+CHEQUE_NO_MAX_LENGTH = 30
 
 
 def _require_full_operator():
@@ -870,6 +875,130 @@ def add_invoice_note(invoice, note):
             "content": note_content(text),
         }
     ).insert(ignore_permissions=True)
+
+
+def _require_customer_access(customer):
+    """A scoped actor may only act on a customer they hold an outstanding invoice for — an
+    on-account cheque names no invoice, so nothing else would scope it."""
+    from ipay.ipay.main.utils.collector import can_access_invoice
+
+    for invoice in frappe.get_all(
+        "Sales Invoice",
+        filters={"customer": customer, "docstatus": 1, "outstanding_amount": [">", 0]},
+        pluck="name",
+    ):
+        if can_access_invoice(invoice):
+            return
+    frappe.throw("You are not assigned to this customer.", frappe.PermissionError)
+
+
+def _cheque_account(company):
+    """Cheques land in the undeposited-cheque account, never cash."""
+    account = frappe.db.get_value(
+        "Mode of Payment Account", {"parent": CHEQUE_MODE, "company": company}, "default_account"
+    ) or frappe.db.get_single_value("iPay Settings", "cheque_account")
+    if not account:
+        frappe.throw(
+            f"No cheque account is configured for {company}. Set a Default Account on Mode of "
+            f"Payment {CHEQUE_MODE}, or set iPay Settings → Cheque Account (fallback)."
+        )
+    return account
+
+
+def _cheque_company(customer):
+    """On-account cheques name no invoice, so take the company from the customer's own book."""
+    company = frappe.db.get_value(
+        "Sales Invoice", {"customer": customer, "docstatus": 1}, "company", order_by="posting_date desc"
+    )
+    if not company:
+        frappe.throw("This customer has no invoices to book a cheque against.")
+    return company
+
+
+@frappe.whitelist(methods=["POST"])
+def record_cheque(customer, amount, cheque_no, photo, invoices=None, cheque_date=None):
+    """Record a collected cheque as a DRAFT Payment Entry — the accounts team submits it, never us.
+
+    Ticked invoices allocate against them; none means an on-account credit."""
+    _require_operator()
+
+    invoice_names = frappe.parse_json(invoices) if isinstance(invoices, str) else list(invoices or [])
+    for invoice in invoice_names:
+        _require_invoice_access(invoice)
+    if not invoice_names:
+        _require_customer_access(customer)
+
+    amount = frappe.utils.flt(amount)
+    if amount <= 0:
+        frappe.throw("Enter the cheque amount.")
+    number = (cheque_no or "").strip()
+    if not number:
+        frappe.throw("Enter the cheque number.")
+    if len(number) > CHEQUE_NO_MAX_LENGTH:
+        frappe.throw(f"Keep the cheque number under {CHEQUE_NO_MAX_LENGTH} characters.")
+    if not photo:
+        frappe.throw("Attach a photo of the cheque.")
+
+    if invoice_names:
+        invoices_data, references, remaining = allocate_references(invoice_names, amount)
+        if any(si.customer != customer for si in invoices_data):
+            frappe.throw("Those invoices do not all belong to this customer.")
+        company = invoices_data[0].company
+    else:
+        references, remaining = [], amount
+        company = _cheque_company(customer)
+
+    payment_entry = frappe.new_doc("Payment Entry")
+    payment_entry.payment_type = "Receive"
+    payment_entry.company = company
+    payment_entry.posting_date = frappe.utils.today()
+    payment_entry.mode_of_payment = CHEQUE_MODE
+    payment_entry.party_type = "Customer"
+    payment_entry.party = customer
+    payment_entry.paid_to = _cheque_account(company)
+    payment_entry.paid_amount = amount
+    payment_entry.received_amount = amount
+    payment_entry.source_exchange_rate = 1.0
+    payment_entry.target_exchange_rate = 1.0
+    payment_entry.unallocated_amount = remaining
+    # Namespaced by customer: two customers may share a cheque number, one customer may not reuse it.
+    payment_entry.reference_no = f"{number}-{customer}"
+    payment_entry.reference_date = cheque_date or frappe.utils.today()
+    payment_entry.custom_remarks = 1
+    allocated_to = ", ".join(r["reference_name"] for r in references) or "account"
+    payment_entry.remarks = (
+        f"Cheque {number} for KES {amount} collected from {customer} against {allocated_to}\n"
+        f"Recorded from iPay Collect by {frappe.session.user}"
+    )
+    for ref in references:
+        payment_entry.append("references", ref)
+
+    # ERPNext's own validation calls frappe.has_permission("Payment Entry"), which ignore_permissions
+    # cannot bypass and iPay roles never hold — the guards above are the authorisation instead.
+    collector = frappe.session.user
+    frappe.set_user("Administrator")
+    try:
+        payment_entry.insert(ignore_permissions=True)
+        # insert() always stamps the session user, so the collector is restored as owner after it.
+        payment_entry.db_set("owner", collector, update_modified=False)
+        # Attached after the insert, or a rejected Payment Entry strands the written file.
+        save_file(
+            f"cheque-{number}.jpg", photo, "Payment Entry", payment_entry.name,
+            decode=True, is_private=1,
+        )
+    except frappe.UniqueValidationError:
+        frappe.throw(f"Cheque {number} is already recorded for this customer.")
+    except OSError:
+        # A corrupt photo arrives as an unreadable image, not a validation error.
+        frappe.throw("That photo could not be read. Take it again.")
+    finally:
+        frappe.set_user(collector)
+
+    return {
+        "payment_entry": payment_entry.name,
+        "amount": amount,
+        "allocated": frappe.utils.flt(amount - remaining),
+    }
 
 
 @frappe.whitelist(allow_guest=True, methods=["POST"])

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -936,16 +936,10 @@ def add_invoice_note(invoice, note):
 def _require_customer_access(customer):
     """A scoped actor may only act on a customer they hold an outstanding invoice for — an
     on-account cheque names no invoice, so nothing else would scope it."""
-    from ipay.ipay.main.utils.collector import can_access_invoice
+    from ipay.ipay.main.utils.collector import can_access_customer
 
-    for invoice in frappe.get_all(
-        "Sales Invoice",
-        filters={"customer": customer, "docstatus": 1, "outstanding_amount": [">", 0]},
-        pluck="name",
-    ):
-        if can_access_invoice(invoice):
-            return
-    frappe.throw("You are not assigned to this customer.", frappe.PermissionError)
+    if not can_access_customer(customer):
+        frappe.throw("You are not assigned to this customer.", frappe.PermissionError)
 
 
 def _cheque_account(company):

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -38,6 +38,8 @@ ALL_OPERATOR_ROLES = OPERATOR_ROLES | {"iPay Collector", "Sales User", "Sales Ma
 # Bundling several invoices into one prompt: operators, sales users and sales managers
 # (who chase a customer's whole balance). Field collectors stay one invoice at a time.
 BUNDLER_ROLES = OPERATOR_ROLES | {"Sales User", "Sales Manager"}
+# Shown wherever a rail refuses an invoice a cheque has already been collected for.
+CHEQUE_HELD = "A cheque has already been collected for this — accounts will bank it."
 
 
 def _require_full_operator():
@@ -231,6 +233,10 @@ def _ensure_request(invoice):
     # _ensure_request for the same invoice blocks here until we commit, then sees
     # the request we created and reuses it instead of inserting a second one.
     frappe.db.get_value("Sales Invoice", invoice, "name", for_update=True)
+    # A cheque already collected leaves the invoice outstanding until accounts bank it, so it
+    # still looks chargeable — every rail creates its request here, so one refusal covers them.
+    if awaiting_cheque_amounts([invoice]):
+        frappe.throw(CHEQUE_HELD)
     # If this invoice is a member of an active bundle, collect through that bundle —
     # never spin up a duplicate request for a bundled invoice (it would double-charge
     # it). A non-primary member's lookup below would otherwise miss the bundle.
@@ -316,6 +322,10 @@ def resolve_pay_token(token):
         return None, "invalid"
     if row.pay_token_expiry and frappe.utils.get_datetime(row.pay_token_expiry) < frappe.utils.now_datetime():
         return None, "expired"
+    # The token outlives the moment it was minted (days), so a cheque collected after it was
+    # shared must still stop it here — this is the one gate every token rail passes through.
+    if _request_awaits_cheque(row.name):
+        return None, "held"
     return row.name, "ok"
 
 
@@ -344,13 +354,23 @@ def _payment_state(request_name, include_detail=False):
     return state
 
 
+def _request_invoices(request_name, sales_invoice=None):
+    """The Sales Invoices a request covers: a bundle's child rows, else its single invoice."""
+    return frappe.get_all(
+        "iPay Request Invoice", filters={"parent": request_name}, pluck="sales_invoice"
+    ) or [sales_invoice or frappe.db.get_value("iPay Request", request_name, "sales_invoice")]
+
+
+def _request_awaits_cheque(request_name, sales_invoice=None):
+    """True when a draft cheque already covers any invoice this request would charge."""
+    return bool(awaiting_cheque_amounts(_request_invoices(request_name, sales_invoice)))
+
+
 def _live_request_amount(request_name, sales_invoice):
     """Sum the live outstanding of a request's invoices (a bundle's child rows, or
     the single sales invoice) so an STK charges what is actually owed now — not a
     stored amount that goes stale when a member invoice is paid separately."""
-    invoices = frappe.get_all(
-        "iPay Request Invoice", filters={"parent": request_name}, pluck="sales_invoice"
-    ) or [sales_invoice]
+    invoices = _request_invoices(request_name, sales_invoice)
     total = 0.0
     for invoice in invoices:
         if invoice:
@@ -382,6 +402,10 @@ def _enqueue_stk(request_name, phone):
         return {"status": "error", "message": "This request is no longer chargeable."}
     if req.status in ("Success", "Underpaid", "Overpaid"):
         return {"status": "error", "message": "This request has already been paid."}
+    # A request raised before the cheque was collected is still chargeable on its own — the
+    # invoice's outstanding does not move until accounts bank it.
+    if _request_awaits_cheque(request_name, req.sales_invoice):
+        return {"status": "error", "message": CHEQUE_HELD}
 
     phone = normalize_phone(phone or req.customer_phone)
     if not phone:
@@ -465,6 +489,8 @@ def start_request_checkout(request):
     _require_operator()
     _require_redirect_enabled()
     _require_request_access(request)
+    if _request_awaits_cheque(request):
+        frappe.throw(CHEQUE_HELD)
     token = _ensure_pay_token(request)
     return {"url": f"/ipay_checkout?token={token}"}
 
@@ -481,6 +507,10 @@ def get_payment_link(invoice=None, request=None):
     request_name = request or (_ensure_request(invoice) if invoice else None)
     if not request_name:
         frappe.throw("An invoice or iPay Request is required.")
+    # The invoice path is already refused inside _ensure_request; this covers the request path,
+    # so an operator is never handed a link the checkout page would then refuse.
+    if _request_awaits_cheque(request_name):
+        frappe.throw(CHEQUE_HELD)
     token = _ensure_pay_token(request_name)
     return {
         "url": frappe.utils.get_url("/pay?token=" + token),
@@ -502,6 +532,8 @@ def regenerate_payment_link(request):
     status = frappe.db.get_value("iPay Request", request, "status")
     if status in ("Success", "Overpaid"):
         frappe.throw("This request is already paid; a new payment link is not needed.")
+    if _request_awaits_cheque(request):
+        frappe.throw(CHEQUE_HELD)
     token = _new_pay_token(request)
     frappe.db.commit()
     return {

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -75,6 +75,11 @@ def _cheque_enabled():
     return bool(frappe.db.get_single_value("iPay Settings", "allow_cheque_collection"))
 
 
+def _cheque_per_invoice_enabled():
+    """True when a cheque may attach to specific invoices; off means customer-level only."""
+    return bool(frappe.db.get_single_value("iPay Settings", "cheque_per_invoice"))
+
+
 def _require_redirect_enabled():
     """Hard gate for the payment-link / hosted-checkout endpoints: they exist only
     when "Use Hosted Checkout Redirect" is on. With it off the org collects by
@@ -836,6 +841,8 @@ def request_detail(request):
         "enable_redirect": _redirect_enabled(),
         # Whether the cheque action is offered here, read fresh like enable_redirect.
         "allow_cheque": _cheque_enabled(),
+        # Off means the cheque here records on account, not against this request's invoices.
+        "cheque_per_invoice": _cheque_per_invoice_enabled(),
         # Non-zero once a cheque covers these invoices — the page then hides its charge actions.
         "awaiting_cheque": awaiting_cheque,
         # Above this the M-Pesa prompt is hidden (only hosted checkout can take it).
@@ -978,6 +985,10 @@ def record_cheque(customer, amount, cheque_no, photo, invoices=None, cheque_date
         frappe.throw("Cheque collection is turned off (enable it in iPay Settings).")
 
     invoice_names = frappe.parse_json(invoices) if isinstance(invoices, str) else list(invoices or [])
+    # When per-invoice cheques are off, every cheque is customer-level — drop any invoices a client
+    # sent so it can never attach to one, whatever the UI offered.
+    if not _cheque_per_invoice_enabled():
+        invoice_names = []
     for invoice in invoice_names:
         _require_invoice_access(invoice)
     if not invoice_names:

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -805,6 +805,9 @@ def request_detail(request):
         # A single (non-bundle) request has no child rows; its one invoice carries the
         # whole request amount.
         invoices = [{"name": req.sales_invoice, "amount": frappe.utils.flt(req.amount)}]
+    # A cheque already collected against any of these invoices makes the request unchargeable,
+    # so the page hides its charge actions the same way an invoice card does.
+    awaiting_cheque = frappe.utils.flt(sum(awaiting_cheque_amounts([i["name"] for i in invoices]).values()))
     cancelled = req.docstatus == 2
     status = "Cancelled" if cancelled else (req.status or "Pending")
     is_bundle = len(invoices) > 1
@@ -825,6 +828,10 @@ def request_detail(request):
         "paid": req.status == "Success",
         # Drives whether the detail page shows the payment-link actions.
         "enable_redirect": _redirect_enabled(),
+        # Whether the cheque action is offered here, read fresh like enable_redirect.
+        "allow_cheque": _cheque_enabled(),
+        # Non-zero once a cheque covers these invoices — the page then hides its charge actions.
+        "awaiting_cheque": awaiting_cheque,
         # Above this the M-Pesa prompt is hidden (only hosted checkout can take it).
         "mpesa_max": _mpesa_max_amount(),
     }

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -893,15 +893,12 @@ def _require_customer_access(customer):
 
 
 def _cheque_account(company):
-    """Cheques land in the undeposited-cheque account, never cash."""
-    account = frappe.db.get_value(
-        "Mode of Payment Account", {"parent": CHEQUE_MODE, "company": company}, "default_account"
-    ) or frappe.db.get_single_value("iPay Settings", "cheque_account")
+    """Where collected cheques are booked — set once in iPay Settings, and never cash."""
+    account = frappe.db.get_single_value("iPay Settings", "cheque_account")
     if not account:
-        frappe.throw(
-            f"No cheque account is configured for {company}. Set a Default Account on Mode of "
-            f"Payment {CHEQUE_MODE}, or set iPay Settings → Cheque Account (fallback)."
-        )
+        frappe.throw("No cheque account is configured. Set iPay Settings → Cheque Account.")
+    if frappe.db.get_value("Account", account, "company") != company:
+        frappe.throw(f"The cheque account in iPay Settings does not belong to {company}.")
     return account
 
 

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -70,6 +70,11 @@ def _redirect_enabled():
     return bool(frappe.db.get_single_value("iPay Settings", "enable_redirect"))
 
 
+def _cheque_enabled():
+    """True when "Allow Cheque Collection" is on in iPay Settings."""
+    return bool(frappe.db.get_single_value("iPay Settings", "allow_cheque_collection"))
+
+
 def _require_redirect_enabled():
     """Hard gate for the payment-link / hosted-checkout endpoints: they exist only
     when "Use Hosted Checkout Redirect" is on. With it off the org collects by
@@ -962,6 +967,8 @@ def record_cheque(customer, amount, cheque_no, photo, invoices=None, cheque_date
 
     Ticked invoices allocate against them; none means an on-account credit."""
     _require_operator()
+    if not _cheque_enabled():
+        frappe.throw("Cheque collection is turned off (enable it in iPay Settings).")
 
     invoice_names = frappe.parse_json(invoices) if isinstance(invoices, str) else list(invoices or [])
     for invoice in invoice_names:

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -1042,10 +1042,17 @@ def record_cheque(customer, amount, cheque_no, photo, invoices=None, cheque_date
     finally:
         frappe.set_user(collector)
 
+    # Per-invoice cover, so the caller can flag each card with the real amount instead of
+    # refetching — the same shape awaiting_cheque_amounts returns on the next load.
+    covered = {}
+    for ref in references:
+        covered[ref["reference_name"]] = covered.get(ref["reference_name"], 0) + ref["allocated_amount"]
+
     return {
         "payment_entry": payment_entry.name,
         "amount": amount,
         "allocated": frappe.utils.flt(amount - remaining),
+        "covered": covered,
     }
 
 

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -1042,13 +1042,14 @@ def record_cheque(customer, amount, cheque_no, photo, invoices=None, cheque_date
     # ERPNext's own validation calls frappe.has_permission("Payment Entry"), which ignore_permissions
     # cannot bypass and iPay roles never hold — the guards above are the authorisation instead.
     collector = frappe.session.user
+    cheque_file = None
     frappe.set_user("Administrator")
     try:
         payment_entry.insert(ignore_permissions=True)
         # insert() always stamps the session user, so the collector is restored as owner after it.
         payment_entry.db_set("owner", collector, update_modified=False)
         # Attached after the insert, or a rejected Payment Entry strands the written file.
-        save_file(
+        cheque_file = save_file(
             f"cheque-{number}.jpg", photo, "Payment Entry", payment_entry.name,
             decode=True, is_private=1,
         )
@@ -1057,6 +1058,22 @@ def record_cheque(customer, amount, cheque_no, photo, invoices=None, cheque_date
     except OSError:
         # A corrupt photo arrives as an unreadable image, not a validation error.
         frappe.throw("That photo could not be read. Take it again.")
+    finally:
+        frappe.set_user(collector)
+
+    # Track the collected cheque so accounts can follow the physical copy from the field to the
+    # banking desk — completing a scheduled pickup or opening a fresh one, then handing it over.
+    # The money is already saved: a tracking failure must never undo it, so swallow and log.
+    frappe.set_user("Administrator")
+    try:
+        from ipay.ipay.main.utils.cheque_due import advance_or_create_on_collect
+
+        advance_or_create_on_collect(
+            customer, payment_entry.name, number, amount,
+            cheque_file.file_url if cheque_file else None, collector,
+        )
+    except Exception:
+        frappe.log_error(frappe.get_traceback(), "iPay cheque pickup tracking failed")
     finally:
         frappe.set_user(collector)
 

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -567,6 +567,7 @@ def create_bundle(customer, invoices):
     rows = []
     total = 0.0
     companies = set()
+    seen = set()
     for name in invoices:
         # A scoped caller (sales member) may only bundle their own work — without this the
         # customer check below would still pass for another member's invoices.
@@ -579,6 +580,11 @@ def create_bundle(customer, invoices):
         if not si:
             continue
         name = si.name
+        # The same invoice sent twice (or in a different case) must not be bundled — and charged —
+        # twice; dedup on the canonical name the DB returned.
+        if name in seen:
+            continue
+        seen.add(name)
         if si.customer != customer:
             frappe.throw(f"Invoice {name} does not belong to {customer}.")
         if frappe.utils.flt(si.outstanding_amount) <= 0:

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -5,6 +5,7 @@ import hashlib
 import frappe
 from frappe.utils.file_manager import save_file
 
+from ipay.ipay.main.utils.cheque import awaiting_cheque_amounts
 from ipay.ipay.main.utils.make_payment_entry import allocate_references
 from ipay.ipay.main.utils.reconcile_payments import reconcile_request
 from ipay.ipay.main.utils.ipay_logs import create_log_entry
@@ -522,6 +523,10 @@ def create_bundle(customer, invoices):
     if not invoices:
         frappe.throw("Select at least one invoice.")
 
+    # A cheque already in hand does not reduce outstanding until accounts bank it, so these
+    # invoices still look collectable here — bundling one would charge the money twice.
+    awaiting_cheque = awaiting_cheque_amounts(invoices)
+
     rows = []
     total = 0.0
     companies = set()
@@ -529,11 +534,14 @@ def create_bundle(customer, invoices):
         # A scoped caller (sales member) may only bundle their own work — without this the
         # customer check below would still pass for another member's invoices.
         _require_invoice_access(name)
+        # Take the name back from the DB: invoice names match case-insensitively, so a caller's
+        # spelling would slip past the checks below that compare names in Python.
         si = frappe.db.get_value(
-            "Sales Invoice", name, ["customer", "company", "outstanding_amount", "posting_date"], as_dict=True
+            "Sales Invoice", name, ["name", "customer", "company", "outstanding_amount", "posting_date"], as_dict=True
         )
         if not si:
             continue
+        name = si.name
         if si.customer != customer:
             frappe.throw(f"Invoice {name} does not belong to {customer}.")
         if frappe.utils.flt(si.outstanding_amount) <= 0:
@@ -541,12 +549,17 @@ def create_bundle(customer, invoices):
         # Prepaid invoices settle automatically — never bundle them for collection.
         if is_sales_invoice_prepaid(name):
             continue
+        if frappe.utils.flt(awaiting_cheque.get(name)) > 0:
+            continue
         companies.add(si.company)
         rows.append((si.posting_date, name))
         total += frappe.utils.flt(si.outstanding_amount)
 
     if not rows:
-        frappe.throw("None of the selected invoices need collection (paid, prepaid, or zero balance).")
+        frappe.throw(
+            "None of the selected invoices need collection (paid, prepaid, awaiting a cheque, "
+            "or zero balance)."
+        )
     if len(companies) > 1:
         frappe.throw("All invoices in a bundle must belong to the same company.")
 

--- a/ipay/ipay/main/utils/make_payment_entry.py
+++ b/ipay/ipay/main/utils/make_payment_entry.py
@@ -31,7 +31,10 @@ def allocate_references(invoice_names, amount):
     for si in invoices:
         if remaining <= 0:
             break
-        if flt(si.outstanding_amount) <= 0:
+        # Live outstanding caps the terms below: ERPNext leaves a term row stale unless the
+        # payment that cleared it named its payment_term, and most do not.
+        payable = flt(si.outstanding_amount)
+        if payable <= 0:
             continue
 
         # Invoices with payment terms must allocate per term (oldest due first) and carry the
@@ -48,9 +51,9 @@ def allocate_references(invoice_names, amount):
         ]
         if terms:
             for term in terms:
-                if remaining <= 0:
+                if remaining <= 0 or payable <= 0:
                     break
-                allocated = min(remaining, flt(term.outstanding))
+                allocated = min(remaining, flt(term.outstanding), payable)
                 references.append(
                     {
                         "reference_doctype": "Sales Invoice",
@@ -60,8 +63,9 @@ def allocate_references(invoice_names, amount):
                     }
                 )
                 remaining = flt(remaining - allocated)
+                payable = flt(payable - allocated)
         else:
-            allocated = min(remaining, flt(si.outstanding_amount))
+            allocated = min(remaining, payable)
             references.append(
                 {
                     "reference_doctype": "Sales Invoice",

--- a/ipay/ipay/main/utils/make_payment_entry.py
+++ b/ipay/ipay/main/utils/make_payment_entry.py
@@ -64,6 +64,20 @@ def allocate_references(invoice_names, amount):
                 )
                 remaining = flt(remaining - allocated)
                 payable = flt(payable - allocated)
+            # The term rows can sum to less than the invoice still owes (a stale schedule). Money
+            # left over then clears the rest against the invoice itself — with no payment_term, the
+            # bucket ERPNext allocates a term-less payment to — so the invoice is settled in full
+            # instead of leaving a shortfall that reads as still-owing and gets collected again.
+            if remaining > 0 and payable > 0:
+                shortfall = min(remaining, payable)
+                references.append(
+                    {
+                        "reference_doctype": "Sales Invoice",
+                        "reference_name": si.name,
+                        "allocated_amount": shortfall,
+                    }
+                )
+                remaining = flt(remaining - shortfall)
         else:
             allocated = min(remaining, payable)
             references.append(

--- a/ipay/ipay/main/utils/make_payment_entry.py
+++ b/ipay/ipay/main/utils/make_payment_entry.py
@@ -64,20 +64,10 @@ def allocate_references(invoice_names, amount):
                 )
                 remaining = flt(remaining - allocated)
                 payable = flt(payable - allocated)
-            # The term rows can sum to less than the invoice still owes (a stale schedule). Money
-            # left over then clears the rest against the invoice itself — with no payment_term, the
-            # bucket ERPNext allocates a term-less payment to — so the invoice is settled in full
-            # instead of leaving a shortfall that reads as still-owing and gets collected again.
-            if remaining > 0 and payable > 0:
-                shortfall = min(remaining, payable)
-                references.append(
-                    {
-                        "reference_doctype": "Sales Invoice",
-                        "reference_name": si.name,
-                        "allocated_amount": shortfall,
-                    }
-                )
-                remaining = flt(remaining - shortfall)
+            # If the term rows sum to less than the invoice still owes (a stale schedule), the
+            # rest cannot be allocated: a Collect invoice's template allocates by payment term, and
+            # ERPNext rejects a term-less reference on it. So the shortfall stays as customer credit
+            # rather than being forced onto the invoice — the payment is still recorded.
         else:
             allocated = min(remaining, payable)
             references.append(

--- a/ipay/ipay/main/utils/make_payment_entry.py
+++ b/ipay/ipay/main/utils/make_payment_entry.py
@@ -5,6 +5,75 @@ import json
 logger = logging.getLogger(__name__)
 
 
+def allocate_references(invoice_names, amount):
+    """Split `amount` across invoices oldest-first, per payment term where the invoice has them.
+
+    Returns (invoices, references, remaining) — `remaining` is unallocated customer credit. Shared
+    by every rail: allocation belongs to the invoices, not to how the money arrived."""
+    flt = frappe.utils.flt
+
+    # Read outstanding live, so an invoice settled elsewhere meanwhile is skipped.
+    invoices = sorted(
+        (
+            frappe.db.get_value(
+                "Sales Invoice",
+                name,
+                ["name", "outstanding_amount", "posting_date", "customer", "customer_name", "company"],
+                as_dict=True,
+            )
+            for name in invoice_names
+        ),
+        key=lambda si: (si.posting_date, si.name),
+    )
+
+    remaining = flt(amount)
+    references = []
+    for si in invoices:
+        if remaining <= 0:
+            break
+        if flt(si.outstanding_amount) <= 0:
+            continue
+
+        # Invoices with payment terms must allocate per term (oldest due first) and carry the
+        # payment_term on the reference; others take a single reference.
+        terms = [
+            t
+            for t in frappe.get_all(
+                "Payment Schedule",
+                filters={"parent": si.name, "parenttype": "Sales Invoice"},
+                fields=["payment_term", "outstanding"],
+                order_by="due_date asc",
+            )
+            if flt(t.outstanding) > 0
+        ]
+        if terms:
+            for term in terms:
+                if remaining <= 0:
+                    break
+                allocated = min(remaining, flt(term.outstanding))
+                references.append(
+                    {
+                        "reference_doctype": "Sales Invoice",
+                        "reference_name": si.name,
+                        "payment_term": term.payment_term,
+                        "allocated_amount": allocated,
+                    }
+                )
+                remaining = flt(remaining - allocated)
+        else:
+            allocated = min(remaining, flt(si.outstanding_amount))
+            references.append(
+                {
+                    "reference_doctype": "Sales Invoice",
+                    "reference_name": si.name,
+                    "allocated_amount": allocated,
+                }
+            )
+            remaining = flt(remaining - allocated)
+
+    return invoices, references, remaining
+
+
 # NOT @frappe.whitelist: this is an internal helper called only by
 # finalize_payment (server-side). Exposing it let any authenticated user POST a
 # forged response_data (fake transaction_code + amount) and submit a Payment
@@ -68,68 +137,9 @@ def make_payment_entry(user_id, customer_email, inv, response_data, ipay_request
         if not invoice_names:
             invoice_names = [inv]
 
-        # Pull live invoice data and allocate oldest-first against current
-        # outstanding (so an invoice paid elsewhere meanwhile is skipped).
-        invoices = sorted(
-            (
-                frappe.db.get_value(
-                    "Sales Invoice",
-                    name,
-                    ["name", "outstanding_amount", "posting_date", "customer", "customer_name", "company"],
-                    as_dict=True,
-                )
-                for name in invoice_names
-            ),
-            key=lambda si: (si.posting_date, si.name),
-        )
-        primary = invoices[0]
-
         transaction_amount = flt(response_data.get("transaction_amount", 0))
-        remaining = transaction_amount
-        references = []
-        for si in invoices:
-            if remaining <= 0:
-                break
-            if flt(si.outstanding_amount) <= 0:
-                continue
-
-            # Invoices with payment terms must allocate per term (oldest due
-            # first) and carry the payment_term on the reference; others take a
-            # single reference.
-            terms = [
-                t
-                for t in frappe.get_all(
-                    "Payment Schedule",
-                    filters={"parent": si.name, "parenttype": "Sales Invoice"},
-                    fields=["payment_term", "outstanding"],
-                    order_by="due_date asc",
-                )
-                if flt(t.outstanding) > 0
-            ]
-            if terms:
-                for term in terms:
-                    if remaining <= 0:
-                        break
-                    allocated = min(remaining, flt(term.outstanding))
-                    references.append(
-                        {
-                            "reference_doctype": "Sales Invoice",
-                            "reference_name": si.name,
-                            "payment_term": term.payment_term,
-                            "allocated_amount": allocated,
-                        }
-                    )
-                    remaining = flt(remaining - allocated)
-            else:
-                allocated = min(remaining, flt(si.outstanding_amount))
-                references.append(
-                    {
-                        "reference_doctype": "Sales Invoice",
-                        "reference_name": si.name,
-                        "allocated_amount": allocated,
-                    }
-                )
-                remaining = flt(remaining - allocated)
+        invoices, references, remaining = allocate_references(invoice_names, transaction_amount)
+        primary = invoices[0]
 
         # If nothing could be allocated (every invoice was already settled
         # elsewhere), the money is still real — record it as unallocated credit,

--- a/ipay/ipay/main/utils/sales.py
+++ b/ipay/ipay/main/utils/sales.py
@@ -120,6 +120,25 @@ def can_access_invoice(sales_invoice, user=None):
     return _in_book(sales_invoice, named, customers)
 
 
+def can_access_customer(customer, user=None):
+    """May this sales member act on a customer-level (on-account) cheque? Only a customer with an
+    outstanding invoice in their book — the customer is theirs, or one of their named invoices is
+    the customer's. One query either way; never a scan of the customer's every invoice."""
+    person = my_sales_person(user)
+    if not person:
+        return False
+    named, customers = _cached_scope(person)
+    if customer in customers:
+        return bool(frappe.db.exists(
+            "Sales Invoice",
+            {"customer": customer, "docstatus": 1, "outstanding_amount": [">", 0]},
+        ))
+    return bool(named) and bool(frappe.db.exists(
+        "Sales Invoice",
+        {"name": ["in", list(named)], "customer": customer, "docstatus": 1, "outstanding_amount": [">", 0]},
+    ))
+
+
 def can_access_request(request_name, user=None):
     """May this sales member act on the given iPay Request? Only when EVERY invoice it
     covers is their own book — owning one member must not grant prompting a bundle across

--- a/ipay/patches.txt
+++ b/ipay/patches.txt
@@ -8,3 +8,4 @@ ipay.patches.v1_0.seed_cod_payment_terms
 ipay.patches.v1_0.seed_mpesa_mode_of_payment
 ipay.patches.v1_0.seed_collection_payment_terms
 ipay.patches.v1_0.set_default_mpesa_max
+ipay.patches.v1_0.set_cheque_per_invoice_default

--- a/ipay/patches/v1_0/set_cheque_per_invoice_default.py
+++ b/ipay/patches/v1_0/set_cheque_per_invoice_default.py
@@ -1,0 +1,9 @@
+import frappe
+
+
+def execute():
+    """Cheque Per Invoice defaults on, but a Check field reads 0 when unset on an existing single,
+    so per-invoice cheques would silently turn off after migrate. Seed it to 1 (mirrors
+    set_default_mpesa_max). One-time, so a later admin choice of off is preserved."""
+    if not frappe.db.get_single_value("iPay Settings", "cheque_per_invoice"):
+        frappe.db.set_single_value("iPay Settings", "cheque_per_invoice", 1)

--- a/ipay/tests/test_payment_core.py
+++ b/ipay/tests/test_payment_core.py
@@ -4,7 +4,8 @@ import frappe
 import requests
 from frappe.tests.utils import FrappeTestCase
 
-from ipay.ipay.main.utils import cheque, make_payment_entry, reconcile_payments
+from ipay.ipay.main.utils import cheque, collector, make_payment_entry, reconcile_payments
+from ipay.ipay.main.utils import sales
 from ipay.ipay.main.utils.constants import amounts_match, clean_oid
 from ipay.ipay.main.utils.finalize_payment import _resolve_status
 from ipay.ipay.main.utils.ipay_redirect import normalize_phone
@@ -218,6 +219,71 @@ class TestAwaitingChequeAmounts(FrappeTestCase):
             ("PE-2", DRAFT, "MPESA", [("INV-2", 50.0)]),
         ])
         self.assertEqual(covered, {"INV-1": 700.0})
+
+
+def _sales_access(person, named, customers, exists):
+    """Run sales.can_access_customer with a mocked book. `exists` is what frappe.db.exists
+    returns for the outstanding-invoice lookup — no live sales user exists to test against."""
+    with patch.object(sales, "my_sales_person", return_value=person), \
+         patch.object(sales, "_cached_scope", return_value=(named, customers)), \
+         patch.object(sales.frappe.db, "exists", return_value=exists):
+        return sales.can_access_customer("CUST", user="u")
+
+
+class TestSalesCanAccessCustomer(FrappeTestCase):
+    """The on-account cheque guard for a sales member. A false positive lets them record against
+    a customer outside their book; a false negative blocks their own customer."""
+
+    def test_no_sales_person_is_refused(self):
+        self.assertFalse(_sales_access(None, [], set(), True))
+
+    def test_customer_in_book_with_an_outstanding_invoice(self):
+        self.assertTrue(_sales_access("P", [], {"CUST"}, exists=True))
+
+    def test_customer_in_book_but_nothing_outstanding_is_refused(self):
+        # Mirrors the old loop: no outstanding invoice for the customer means no access.
+        self.assertFalse(_sales_access("P", [], {"CUST"}, exists=False))
+
+    def test_customer_not_in_book_but_a_named_invoice_is_theirs(self):
+        self.assertTrue(_sales_access("P", ["INV-1"], set(), exists=True))
+
+    def test_customer_outside_the_book_is_refused(self):
+        self.assertFalse(_sales_access("P", ["INV-1"], {"OTHER"}, exists=False))
+
+    def test_no_named_and_not_in_book_is_refused_without_a_query(self):
+        # Empty named + customer not in book short-circuits, so exists is never consulted.
+        with patch.object(sales, "my_sales_person", return_value="P"), \
+             patch.object(sales, "_cached_scope", return_value=([], {"OTHER"})), \
+             patch.object(sales.frappe.db, "exists", side_effect=AssertionError("should not query")):
+            self.assertFalse(sales.can_access_customer("CUST", user="u"))
+
+
+class TestCollectorCanAccessCustomer(FrappeTestCase):
+    """The union guard for an on-account cheque. A scoped actor needs the customer in their own
+    book; an unscoped operator still needs the customer to have an outstanding invoice — the old
+    loop had nothing to grant on otherwise."""
+
+    def _run(self, is_col, is_sal, has_outstanding, in_scope=False, sales_grants=False):
+        with patch.object(collector, "is_collector_only", return_value=is_col), \
+             patch.object(sales, "is_sales_only", return_value=is_sal), \
+             patch.object(collector, "collector_scope", return_value={"invoices": set(), "requests": set()}), \
+             patch.object(collector, "_customer_has_scoped_invoice", return_value=in_scope), \
+             patch.object(sales, "can_access_customer", return_value=sales_grants), \
+             patch.object(collector, "_customer_has_outstanding", return_value=has_outstanding):
+            return collector.can_access_customer("CUST", user="u")
+
+    def test_unscoped_operator_needs_an_outstanding_invoice(self):
+        self.assertTrue(self._run(is_col=False, is_sal=False, has_outstanding=True))
+        self.assertFalse(self._run(is_col=False, is_sal=False, has_outstanding=False))
+
+    def test_collector_only_uses_only_their_scope(self):
+        # A customer they hold is granted; one they do not is refused even if it has outstanding.
+        self.assertTrue(self._run(is_col=True, is_sal=False, has_outstanding=False, in_scope=True))
+        self.assertFalse(self._run(is_col=True, is_sal=False, has_outstanding=True, in_scope=False))
+
+    def test_sales_only_delegates_to_the_sales_book(self):
+        self.assertTrue(self._run(is_col=False, is_sal=True, has_outstanding=False, sales_grants=True))
+        self.assertFalse(self._run(is_col=False, is_sal=True, has_outstanding=True, sales_grants=False))
 
 
 def _fake_response(status_code, json_value=None, json_error=False):

--- a/ipay/tests/test_payment_core.py
+++ b/ipay/tests/test_payment_core.py
@@ -151,6 +151,23 @@ class TestAllocateReferences(FrappeTestCase):
         self.assertEqual(refs, [])
         self.assertEqual(remaining, 700.0)
 
+    def test_stale_low_schedule_clears_the_invoice_with_a_termless_reference(self):
+        # The term rows sum to less than the invoice owes (a stale schedule). A full payment must
+        # still clear it — the shortfall goes on a termless reference — not leave a balance that
+        # reads as owing and gets collected again.
+        _, refs, remaining = _allocate({"INV-1": 4163.0}, {"INV-1": [("NET 15", 3747.0)]}, 4163.0)
+        self.assertEqual(
+            [(r.get("payment_term"), r["allocated_amount"]) for r in refs],
+            [("NET 15", 3747.0), (None, 416.0)],
+        )
+        self.assertEqual(remaining, 0.0)
+
+    def test_stale_low_shortfall_never_exceeds_the_money_received(self):
+        # Underpayment: only the money in hand is allocated, no invented shortfall.
+        _, refs, remaining = _allocate({"INV-1": 4163.0}, {"INV-1": [("NET 15", 3747.0)]}, 3900.0)
+        self.assertEqual(sum(r["allocated_amount"] for r in refs), 3900.0)
+        self.assertEqual(remaining, 0.0)
+
 
 def _awaiting(entries, ask=None):
     """Run the cheque predicate against fake Payment Entries.

--- a/ipay/tests/test_payment_core.py
+++ b/ipay/tests/test_payment_core.py
@@ -4,7 +4,7 @@ import frappe
 import requests
 from frappe.tests.utils import FrappeTestCase
 
-from ipay.ipay.main.utils import make_payment_entry, reconcile_payments
+from ipay.ipay.main.utils import cheque, make_payment_entry, reconcile_payments
 from ipay.ipay.main.utils.constants import amounts_match, clean_oid
 from ipay.ipay.main.utils.finalize_payment import _resolve_status
 from ipay.ipay.main.utils.ipay_redirect import normalize_phone
@@ -149,6 +149,75 @@ class TestAllocateReferences(FrappeTestCase):
         _, refs, remaining = _allocate({"INV-1": 0.0}, {"INV-1": [("NET 15", 5000.0)]}, 700.0)
         self.assertEqual(refs, [])
         self.assertEqual(remaining, 700.0)
+
+
+def _awaiting(entries, ask=None):
+    """Run the cheque predicate against fake Payment Entries.
+
+    `entries` is [(parent, docstatus, mode, [(invoice, amount), ...]), ...]. The mock applies the
+    real filters, so dropping one in the code makes these tests fail rather than pass regardless."""
+    def get_all(doctype, **kwargs):
+        filters = kwargs["filters"]
+        if doctype == "Payment Entry Reference":
+            return [
+                frappe._dict(parent=parent, reference_name=inv, allocated_amount=amount)
+                for parent, docstatus, _mode, refs in entries
+                for inv, amount in refs
+                if docstatus == filters["docstatus"]
+                and filters["reference_doctype"] == "Sales Invoice"
+                and inv in filters["reference_name"][1]
+            ]
+        return [
+            parent
+            for parent, docstatus, mode, _refs in entries
+            if parent in filters["name"][1]
+            and docstatus == filters["docstatus"]
+            and mode == filters["mode_of_payment"]
+        ]
+
+    invoices = ask or [inv for _, _, _, refs in entries for inv, _ in refs]
+    with patch.object(cheque.frappe, "get_all", side_effect=get_all):
+        return cheque.awaiting_cheque_amounts(invoices)
+
+
+DRAFT, SUBMITTED = 0, 1
+
+
+class TestAwaitingChequeAmounts(FrappeTestCase):
+    """What this returns decides whether an invoice can be charged again. A false negative
+    collects the money twice; a false positive strands an invoice nobody can collect."""
+
+    def test_no_invoices_asks_nothing(self):
+        self.assertEqual(cheque.awaiting_cheque_amounts([]), {})
+        self.assertEqual(cheque.awaiting_cheque_amounts(None), {})
+
+    def test_draft_cheque_covers_its_invoice(self):
+        covered = _awaiting([("PE-1", DRAFT, "Cheque", [("INV-1", 700.0)])])
+        self.assertEqual(covered, {"INV-1": 700.0})
+
+    def test_a_draft_of_another_mode_does_not_count(self):
+        # Only the parent knows the mode; an M-Pesa draft must never strand an invoice.
+        covered = _awaiting([("PE-1", DRAFT, "MPESA", [("INV-1", 700.0)])], ask=["INV-1"])
+        self.assertEqual(covered, {})
+
+    def test_a_submitted_cheque_does_not_count(self):
+        # Once accounts submit it, outstanding drops on its own and the marker must let go.
+        covered = _awaiting([("PE-1", SUBMITTED, "Cheque", [("INV-1", 700.0)])], ask=["INV-1"])
+        self.assertEqual(covered, {})
+
+    def test_several_cheques_on_one_invoice_are_summed(self):
+        covered = _awaiting([
+            ("PE-1", DRAFT, "Cheque", [("INV-1", 700.0)]),
+            ("PE-2", DRAFT, "Cheque", [("INV-1", 300.0)]),
+        ])
+        self.assertEqual(covered, {"INV-1": 1000.0})
+
+    def test_only_the_covered_invoice_is_flagged(self):
+        covered = _awaiting([
+            ("PE-1", DRAFT, "Cheque", [("INV-1", 700.0)]),
+            ("PE-2", DRAFT, "MPESA", [("INV-2", 50.0)]),
+        ])
+        self.assertEqual(covered, {"INV-1": 700.0})
 
 
 def _fake_response(status_code, json_value=None, json_error=False):

--- a/ipay/tests/test_payment_core.py
+++ b/ipay/tests/test_payment_core.py
@@ -151,22 +151,16 @@ class TestAllocateReferences(FrappeTestCase):
         self.assertEqual(refs, [])
         self.assertEqual(remaining, 700.0)
 
-    def test_stale_low_schedule_clears_the_invoice_with_a_termless_reference(self):
-        # The term rows sum to less than the invoice owes (a stale schedule). A full payment must
-        # still clear it — the shortfall goes on a termless reference — not leave a balance that
-        # reads as owing and gets collected again.
+    def test_stale_low_schedule_leaves_the_shortfall_as_credit(self):
+        # Terms sum to less than the invoice owes (a stale schedule). A Collect invoice allocates by
+        # payment term and ERPNext rejects a term-less reference on it, so the rest cannot go on the
+        # invoice — it stays as customer credit, and the payment is still recorded.
         _, refs, remaining = _allocate({"INV-1": 4163.0}, {"INV-1": [("NET 15", 3747.0)]}, 4163.0)
         self.assertEqual(
             [(r.get("payment_term"), r["allocated_amount"]) for r in refs],
-            [("NET 15", 3747.0), (None, 416.0)],
+            [("NET 15", 3747.0)],
         )
-        self.assertEqual(remaining, 0.0)
-
-    def test_stale_low_shortfall_never_exceeds_the_money_received(self):
-        # Underpayment: only the money in hand is allocated, no invented shortfall.
-        _, refs, remaining = _allocate({"INV-1": 4163.0}, {"INV-1": [("NET 15", 3747.0)]}, 3900.0)
-        self.assertEqual(sum(r["allocated_amount"] for r in refs), 3900.0)
-        self.assertEqual(remaining, 0.0)
+        self.assertEqual(remaining, 416.0)
 
 
 def _awaiting(entries, ask=None):

--- a/ipay/tests/test_payment_core.py
+++ b/ipay/tests/test_payment_core.py
@@ -1,12 +1,14 @@
 from unittest.mock import MagicMock, patch
 
+import frappe
 import requests
 from frappe.tests.utils import FrappeTestCase
 
-from ipay.ipay.main.utils import reconcile_payments
+from ipay.ipay.main.utils import make_payment_entry, reconcile_payments
 from ipay.ipay.main.utils.constants import amounts_match, clean_oid
 from ipay.ipay.main.utils.finalize_payment import _resolve_status
 from ipay.ipay.main.utils.ipay_redirect import normalize_phone
+from ipay.ipay.main.utils.make_payment_entry import allocate_references
 
 
 class TestNormalizePhone(FrappeTestCase):
@@ -79,6 +81,74 @@ class TestCleanOid(FrappeTestCase):
 
     def test_empty_name_is_empty(self):
         self.assertEqual(clean_oid(None), "")
+
+
+def _allocate(invoices, terms, amount):
+    """Run the allocator against fake invoices/terms. `invoices` maps name -> outstanding,
+    `terms` maps invoice name -> [(payment_term, term_outstanding), ...]."""
+    rows = {
+        name: frappe._dict(
+            name=name, outstanding_amount=out, posting_date="2026-01-01",
+            customer="C", customer_name="C", company="Co",
+        )
+        for name, out in invoices.items()
+    }
+    with patch.object(make_payment_entry.frappe.db, "get_value", side_effect=lambda dt, n, f, **k: rows[n]):
+        with patch.object(
+            make_payment_entry.frappe,
+            "get_all",
+            side_effect=lambda dt, **k: [
+                frappe._dict(payment_term=t, outstanding=o)
+                for t, o in terms.get(k["filters"]["parent"], [])
+            ],
+        ):
+            return allocate_references(list(invoices), amount)
+
+
+class TestAllocateReferences(FrappeTestCase):
+    """Allocation decides which invoice a payment clears. Over-allocate and ERPNext rejects the
+    whole entry — the customer's money is taken and no Payment Entry exists."""
+
+    def test_term_outstanding_never_exceeds_the_invoice(self):
+        # ERPNext only decrements a term row when the payment names its payment_term, so the row
+        # can claim far more than the invoice still owes. The invoice is the truth.
+        _, refs, remaining = _allocate({"INV-1": 3229.8}, {"INV-1": [("NET 15", 249952.0)]}, 53229.8)
+        self.assertEqual(sum(r["allocated_amount"] for r in refs), 3229.8)
+        self.assertEqual(remaining, 50000.0)
+
+    def test_exact_bundle_total_reaches_every_invoice(self):
+        # A stale first term used to swallow the whole payment, leaving the rest unpaid.
+        _, refs, remaining = _allocate(
+            {"INV-1": 3229.8, "INV-2": 22088.0},
+            {"INV-1": [("NET 15", 249952.0)], "INV-2": [("NET 15", 22088.0)]},
+            25317.8,
+        )
+        allocated = {r["reference_name"]: r["allocated_amount"] for r in refs}
+        self.assertEqual(allocated, {"INV-1": 3229.8, "INV-2": 22088.0})
+        self.assertEqual(remaining, 0.0)
+
+    def test_partial_payment_fills_each_term_before_the_next(self):
+        # Due-date order is the DB's job (order_by on the query), so it is not asserted here.
+        _, refs, remaining = _allocate(
+            {"INV-1": 1000.0}, {"INV-1": [("First", 400.0), ("Second", 600.0)]}, 500.0
+        )
+        self.assertEqual(
+            [(r["payment_term"], r["allocated_amount"]) for r in refs],
+            [("First", 400.0), ("Second", 100.0)],
+        )
+        self.assertEqual(remaining, 0.0)
+
+    def test_invoice_without_terms_takes_one_reference(self):
+        _, refs, remaining = _allocate({"INV-1": 800.0}, {}, 1000.0)
+        self.assertEqual(refs, [
+            {"reference_doctype": "Sales Invoice", "reference_name": "INV-1", "allocated_amount": 800.0}
+        ])
+        self.assertEqual(remaining, 200.0)
+
+    def test_settled_invoice_is_skipped_and_money_stays_credit(self):
+        _, refs, remaining = _allocate({"INV-1": 0.0}, {"INV-1": [("NET 15", 5000.0)]}, 700.0)
+        self.assertEqual(refs, [])
+        self.assertEqual(remaining, 700.0)
 
 
 def _fake_response(status_code, json_value=None, json_error=False):

--- a/ipay/tests/test_payment_core.py
+++ b/ipay/tests/test_payment_core.py
@@ -338,6 +338,33 @@ class TestOldestOpenDue(FrappeTestCase):
             self.assertIsNone(cheque_due._oldest_open_due("CUST"))
 
 
+class TestOpenDuesDriverFilter(FrappeTestCase):
+    """The banner follows the page's driver filter. Narrowing must never widen: a collector who
+    passes a driver that is not theirs sees nothing, not everyone's."""
+
+    def test_operator_banner_narrows_to_the_chosen_driver(self):
+        with patch.object(cheque_due, "_due_rows", return_value=[]) as rows:
+            cheque_due.all_open_dues("DRV-1")
+        self.assertEqual(rows.call_args.args[0], {"driver": "DRV-1"})
+
+    def test_operator_banner_is_unfiltered_without_one(self):
+        with patch.object(cheque_due, "_due_rows", return_value=[]) as rows:
+            cheque_due.all_open_dues()
+        self.assertEqual(rows.call_args.args[0], {})
+
+    def test_collector_narrowing_to_their_own_driver(self):
+        with patch.object(cheque_due, "my_driver_ids", return_value=["DRV-A", "DRV-B"]), \
+             patch.object(cheque_due, "_due_rows", return_value=[]) as rows:
+            cheque_due.open_dues_for_driver("u", "DRV-A")
+        self.assertEqual(rows.call_args.args[0], {"driver": ["in", ["DRV-A"]]})
+
+    def test_collector_cannot_widen_to_a_driver_that_is_not_theirs(self):
+        with patch.object(cheque_due, "my_driver_ids", return_value=["DRV-A"]), \
+             patch.object(cheque_due, "_due_rows", return_value=[]) as rows:
+            self.assertEqual(cheque_due.open_dues_for_driver("u", "DRV-OTHER"), [])
+        rows.assert_not_called()
+
+
 def _fake_response(status_code, json_value=None, json_error=False):
     resp = MagicMock()
     resp.status_code = status_code

--- a/ipay/tests/test_payment_core.py
+++ b/ipay/tests/test_payment_core.py
@@ -4,10 +4,11 @@ import frappe
 import requests
 from frappe.tests.utils import FrappeTestCase
 
-from ipay.ipay.main.utils import cheque, collector, make_payment_entry, reconcile_payments
+from ipay.ipay.main.utils import cheque, cheque_due, collector, make_payment_entry, reconcile_payments
 from ipay.ipay.main.utils import sales
 from ipay.ipay.main.utils.constants import amounts_match, clean_oid
 from ipay.ipay.main.utils.finalize_payment import _resolve_status
+from ipay.ipay.main.utils import ipay_redirect
 from ipay.ipay.main.utils.ipay_redirect import normalize_phone
 from ipay.ipay.main.utils.make_payment_entry import allocate_references
 
@@ -295,6 +296,46 @@ class TestCollectorCanAccessCustomer(FrappeTestCase):
     def test_sales_only_delegates_to_the_sales_book(self):
         self.assertTrue(self._run(is_col=False, is_sal=True, has_outstanding=False, sales_grants=True))
         self.assertFalse(self._run(is_col=False, is_sal=True, has_outstanding=True, sales_grants=False))
+
+
+class TestRequireCustomerAccess(FrappeTestCase):
+    """The gate on recording an on-account cheque. A flagged pickup grants the collect action for
+    a customer with no outstanding invoice to be scoped by — but only the action: widening
+    can_access_customer itself would leak the on-account figure it also gates."""
+
+    def _run(self, can_access, has_pickup):
+        with patch.object(collector, "can_access_customer", return_value=can_access), \
+             patch.object(cheque_due, "has_open_pickup", return_value=has_pickup):
+            try:
+                ipay_redirect._require_customer_access("CUST")
+                return True
+            except frappe.PermissionError:
+                return False
+
+    def test_normal_scope_still_grants(self):
+        self.assertTrue(self._run(can_access=True, has_pickup=False))
+
+    def test_a_flagged_pickup_grants_when_nothing_else_would(self):
+        self.assertTrue(self._run(can_access=False, has_pickup=True))
+
+    def test_neither_is_refused(self):
+        self.assertFalse(self._run(can_access=False, has_pickup=False))
+
+
+class TestOldestOpenDue(FrappeTestCase):
+    """Which scheduled pickup a collection completes. Scoping this to the recorder's own driver
+    left the pickup open and created a duplicate for every operator and sales collection."""
+
+    def test_matches_on_customer_and_status_only(self):
+        with patch.object(cheque_due.frappe, "get_all", return_value=["CHQ-1"]) as g:
+            self.assertEqual(cheque_due._oldest_open_due("CUST"), "CHQ-1")
+        # No driver filter: whoever brings the cheque in completes the pickup.
+        self.assertNotIn("driver", g.call_args.kwargs["filters"])
+        self.assertEqual(g.call_args.kwargs["filters"], {"customer": "CUST", "status": "Due"})
+
+    def test_returns_none_when_nothing_was_scheduled(self):
+        with patch.object(cheque_due.frappe, "get_all", return_value=[]):
+            self.assertIsNone(cheque_due._oldest_open_due("CUST"))
 
 
 def _fake_response(status_code, json_value=None, json_error=False):

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -3,6 +3,7 @@ from frappe.utils import add_to_date, cint, flt, now_datetime, today
 
 from ipay.ipay.main.utils.prepaid import all_prepaid_invoice_names, prepaid_invoice_names
 from ipay.ipay.main.utils.collector import OPERATOR_ROLES, collector_scope, is_collector_only
+from ipay.ipay.main.utils.cheque import awaiting_cheque_amounts
 from ipay.ipay.main.utils.constants import (
     ACTIVE_BUNDLE_WINDOW_MIN,
     CHEQUE_MODE,
@@ -305,35 +306,10 @@ def _annotate_notes(invoices):
 
 
 def _annotate_awaiting_cheque(invoices):
-    """Flag invoices a collected cheque already covers, batched. A cheque sits as a DRAFT Payment
-    Entry until accounts submit it, and a draft does not reduce outstanding — so without this the
-    invoice still looks unpaid and would be charged a second time."""
-    names = [inv.name for inv in invoices]
-    if not names:
-        return
-    rows = frappe.get_all(
-        "Payment Entry Reference",
-        filters={"reference_doctype": "Sales Invoice", "reference_name": ["in", names], "docstatus": 0},
-        fields=["parent", "reference_name", "allocated_amount"],
-    )
-    covered = {}
-    if rows:
-        cheques = set(
-            frappe.get_all(
-                "Payment Entry",
-                filters={
-                    "name": ["in", list({r.parent for r in rows})],
-                    "docstatus": 0,
-                    "mode_of_payment": CHEQUE_MODE,
-                },
-                pluck="name",
-            )
-        )
-        for row in rows:
-            if row.parent in cheques:
-                covered[row.reference_name] = covered.get(row.reference_name, 0) + flt(row.allocated_amount)
-    # The amount rides along: a cheque may cover only part of the invoice, and "awaiting" without
-    # a figure would read as though the whole balance were settled.
+    """Flag each invoice with the amount a collected cheque already covers, so the card can drop
+    its prompt buttons. The amount rides along because a cheque may cover only part of the
+    invoice, and a bare flag would read as though the whole balance were settled."""
+    covered = awaiting_cheque_amounts([inv.name for inv in invoices])
     for inv in invoices:
         inv.awaiting_cheque = flt(covered.get(inv.name, 0))
 

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -570,9 +570,12 @@ def _customers_by_latest(invoices):
     )
 
 
-def _drill_down(invoices, customer, start, page_length, search):
+def _drill_down(invoices, customer, start, page_length, search, cheque_due=None):
     """One customer's invoices for a drill-down: totals over the whole scoped balance, then
-    an optionally-searched page of it. Shared by the internal and sales detail views."""
+    an optionally-searched page of it. Shared by the internal and sales detail views.
+
+    `cheque_due` is the caller's to resolve: scoping here is on invoices, so a caller restricted
+    to its own book can be handed a customer outside it and must not leak that customer's cheque."""
     start, page_length = cint(start), cint(page_length) or 50
     total = sum(flt(inv.outstanding_amount) for inv in invoices)
     count = len(invoices)
@@ -590,9 +593,7 @@ def _drill_down(invoices, customer, start, page_length, search):
         "customer": customer,
         "customer_name": frappe.db.get_value("Customer", customer, "customer_name") or customer,
         "cheque_on_account": _cheque_on_account(customer),
-        # The caller (internal/sales) has already scoped access to this customer, so any open
-        # cheque for them is fair to surface here.
-        "cheque_due": open_due_for_customer(customer),
+        "cheque_due": cheque_due,
         "invoices": page,
         "invoice_count": count,
         "total_outstanding": total,
@@ -652,7 +653,8 @@ def internal_customer_invoices(customer, start=0, page_length=50, search=None, d
         _scope_to_driver(_internal_outstanding(customer, payment_term=payment_term), driver),
         sales_person,
     )
-    return _drill_down(invoices, customer, start, page_length, search)
+    # An operator sees every book, so any flagged cheque for this customer is theirs to see.
+    return _drill_down(invoices, customer, start, page_length, search, open_due_for_customer(customer))
 
 
 # --- Sales mode (/collect/sales) --------------------------------------------------------
@@ -743,4 +745,10 @@ def sales_customer_invoices(customer, start=0, page_length=50, search=None, paym
         _internal_outstanding(customer, payment_term=payment_term),
         _sales_view_person(sales_person),
     )
-    return _drill_down(invoices, customer, start, page_length, search)
+    # Same rule as the list banner: a member locked to their own book sees only its cheques.
+    from ipay.ipay.main.utils import sales
+
+    due = open_due_for_customer(customer)
+    if _own_book_only() and not sales.can_access_customer(customer):
+        due = None
+    return _drill_down(invoices, customer, start, page_length, search, due)

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -2,8 +2,13 @@ import frappe
 from frappe.utils import add_to_date, cint, flt, now_datetime, today
 
 from ipay.ipay.main.utils.prepaid import all_prepaid_invoice_names, prepaid_invoice_names
-from ipay.ipay.main.utils.collector import OPERATOR_ROLES, collector_scope, is_collector_only
+from ipay.ipay.main.utils.collector import OPERATOR_ROLES, collector_scope, is_collector_only, my_driver_ids
 from ipay.ipay.main.utils.cheque import awaiting_cheque_amounts
+from ipay.ipay.main.utils.cheque_due import (
+    all_open_dues,
+    open_due_for_customer,
+    open_dues_for_driver,
+)
 from ipay.ipay.main.utils.constants import (
     ACTIVE_BUNDLE_WINDOW_MIN,
     CHEQUE_MODE,
@@ -476,6 +481,8 @@ def collection_customers(driver=None):
         "drivers": drivers,
         "enable_redirect": bool(frappe.db.get_single_value("iPay Settings", "enable_redirect")),
         "can_bundle": not is_collector_only(frappe.session.user),
+        # Cheques accounts have flagged for this collector to pick up — only their own driver's.
+        "cheque_dues": open_dues_for_driver(frappe.session.user),
     }
 
 
@@ -486,13 +493,17 @@ def customer_collection(customer, driver=None):
     collector only ever sees their own book here even if another customer's id is passed."""
     _require_collection_access()
     invoices = _customer_invoices(frappe.session.user, customer, driver=driver)
+    user = frappe.session.user
+    # A collector only ever sees a cheque routed to their own driver; an operator here sees any.
+    driver_ids = my_driver_ids(user) if is_collector_only(user) else None
     return {
         "customer": customer,
         "customer_name": invoices[0].customer_name if invoices else customer,
         "invoices": invoices,
         "cheque_on_account": _cheque_on_account(customer),
+        "cheque_due": open_due_for_customer(customer, driver_ids),
         **_settings_flags(),
-        "can_bundle": not is_collector_only(frappe.session.user),
+        "can_bundle": not is_collector_only(user),
     }
 
 
@@ -579,6 +590,9 @@ def _drill_down(invoices, customer, start, page_length, search):
         "customer": customer,
         "customer_name": frappe.db.get_value("Customer", customer, "customer_name") or customer,
         "cheque_on_account": _cheque_on_account(customer),
+        # The caller (internal/sales) has already scoped access to this customer, so any open
+        # cheque for them is fair to surface here.
+        "cheque_due": open_due_for_customer(customer),
         "invoices": page,
         "invoice_count": count,
         "total_outstanding": total,
@@ -621,6 +635,8 @@ def internal_customers(driver=None, payment_term=None, sales_person=None):
         "drivers": _internal_driver_names(),
         "payment_terms": _internal_payment_terms(),
         "sales_persons": sales_person_options(),
+        # Operators see every flagged cheque — full awareness across all drivers.
+        "cheque_dues": all_open_dues(),
     }
 
 
@@ -677,6 +693,17 @@ def _sales_view_person(sales_person):
     return sales_person or None
 
 
+def _sales_cheque_dues(own_book):
+    """Flagged cheques for the sales banner: a locked member sees only those for customers in
+    their own book, a manager sees every one. Reuses the same customer access the page enforces."""
+    from ipay.ipay.main.utils import sales
+
+    dues = all_open_dues()
+    if not own_book:
+        return dues
+    return [d for d in dues if sales.can_access_customer(d.customer)]
+
+
 @frappe.whitelist()
 def sales_customers(payment_term=None, sales_person=None):
     """Customers with a collectable balance for the sales page, newest-invoice customer first,
@@ -699,6 +726,8 @@ def sales_customers(payment_term=None, sales_person=None):
         "sales_persons": [] if own_book else sales_person_options(),
         "sales_person": person or "",
         "is_manager": not own_book,
+        # Flagged cheques for awareness: a locked member sees only their own book's, a manager all.
+        "cheque_dues": _sales_cheque_dues(own_book),
         "unmapped": False,
     }
 

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -319,7 +319,14 @@ def _annotate_awaiting_cheque(invoices):
 def _cheque_on_account(customer):
     """What a customer has handed over in cheques that name no invoice. Nothing marks those
     invoices, so this is the only thing standing between an on-account cheque and collecting
-    the same money twice."""
+    the same money twice.
+
+    Scoped to the caller: the invoices in the same response are already scoped, so this figure
+    must be too — a collector or sales member never sees it for a customer they cannot access."""
+    from ipay.ipay.main.utils.collector import can_access_customer
+
+    if not can_access_customer(customer):
+        return 0.0
     amounts = frappe.get_all(
         "Payment Entry",
         filters={

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -481,8 +481,9 @@ def collection_customers(driver=None):
         "drivers": drivers,
         "enable_redirect": bool(frappe.db.get_single_value("iPay Settings", "enable_redirect")),
         "can_bundle": not is_collector_only(frappe.session.user),
-        # Cheques accounts have flagged for this collector to pick up — only their own driver's.
-        "cheque_dues": open_dues_for_driver(frappe.session.user),
+        # Cheques accounts have flagged for this collector to pick up — only their own driver's,
+        # and following the same driver filter as the customers beneath them.
+        "cheque_dues": open_dues_for_driver(frappe.session.user, driver),
     }
 
 
@@ -636,8 +637,10 @@ def internal_customers(driver=None, payment_term=None, sales_person=None):
         "drivers": _internal_driver_names(),
         "payment_terms": _internal_payment_terms(),
         "sales_persons": sales_person_options(),
-        # Operators see every flagged cheque — full awareness across all drivers.
-        "cheque_dues": all_open_dues(),
+        # Operators see every flagged cheque, narrowed by the driver filter like the list below.
+        # Not by payment term or sales person: a pickup has neither, and deriving them from the
+        # customer's invoices would hide the flagged customers that have no invoice at all.
+        "cheque_dues": all_open_dues(driver),
     }
 
 

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -153,11 +153,14 @@ def _collectable_terms():
 
 
 def _settings_flags():
-    """The two iPay Settings every collection response carries: hosted-checkout
-    availability and the M-Pesa STK ceiling."""
+    """The iPay Settings every collection response carries: hosted-checkout availability, the
+    M-Pesa STK ceiling, and whether cheque collection is usable — on AND a cheque account set,
+    so the app never offers a journey that would only fail at the final step."""
+    settings = frappe.get_cached_doc("iPay Settings")
     return {
-        "enable_redirect": bool(frappe.db.get_single_value("iPay Settings", "enable_redirect")),
-        "mpesa_max": flt(frappe.db.get_single_value("iPay Settings", "mpesa_max_amount")),
+        "enable_redirect": bool(settings.enable_redirect),
+        "mpesa_max": flt(settings.mpesa_max_amount),
+        "allow_cheque": bool(settings.allow_cheque_collection and settings.cheque_account),
     }
 
 

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -166,6 +166,7 @@ def _settings_flags():
         "enable_redirect": bool(frappe.db.get_single_value("iPay Settings", "enable_redirect")),
         "mpesa_max": flt(frappe.db.get_single_value("iPay Settings", "mpesa_max_amount")),
         "allow_cheque": bool(frappe.db.get_single_value("iPay Settings", "allow_cheque_collection")),
+        "cheque_per_invoice": bool(frappe.db.get_single_value("iPay Settings", "cheque_per_invoice")),
     }
 
 

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -322,7 +322,10 @@ def _cheque_on_account(customer):
     the same money twice.
 
     Scoped to the caller: the invoices in the same response are already scoped, so this figure
-    must be too — a collector or sales member never sees it for a customer they cannot access."""
+    must be too — a collector or sales member never sees it for a customer they cannot access.
+
+    Any unallocated amount counts, not only fully-on-account cheques: a cheque that partly covers
+    ticked invoices leaves the rest as customer credit, and that surplus is on account too."""
     from ipay.ipay.main.utils.collector import can_access_customer
 
     if not can_access_customer(customer):
@@ -334,7 +337,7 @@ def _cheque_on_account(customer):
             "party": customer,
             "docstatus": 0,
             "mode_of_payment": CHEQUE_MODE,
-            "total_allocated_amount": 0,
+            "unallocated_amount": [">", 0],
         },
         pluck="unallocated_amount",
     )

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -154,13 +154,12 @@ def _collectable_terms():
 
 def _settings_flags():
     """The iPay Settings every collection response carries: hosted-checkout availability, the
-    M-Pesa STK ceiling, and whether cheque collection is usable — on AND a cheque account set,
-    so the app never offers a journey that would only fail at the final step."""
-    settings = frappe.get_cached_doc("iPay Settings")
+    M-Pesa STK ceiling, and whether cheque collection is on. Read fresh, exactly like
+    enable_redirect — a cached read would keep showing the old value after the setting is toggled."""
     return {
-        "enable_redirect": bool(settings.enable_redirect),
-        "mpesa_max": flt(settings.mpesa_max_amount),
-        "allow_cheque": bool(settings.allow_cheque_collection and settings.cheque_account),
+        "enable_redirect": bool(frappe.db.get_single_value("iPay Settings", "enable_redirect")),
+        "mpesa_max": flt(frappe.db.get_single_value("iPay Settings", "mpesa_max_amount")),
+        "allow_cheque": bool(frappe.db.get_single_value("iPay Settings", "allow_cheque_collection")),
     }
 
 

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -314,9 +314,9 @@ def _annotate_awaiting_cheque(invoices):
     rows = frappe.get_all(
         "Payment Entry Reference",
         filters={"reference_doctype": "Sales Invoice", "reference_name": ["in", names], "docstatus": 0},
-        fields=["parent", "reference_name"],
+        fields=["parent", "reference_name", "allocated_amount"],
     )
-    drafts = set()
+    covered = {}
     if rows:
         cheques = set(
             frappe.get_all(
@@ -329,9 +329,13 @@ def _annotate_awaiting_cheque(invoices):
                 pluck="name",
             )
         )
-        drafts = {r.reference_name for r in rows if r.parent in cheques}
+        for row in rows:
+            if row.parent in cheques:
+                covered[row.reference_name] = covered.get(row.reference_name, 0) + flt(row.allocated_amount)
+    # The amount rides along: a cheque may cover only part of the invoice, and "awaiting" without
+    # a figure would read as though the whole balance were settled.
     for inv in invoices:
-        inv.awaiting_cheque = inv.name in drafts
+        inv.awaiting_cheque = flt(covered.get(inv.name, 0))
 
 
 def _cheque_on_account(customer):

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -147,9 +147,15 @@ def _annotate_delivery(invoices):
 def _collectable_terms():
     """Payment Terms Templates the Collect app is scoped to (iPay Settings → Collect
     Payment Terms) — the terms drivers settle on delivery. Empty means no term filter,
-    so every outstanding invoice is collectable (behaviour before the setting existed)."""
-    settings = frappe.get_cached_doc("iPay Settings")
-    return [row.payment_terms_template for row in (settings.get("collect_payment_terms") or [])]
+    so every outstanding invoice is collectable (behaviour before the setting existed).
+
+    Read fresh from the child rows, not the doc cache — a cached read would keep the old terms
+    after the setting changes (same reason _settings_flags reads the flags fresh)."""
+    return frappe.get_all(
+        "iPay Collection Payment Term",
+        filters={"parenttype": "iPay Settings", "parentfield": "collect_payment_terms"},
+        pluck="payment_terms_template",
+    )
 
 
 def _settings_flags():

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -3,7 +3,12 @@ from frappe.utils import add_to_date, cint, flt, now_datetime, today
 
 from ipay.ipay.main.utils.prepaid import all_prepaid_invoice_names, prepaid_invoice_names
 from ipay.ipay.main.utils.collector import OPERATOR_ROLES, collector_scope, is_collector_only
-from ipay.ipay.main.utils.constants import ACTIVE_BUNDLE_WINDOW_MIN, note_filters, note_text
+from ipay.ipay.main.utils.constants import (
+    ACTIVE_BUNDLE_WINDOW_MIN,
+    CHEQUE_MODE,
+    note_filters,
+    note_text,
+)
 from ipay.ipay.main.utils.sales import (
     SALES_MANAGER_ROLES,
     SALES_ROLE,
@@ -227,6 +232,7 @@ def _customer_invoices(user, customer, driver=None):
     _annotate_customer_phone(invoices)
     _annotate_sales_person(invoices)
     _annotate_notes(invoices)
+    _annotate_awaiting_cheque(invoices)
     return invoices
 
 
@@ -296,6 +302,54 @@ def _annotate_notes(invoices):
     for inv in invoices:
         inv.note_count = counts.get(inv.name, 0)
         inv.note_latest = note_text(latest.get(inv.name) or "")
+
+
+def _annotate_awaiting_cheque(invoices):
+    """Flag invoices a collected cheque already covers, batched. A cheque sits as a DRAFT Payment
+    Entry until accounts submit it, and a draft does not reduce outstanding — so without this the
+    invoice still looks unpaid and would be charged a second time."""
+    names = [inv.name for inv in invoices]
+    if not names:
+        return
+    rows = frappe.get_all(
+        "Payment Entry Reference",
+        filters={"reference_doctype": "Sales Invoice", "reference_name": ["in", names], "docstatus": 0},
+        fields=["parent", "reference_name"],
+    )
+    drafts = set()
+    if rows:
+        cheques = set(
+            frappe.get_all(
+                "Payment Entry",
+                filters={
+                    "name": ["in", list({r.parent for r in rows})],
+                    "docstatus": 0,
+                    "mode_of_payment": CHEQUE_MODE,
+                },
+                pluck="name",
+            )
+        )
+        drafts = {r.reference_name for r in rows if r.parent in cheques}
+    for inv in invoices:
+        inv.awaiting_cheque = inv.name in drafts
+
+
+def _cheque_on_account(customer):
+    """What a customer has handed over in cheques that name no invoice. Nothing marks those
+    invoices, so this is the only thing standing between an on-account cheque and collecting
+    the same money twice."""
+    amounts = frappe.get_all(
+        "Payment Entry",
+        filters={
+            "party_type": "Customer",
+            "party": customer,
+            "docstatus": 0,
+            "mode_of_payment": CHEQUE_MODE,
+            "total_allocated_amount": 0,
+        },
+        pluck="unallocated_amount",
+    )
+    return flt(sum(amounts))
 
 
 def get_context(context):
@@ -437,6 +491,7 @@ def customer_collection(customer, driver=None):
         "customer": customer,
         "customer_name": invoices[0].customer_name if invoices else customer,
         "invoices": invoices,
+        "cheque_on_account": _cheque_on_account(customer),
         **_settings_flags(),
         "can_bundle": not is_collector_only(frappe.session.user),
     }
@@ -520,9 +575,11 @@ def _drill_down(invoices, customer, start, page_length, search):
     _annotate_customer_phone(page)
     _annotate_sales_person(page)
     _annotate_notes(page)
+    _annotate_awaiting_cheque(page)
     return {
         "customer": customer,
         "customer_name": frappe.db.get_value("Customer", customer, "customer_name") or customer,
+        "cheque_on_account": _cheque_on_account(customer),
         "invoices": page,
         "invoice_count": count,
         "total_outstanding": total,

--- a/ipay/www/ipay_checkout.html
+++ b/ipay/www/ipay_checkout.html
@@ -5,7 +5,9 @@
   {% if disabled %}
     <p>Hosted checkout is not enabled.</p>
   {% elif not_found %}
-    {% if expired %}
+    {% if held %}
+    <p>A cheque has already been collected for this. There is nothing to pay here.</p>
+    {% elif expired %}
     <p>This payment link has expired. Please request a new one.</p>
     {% else %}
     <p>Payment request not found.</p>

--- a/ipay/www/ipay_checkout.py
+++ b/ipay/www/ipay_checkout.py
@@ -22,6 +22,7 @@ def get_context(context):
     if not request_name:
         context.not_found = True
         context.expired = status == "expired"
+        context.held = status == "held"
         return
 
     entered_phone = frappe.form_dict.get("phone")

--- a/ipay/www/pay.html
+++ b/ipay/www/pay.html
@@ -23,7 +23,10 @@
 <div class="ipay-pay">
   <div class="card">
     <div class="card-body p-4 text-center">
-      {% if invalid %}
+      {% if held %}
+        <h4>Cheque received</h4>
+        <p class="muted">A cheque has already been collected for this. There is nothing to pay here.</p>
+      {% elif invalid %}
         <h4>Invalid payment link</h4>
         <p class="muted">This payment link is invalid or has expired. Please request a new one.</p>
       {% elif paid %}

--- a/ipay/www/pay.py
+++ b/ipay/www/pay.py
@@ -13,6 +13,7 @@ def get_context(context):
     if not request_name:
         context.invalid = True
         context.expired = status == "expired"
+        context.held = status == "held"
         return
 
     req = frappe.db.get_value(


### PR DESCRIPTION
## What

Adds cheque collection to the iPay Collect PWA. A collector can record a cheque taken in the field; it is written as a **draft** Payment Entry for the accounts team to submit — the app never submits money itself.

## How it works

- **Gated by setting.** "Allow Cheque Collection" in iPay Settings turns the whole journey on/off, read fresh on every request. The cheque account (undeposited funds, never cash) is configured there and validated per company.
- **Draft Payment Entry.** A collected cheque books a draft PE against the customer, owned by the collector, with the cheque photo attached (private). The cheque number is namespaced per customer so one customer can't reuse a number while two customers can share one.
- **Two modes — new "Cheque Per Invoice" setting (on by default).**
  - *On:* a cheque attaches to the ticked invoices and allocates oldest-first (per payment term where the invoice has them); any surplus stays as on-account credit.
  - *Off:* every cheque is customer-level (on account), the per-invoice UI is hidden, and the server drops any invoice references it is sent — the accounts team decides what it settles. Seeded on for existing sites by a one-time patch (a Check field reads 0 when unset on an existing single).
- **Awaiting-cheque marker.** Once a cheque covers an invoice, that invoice (and any request/bundle covering it) becomes unchargeable across every rail until accounts bank it, so the same money is never collected twice.
- **Surfaces.** The cheque action appears on invoice cards, the collect bar, and the request/bundle detail page. Photo capture supports retake/remove, and the save is bounded so a hung request can't trap the dialog.
- **Scoped access.** Collectors and sales members may only record cheques for their own work — per invoice, and for on-account cheques via a single bounded query against the customer's outstanding book (never a full scan).

## Notes

- Shares the existing `allocate_references` allocator with the M-Pesa rail — allocation belongs to the invoices, not to how the money arrived.
- Introduces a reusable `BaseDialog` shell (single focus trap) that the prompt, notes, and cheque dialogs all sit on.
- Tests cover the cheque recording paths; `docs/cheque-collection.md` documents the operational flow.
