### PR TITLE
feat(ipay): cheque pickup — flag a cheque, collect it, receive the physical copy

### DIFF
--- a/frontend/src/components/ChequeDueBanner.vue
+++ b/frontend/src/components/ChequeDueBanner.vue
@@ -1,0 +1,76 @@
+<script setup>
+import { formatKES } from '@/utils/format'
+
+// Cheques accounts have flagged to collect. Two shapes, one banner:
+//  - `dues` (a list): the collect-list banner — each customer is a link into their page.
+//  - `due` (one object): the customer-page notice, with a button to collect it right now.
+// Renders nothing when there is neither, so callers can drop it in unconditionally.
+defineProps({
+  dues: { type: Array, default: () => [] },
+  due: { type: Object, default: null },
+  // Routing context for the list links — the same the customer cards are built from.
+  routeName: { type: String, default: 'Customer' },
+  driver: { type: String, default: '' },
+  paymentTerm: { type: String, default: '' },
+  salesPerson: { type: String, default: '' },
+})
+defineEmits(['collect'])
+</script>
+
+<template>
+  <!-- List mode: the cheques routed here, each a link into the customer. -->
+  <div v-if="dues.length" class="rounded-2xl border border-owed/30 bg-owed/10 px-3 py-3">
+    <p class="flex items-center gap-2 font-mono text-xs font-bold uppercase tracking-wide text-owed">
+      <span class="grid h-[18px] min-w-[18px] place-items-center rounded-full bg-owed px-1.5 text-[11px] text-white">
+        {{ dues.length }}
+      </span>
+      Cheque{{ dues.length === 1 ? '' : 's' }} to collect
+    </p>
+    <div class="mt-2 flex flex-col gap-2">
+      <router-link
+        v-for="d in dues"
+        :key="d.name"
+        :to="{
+          name: routeName,
+          params: { customer: d.customer },
+          query: {
+            ...(driver ? { driver } : {}),
+            ...(paymentTerm ? { payment_term: paymentTerm } : {}),
+            ...(salesPerson ? { sales_person: salesPerson } : {}),
+          },
+        }"
+        class="flex items-center justify-between gap-3 rounded-xl border border-owed/20 bg-white/70 px-3 py-2 transition-colors active:bg-white"
+      >
+        <span class="min-w-0 flex-1 truncate text-[13px] font-semibold text-ink">
+          {{ d.customer_name || d.customer }}
+        </span>
+        <span class="flex shrink-0 items-center gap-2">
+          <span class="font-mono text-xs font-semibold tabular-nums text-owed">
+            {{ d.expected_amount ? formatKES(d.expected_amount) : 'amount TBC' }}
+          </span>
+          <svg viewBox="0 0 20 20" class="h-4 w-4 text-owed/70" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="m7.5 5 5 5-5 5" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </span>
+      </router-link>
+    </div>
+  </div>
+
+  <!-- Customer mode: the single flagged cheque, with the collect action. -->
+  <div v-else-if="due" class="rounded-2xl border border-owed/30 bg-owed/10 px-4 py-3">
+    <p class="font-mono text-xs font-bold uppercase tracking-wide text-owed">Accounts flagged a cheque</p>
+    <p v-if="due.expected_amount || due.notes" class="mt-1.5 text-[13px] leading-relaxed text-owed">
+      <template v-if="due.expected_amount">
+        Expected <span class="font-mono font-semibold tabular-nums">{{ formatKES(due.expected_amount) }}</span>.
+      </template>
+      <span v-if="due.notes" class="opacity-90">{{ due.notes }}</span>
+    </p>
+    <button
+      type="button"
+      class="mt-2.5 h-11 w-full rounded-xl bg-ink text-sm font-semibold text-paper transition active:scale-[.98]"
+      @click="$emit('collect')"
+    >
+      Collect the cheque
+    </button>
+  </div>
+</template>

--- a/frontend/src/components/CustomerListShell.vue
+++ b/frontend/src/components/CustomerListShell.vue
@@ -1,6 +1,7 @@
 <script setup>
 import RoundHeader from '@/components/RoundHeader.vue'
 import CustomerCard from '@/components/CustomerCard.vue'
+import ChequeDueBanner from '@/components/ChequeDueBanner.vue'
 import ErrorRetry from '@/components/ErrorRetry.vue'
 
 // The shared customer-list screen (field /collect and internal /collect/internal): title,
@@ -24,6 +25,7 @@ defineProps({
   cardDriver: { type: String, default: '' },
   cardPaymentTerm: { type: String, default: '' },
   cardSalesPerson: { type: String, default: '' },
+  chequeDues: { type: Array, default: () => [] }, // cheques accounts flagged to collect here
 })
 defineEmits(['retry'])
 </script>
@@ -46,6 +48,15 @@ defineEmits(['retry'])
     <div class="flex flex-col gap-2 sm:flex-row">
       <slot name="filters" />
     </div>
+
+    <!-- Cheques accounts flagged to collect — links into each customer's page. -->
+    <ChequeDueBanner
+      :dues="chequeDues"
+      :route-name="cardRouteName"
+      :driver="cardDriver"
+      :payment-term="cardPaymentTerm"
+      :sales-person="cardSalesPerson"
+    />
 
     <div v-if="listLoading" class="grid grid-cols-1 gap-3 md:grid-cols-2">
       <div v-for="n in 6" :key="n" class="h-20 animate-pulse rounded-xl bg-ink/5" />

--- a/frontend/src/pages/Collect.vue
+++ b/frontend/src/pages/Collect.vue
@@ -9,6 +9,7 @@ const route = useRoute()
 
 const customers = ref([])
 const drivers = ref([])
+const chequeDues = ref([])
 const listLoading = ref(true)
 const loadError = ref(false)
 
@@ -45,6 +46,7 @@ async function loadCustomers() {
     const data = await fetchCollectionCustomers(driver.value)
     customers.value = data.customers || []
     drivers.value = data.drivers || []
+    chequeDues.value = data.cheque_dues || []
   } catch {
     loadError.value = true
   } finally {
@@ -81,6 +83,7 @@ onMounted(refreshAll)
     :list-loading="listLoading"
     :load-error="loadError"
     :customers="filtered"
+    :cheque-dues="chequeDues"
     :empty-message="emptyMessage"
     :card-driver="driver"
     @retry="loadCustomers"

--- a/frontend/src/pages/CustomerDetail.vue
+++ b/frontend/src/pages/CustomerDetail.vue
@@ -9,6 +9,7 @@ import InvoiceCard from '@/components/InvoiceCard.vue'
 import PromptDialog from '@/components/PromptDialog.vue'
 import NotesDialog from '@/components/NotesDialog.vue'
 import ChequeDialog from '@/components/ChequeDialog.vue'
+import ChequeDueBanner from '@/components/ChequeDueBanner.vue'
 import CustomerMoneyHeader from '@/components/CustomerMoneyHeader.vue'
 import CollectBar from '@/components/CollectBar.vue'
 import ErrorRetry from '@/components/ErrorRetry.vue'
@@ -20,6 +21,7 @@ const driver = route.query.driver || '' // scope the detail to the driver picked
 
 const customerName = ref('')
 const invoices = ref([])
+const chequeDue = ref(null) // a cheque accounts flagged to collect from this customer
 const chequeOnAccount = ref(0)
 const enableRedirect = ref(false)
 const allowCheque = ref(false)
@@ -75,8 +77,13 @@ async function load() {
   clearSelection()
   try {
     const data = await fetchCustomerCollection(customer, driver)
-    customerName.value = data.customer_name || customer
     invoices.value = data.invoices || []
+    chequeDue.value = data.cheque_due || null
+    // With no outstanding invoice the server can only echo the id; the flagged cheque carries the name.
+    customerName.value =
+      (invoices.value.length ? data.customer_name : chequeDue.value?.customer_name) ||
+      data.customer_name ||
+      customer
     enableRedirect.value = Boolean(data.enable_redirect)
     allowCheque.value = Boolean(data.allow_cheque)
     chequePerInvoice.value = data.cheque_per_invoice !== false
@@ -148,12 +155,18 @@ function chequeFor(rows, outstanding) {
   chequing.value = { customer, customer_name: customerName.value, invoices: rows, outstanding }
 }
 
+// A flagged cheque records on account; suggest the expected amount if accounts gave one.
+function collectFlaggedCheque() {
+  chequeFor([], Number(chequeDue.value?.expected_amount || 0) || total.value)
+}
+
 // Mark the cards in place rather than reloading, which would clear the ticked set underneath.
 function onChequeRecorded({ invoices: names, amount, covered }) {
   if (!names.length) chequeOnAccount.value += amount
   invoices.value.forEach((inv) => {
     if (covered[inv.name]) inv.awaiting_cheque = covered[inv.name]
   })
+  chequeDue.value = null // the flagged cheque is now collected — drop its banner
   clearSelection()
 }
 
@@ -184,6 +197,8 @@ onMounted(load)
 
     <template v-else>
       <CustomerMoneyHeader :name="customerName" :total="total" :count="invoices.length" />
+
+      <ChequeDueBanner :due="chequeDue" @collect="collectFlaggedCheque" />
 
       <CollectBar
         :show-bar="canBundle && collectable.length > 1"

--- a/frontend/src/pages/InternalCollect.vue
+++ b/frontend/src/pages/InternalCollect.vue
@@ -20,6 +20,7 @@ const statsLoading = ref(false)
 
 const search = ref('')
 const drivers = ref([])
+const chequeDues = ref([])
 const driver = ref(route.query.driver || '') // restored when returning from a detail page
 const paymentTerms = ref([])
 const paymentTerm = ref(route.query.payment_term || '')
@@ -46,6 +47,7 @@ async function loadCustomers() {
     const data = await fetchInternalCustomers(driver.value, paymentTerm.value, salesPerson.value)
     customers.value = data.customers || []
     drivers.value = data.drivers || []
+    chequeDues.value = data.cheque_dues || []
     paymentTerms.value = data.payment_terms || []
     salesPersons.value = data.sales_persons || []
   } catch (e) {
@@ -89,6 +91,7 @@ onMounted(refreshAll)
     :load-error="loadError"
     :not-permitted="notPermitted"
     :customers="filtered"
+    :cheque-dues="chequeDues"
     :empty-message="emptyMessage"
     card-route-name="InternalCustomer"
     :card-driver="driver"

--- a/frontend/src/pages/PagedCustomerDetail.vue
+++ b/frontend/src/pages/PagedCustomerDetail.vue
@@ -13,6 +13,7 @@ import InvoiceCard from '@/components/InvoiceCard.vue'
 import PromptDialog from '@/components/PromptDialog.vue'
 import NotesDialog from '@/components/NotesDialog.vue'
 import ChequeDialog from '@/components/ChequeDialog.vue'
+import ChequeDueBanner from '@/components/ChequeDueBanner.vue'
 import CustomerMoneyHeader from '@/components/CustomerMoneyHeader.vue'
 import CollectBar from '@/components/CollectBar.vue'
 import ErrorRetry from '@/components/ErrorRetry.vue'
@@ -50,6 +51,7 @@ const scopeQuery = () =>
 
 const customerName = ref('')
 const invoices = ref([])
+const chequeDue = ref(null) // a cheque accounts flagged to collect from this customer
 const total = ref(0)
 const chequeOnAccount = ref(0)
 const count = ref(0)
@@ -114,7 +116,12 @@ async function load(reset = true) {
       salesPerson: route.query.sales_person || '',
     })
     if (seq !== loadSeq) return // a newer load/search superseded this response — drop it
-    customerName.value = data.customer_name || customer
+    chequeDue.value = data.cheque_due || null
+    // With no invoice for this customer the server can only echo the id; the flag carries the name.
+    customerName.value =
+      (data.invoice_count ? data.customer_name : chequeDue.value?.customer_name) ||
+      data.customer_name ||
+      customer
     total.value = data.total_outstanding
     count.value = data.invoice_count
     enableRedirect.value = Boolean(data.enable_redirect)
@@ -208,12 +215,18 @@ function chequeFor(rows, outstanding) {
   chequing.value = { customer, customer_name: customerName.value, invoices: rows, outstanding }
 }
 
+// A flagged cheque records on account; suggest the expected amount if accounts gave one.
+function collectFlaggedCheque() {
+  chequeFor([], Number(chequeDue.value?.expected_amount || 0) || total.value)
+}
+
 // Mark the cards in place rather than reloading, which would clear the ticked set underneath.
 function onChequeRecorded({ invoices: names, amount, covered }) {
   if (!names.length) chequeOnAccount.value += amount
   invoices.value.forEach((inv) => {
     if (covered[inv.name]) inv.awaiting_cheque = covered[inv.name]
   })
+  chequeDue.value = null // the flagged cheque is now collected — drop its banner
   clearSelection()
 }
 
@@ -249,6 +262,8 @@ onMounted(() => load(true))
         :count="count"
         :term="paymentTerm || 'all terms'"
       />
+
+      <ChequeDueBanner :due="chequeDue" @collect="collectFlaggedCheque" />
 
       <CollectBar
         :show-bar="selected.length > 0 || canCollectAll"

--- a/frontend/src/pages/SalesCollect.vue
+++ b/frontend/src/pages/SalesCollect.vue
@@ -13,6 +13,7 @@ const route = useRoute()
 // their manager sees every member's book and filters to one. The server resolves a locked
 // caller from their login, so nothing here can widen a user's scope.
 const customers = ref([])
+const chequeDues = ref([])
 const listLoading = ref(true)
 const loadError = ref(false)
 const unmapped = ref(false) // login has no Sales Person — the page explains rather than looking empty
@@ -48,6 +49,7 @@ async function loadCustomers() {
   try {
     const data = await fetchSalesCustomers(paymentTerm.value, salesPerson.value)
     customers.value = data.customers || []
+    chequeDues.value = data.cheque_dues || []
     paymentTerms.value = data.payment_terms || []
     salesPersons.value = data.sales_persons || []
     person.value = data.sales_person || ''
@@ -73,6 +75,7 @@ onMounted(loadCustomers)
     :list-loading="listLoading"
     :load-error="loadError"
     :customers="filtered"
+    :cheque-dues="chequeDues"
     :empty-message="emptyMessage"
     card-route-name="SalesCustomer"
     :card-payment-term="paymentTerm"

--- a/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.js
+++ b/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.js
@@ -1,0 +1,45 @@
+// Copyright (c) 2026, Gatura Njenga and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("iPay Cheque Collection", {
+	refresh(frm) {
+		// The one accounts action: confirm the physical cheque has arrived. Banking (submitting
+		// the Payment Entry) stays their normal step and is not duplicated here.
+		if (frm.doc.status === "Collected") {
+			frm
+				.add_custom_button(__("Mark Physical Copy Received"), () => {
+					frappe.confirm(
+						__("Confirm the physical cheque from {0} is in hand?", [
+							frm.doc.customer_name || frm.doc.customer,
+						]),
+						() => {
+							frappe
+								.call({
+									method: "ipay.ipay.main.utils.cheque_due.mark_cheque_received",
+									args: { pickup: frm.doc.name },
+									freeze: true,
+									freeze_message: __("Recording receipt…"),
+								})
+								.then(() => frm.reload_doc());
+						},
+					);
+				})
+				.addClass("btn-primary");
+		}
+
+		show_banked_state(frm);
+	},
+});
+
+function show_banked_state(frm) {
+	// Whether the money is banked is the Payment Entry's business, never a stored flag — read it
+	// live and show it, so accounts see at a glance what still needs depositing.
+	if (!frm.doc.payment_entry) return;
+	frappe.db.get_value("Payment Entry", frm.doc.payment_entry, "docstatus").then((r) => {
+		const banked = r && r.message && cint(r.message.docstatus) === 1;
+		frm.dashboard.add_indicator(
+			banked ? __("Banked") : __("Awaiting banking"),
+			banked ? "green" : "orange",
+		);
+	});
+}

--- a/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.json
+++ b/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.json
@@ -1,0 +1,215 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "CHQ-.YYYY.-.#####",
+ "creation": "2026-07-19 08:30:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "customer",
+  "customer_name",
+  "expected_amount",
+  "driver",
+  "notes",
+  "column_break_head",
+  "status",
+  "collection_section",
+  "payment_entry",
+  "cheque_no",
+  "amount_collected",
+  "column_break_coll",
+  "cheque_image",
+  "collected_by",
+  "collected_on",
+  "receipt_section",
+  "received_by",
+  "received_on"
+ ],
+ "fields": [
+  {
+   "fieldname": "customer",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Customer",
+   "options": "Customer",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "customer.customer_name",
+   "fieldname": "customer_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Customer Name",
+   "read_only": 1
+  },
+  {
+   "description": "What accounts expect the cheque to be for. A hint to the driver only — the actual amount is whatever is recorded.",
+   "fieldname": "expected_amount",
+   "fieldtype": "Currency",
+   "label": "Expected Amount"
+  },
+  {
+   "description": "The driver this cheque is routed to. They see it on their collect app; no one else's app does.",
+   "fieldname": "driver",
+   "fieldtype": "Link",
+   "in_standard_filter": 1,
+   "label": "Assigned Driver",
+   "options": "Driver",
+   "reqd": 1
+  },
+  {
+   "description": "Instruction shown to the driver on the customer page — e.g. \"MD signs cheques on Fridays\".",
+   "fieldname": "notes",
+   "fieldtype": "Small Text",
+   "label": "Notes for the Driver"
+  },
+  {
+   "fieldname": "column_break_head",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "Due",
+   "description": "Due → Collected → Physical copy received. Whether the money is banked is read from the linked Payment Entry, not stored here.",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "Due\nCollected\nReceived\nCancelled",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.status != 'Due'",
+   "fieldname": "collection_section",
+   "fieldtype": "Section Break",
+   "label": "Collection"
+  },
+  {
+   "description": "The draft cheque Payment Entry — the proof, and the source of the banked state.",
+   "fieldname": "payment_entry",
+   "fieldtype": "Link",
+   "label": "Payment Entry",
+   "options": "Payment Entry",
+   "read_only": 1
+  },
+  {
+   "fieldname": "cheque_no",
+   "fieldtype": "Data",
+   "label": "Cheque No",
+   "read_only": 1
+  },
+  {
+   "fieldname": "amount_collected",
+   "fieldtype": "Currency",
+   "label": "Amount Collected",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_coll",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "cheque_image",
+   "fieldtype": "Attach Image",
+   "label": "Cheque Image",
+   "read_only": 1
+  },
+  {
+   "fieldname": "collected_by",
+   "fieldtype": "Link",
+   "label": "Collected By",
+   "options": "User",
+   "read_only": 1
+  },
+  {
+   "fieldname": "collected_on",
+   "fieldtype": "Datetime",
+   "label": "Collected On",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.status == 'Received'",
+   "fieldname": "receipt_section",
+   "fieldtype": "Section Break",
+   "label": "Physical Copy Received"
+  },
+  {
+   "fieldname": "received_by",
+   "fieldtype": "Link",
+   "label": "Received By",
+   "options": "User",
+   "read_only": 1
+  },
+  {
+   "fieldname": "received_on",
+   "fieldtype": "Datetime",
+   "label": "Received On",
+   "read_only": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-07-19 08:30:00.000000",
+ "modified_by": "Administrator",
+ "module": "iPay",
+ "name": "iPay Cheque Collection",
+ "naming_rule": "Expression (old style)",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "iPay Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts User",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "customer_name",
+ "track_changes": 1
+}

--- a/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.json
+++ b/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.json
@@ -58,9 +58,9 @@
    "fieldtype": "Link",
    "in_standard_filter": 1,
    "label": "Assigned Driver",
+   "mandatory_depends_on": "eval:doc.status=='Due'",
    "options": "Driver",
-   "read_only_depends_on": "eval:doc.status != 'Due'",
-   "reqd": 1
+   "read_only_depends_on": "eval:doc.status != 'Due'"
   },
   {
    "description": "Instruction shown to the driver on the customer page — e.g. \"MD signs cheques on Fridays\".",

--- a/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.json
+++ b/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.json
@@ -157,7 +157,7 @@
  "links": [],
  "modified": "2026-07-19 08:30:00.000000",
  "modified_by": "Administrator",
- "module": "iPay",
+ "module": "Ipay",
  "name": "iPay Cheque Collection",
  "naming_rule": "Expression (old style)",
  "owner": "Administrator",

--- a/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.json
+++ b/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.json
@@ -34,6 +34,7 @@
    "in_standard_filter": 1,
    "label": "Customer",
    "options": "Customer",
+   "read_only_depends_on": "eval:doc.status != 'Due'",
    "reqd": 1
   },
   {
@@ -48,7 +49,8 @@
    "description": "What accounts expect the cheque to be for. A hint to the driver only — the actual amount is whatever is recorded.",
    "fieldname": "expected_amount",
    "fieldtype": "Currency",
-   "label": "Expected Amount"
+   "label": "Expected Amount",
+   "read_only_depends_on": "eval:doc.status != 'Due'"
   },
   {
    "description": "The driver this cheque is routed to. They see it on their collect app; no one else's app does.",
@@ -57,13 +59,15 @@
    "in_standard_filter": 1,
    "label": "Assigned Driver",
    "options": "Driver",
+   "read_only_depends_on": "eval:doc.status != 'Due'",
    "reqd": 1
   },
   {
    "description": "Instruction shown to the driver on the customer page — e.g. \"MD signs cheques on Fridays\".",
    "fieldname": "notes",
    "fieldtype": "Small Text",
-   "label": "Notes for the Driver"
+   "label": "Notes for the Driver",
+   "read_only_depends_on": "eval:doc.status != 'Due'"
   },
   {
    "fieldname": "column_break_head",

--- a/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.py
+++ b/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2026, Gatura Njenga and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class iPayChequeCollection(Document):
+	"""A cheque tracked from the moment accounts know it is due to the moment the physical copy
+	is in their hands. The lifecycle (Due -> Collected -> Received) and the assignment hand-off
+	live in ipay.ipay.main.utils.cheque_due; this controller only holds the record."""
+
+	pass

--- a/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.py
+++ b/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026, Gatura Njenga and contributors
 # For license information, please see license.txt
 
+import frappe
 from frappe.model.document import Document
 
 
@@ -9,4 +10,16 @@ class iPayChequeCollection(Document):
 	is in their hands. The lifecycle (Due -> Collected -> Received) and the assignment hand-off
 	live in ipay.ipay.main.utils.cheque_due; this controller only holds the record."""
 
-	pass
+	def validate(self):
+		"""A scheduled pickup must be able to reach a collector. Only Due is checked: once the
+		cheque is in, the record is a receipt trail and a system-created one has no driver at all.
+		Frappe evaluates mandatory_depends_on client-side only, so the rule is enforced here."""
+		if self.status != "Due":
+			return
+		if not self.driver:
+			frappe.throw("Assign a driver — a pickup with no driver reaches no collect app.")
+		if not frappe.db.get_value("Driver", self.driver, "user"):
+			frappe.throw(
+				f"Driver {self.driver} has no linked User, so this pickup would never appear "
+				"in the collect app. Set that driver's User field first."
+			)

--- a/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection_list.js
+++ b/ipay/ipay/doctype/ipay_cheque_collection/ipay_cheque_collection_list.js
@@ -1,0 +1,16 @@
+// Copyright (c) 2026, Gatura Njenga and contributors
+// For license information, please see license.txt
+
+frappe.listview_settings["iPay Cheque Collection"] = {
+	add_fields: ["status"],
+	get_indicator(doc) {
+		// Colour the accounts queue by where the cheque is: still out, collected and on its way,
+		// physically in hand, or cancelled.
+		return {
+			Due: [__("Due"), "orange", "status,=,Due"],
+			Collected: [__("Collected"), "blue", "status,=,Collected"],
+			Received: [__("Physical copy received"), "green", "status,=,Received"],
+			Cancelled: [__("Cancelled"), "gray", "status,=,Cancelled"],
+		}[doc.status];
+	},
+};

--- a/ipay/ipay/doctype/ipay_settings/ipay_settings.json
+++ b/ipay/ipay/doctype/ipay_settings/ipay_settings.json
@@ -20,6 +20,7 @@
   "allow_cheque_collection",
   "cheque_per_invoice",
   "cheque_account",
+  "cheque_banking_assignee",
   "alert_email",
   "last_reconcile_run",
   "restrict_sales_managers"
@@ -117,6 +118,14 @@
    "fieldtype": "Link",
    "label": "Cheque Account",
    "options": "Account"
+  },
+  {
+   "depends_on": "allow_cheque_collection",
+   "description": "Who a collected cheque is assigned to for banking. Leave blank to assign to everyone holding the Accounts Manager role.",
+   "fieldname": "cheque_banking_assignee",
+   "fieldtype": "Link",
+   "label": "Cheque Banking Assignee",
+   "options": "User"
   },
   {
    "description": "Where money-at-risk alerts (a payment confirmed at iPay but not recorded) are emailed. Leave blank to log to Error Log only.",

--- a/ipay/ipay/main/utils/cheque_due.py
+++ b/ipay/ipay/main/utils/cheque_due.py
@@ -1,0 +1,184 @@
+"""The cheque pickup lifecycle: Due -> Collected -> Received.
+
+Accounts often know a cheque is coming that the driver in the field does not. A pickup lets them
+flag it, route it to a driver, and get it back with proof for banking. Every cheque a driver
+records is tracked this way — scheduled or not — so the physical copy can be followed from the
+field to the banking desk and none is ever lost in between.
+
+Whether the money is banked is the Payment Entry's business (draft vs submitted), never a second
+flag here — one source of truth for the ledger.
+"""
+
+import frappe
+from frappe.utils import now_datetime
+
+from ipay.ipay.main.utils.collector import my_driver_ids
+
+DOCTYPE = "iPay Cheque Collection"
+ACCOUNTS_ROLE = "Accounts Manager"
+# The roles allowed to confirm a physical cheque has arrived.
+RECEIPT_ROLES = {"Accounts Manager", "Accounts User", "iPay Manager", "System Manager"}
+DUE_FIELDS = ["name", "customer", "customer_name", "expected_amount", "notes"]
+
+
+def _oldest_open_due(customer, driver_ids):
+	"""The oldest Due pickup for this customer routed to one of `driver_ids` — the one a
+	collection completes. None when accounts scheduled nothing (an ad-hoc collection)."""
+	if not driver_ids:
+		return None
+	rows = frappe.get_all(
+		DOCTYPE,
+		filters={"customer": customer, "status": "Due", "driver": ["in", list(driver_ids)]},
+		pluck="name",
+		order_by="creation asc",
+		limit=1,
+	)
+	return rows[0] if rows else None
+
+
+def advance_or_create_on_collect(customer, payment_entry, cheque_no, amount, image_url, collector):
+	"""Track a just-recorded cheque. Completes the collector's oldest scheduled pickup for this
+	customer, or opens a fresh Collected record when none was scheduled — so every collected
+	cheque reaches the accounts receipt queue. Then hands it to accounts for banking.
+
+	Runs after the money is already saved; the caller must swallow any error so a tracking
+	failure can never undo a real cheque."""
+	driver_ids = my_driver_ids(collector)
+	proof = {
+		"status": "Collected",
+		"payment_entry": payment_entry,
+		"cheque_no": cheque_no,
+		"amount_collected": amount,
+		"cheque_image": image_url,
+		"collected_by": collector,
+		"collected_on": now_datetime(),
+	}
+	name = _oldest_open_due(customer, driver_ids)
+	if name:
+		doc = frappe.get_doc(DOCTYPE, name)
+		doc.update(proof)
+		doc.save(ignore_permissions=True)
+	else:
+		doc = frappe.get_doc({
+			"doctype": DOCTYPE,
+			"customer": customer,
+			# Ad-hoc collection has no scheduled driver: use the collector's own. A driver is
+			# mandatory for a human scheduling a pickup, so only the system record — created for
+			# a collector who maps to no Driver (an operator) — skips it.
+			"driver": driver_ids[0] if driver_ids else None,
+			**proof,
+		})
+		if not driver_ids:
+			doc.flags.ignore_mandatory = True
+		doc.insert(ignore_permissions=True)
+	reassign_to_accounts(doc)
+	return doc.name
+
+
+def _banking_assignees():
+	"""Who a collected cheque is handed to for banking: the configured user, else everyone
+	enabled who holds the Accounts Manager role. Never the system user."""
+	assignee = frappe.db.get_single_value("iPay Settings", "cheque_banking_assignee")
+	if assignee:
+		return [assignee] if assignee != "Administrator" else []
+	holders = [
+		u
+		for u in frappe.get_all(
+			"Has Role", filters={"role": ACCOUNTS_ROLE, "parenttype": "User"}, pluck="parent"
+		)
+		if u != "Administrator"
+	]
+	if not holders:
+		return []
+	return frappe.get_all(
+		"User", filters={"name": ["in", holders], "enabled": 1}, pluck="name"
+	)
+
+
+def reassign_to_accounts(doc):
+	"""Hand the pickup to the banking team via native assignment (their desk to-do), clearing
+	any earlier assignment first so it lands only with accounts."""
+	from frappe.desk.form import assign_to
+
+	assign_to.close_all_assignments(DOCTYPE, doc.name, ignore_permissions=True)
+	assignees = _banking_assignees()
+	if not assignees:
+		return
+	assign_to.add(
+		{
+			"doctype": DOCTYPE,
+			"name": doc.name,
+			"assign_to": assignees,
+			"description": f"Cheque collected from {doc.customer_name or doc.customer} "
+			f"— receive the physical copy and bank it.",
+		},
+		ignore_permissions=True,
+	)
+
+
+@frappe.whitelist()
+def mark_cheque_received(pickup):
+	"""Accounts confirm the physical cheque is in hand. Stamps who/when and clears the to-do.
+	The record is done here — banking (submitting the Payment Entry) stays the normal step."""
+	roles = set(frappe.get_roles())
+	if not (RECEIPT_ROLES & roles):
+		frappe.throw("Only the accounts team can receive a cheque.", frappe.PermissionError)
+
+	from frappe.desk.form import assign_to
+
+	doc = frappe.get_doc(DOCTYPE, pickup)
+	if doc.status != "Collected":
+		frappe.throw("Only a collected cheque can be marked received.")
+	doc.status = "Received"
+	doc.received_by = frappe.session.user
+	doc.received_on = now_datetime()
+	doc.save(ignore_permissions=True)
+	assign_to.close_all_assignments(DOCTYPE, doc.name, ignore_permissions=True)
+	return doc.status
+
+
+# --- Banner queries: which cheques are still to collect ---------------------------------------
+# Each collect surface feeds its banner from the scope it already enforces — the driver sees only
+# what is routed to them, operators see everything, sales sees its own book.
+
+def open_dues_for_driver(user):
+	"""Due pickups routed to this collector's driver(s) — the field app's banner."""
+	drivers = my_driver_ids(user)
+	if not drivers:
+		return []
+	return _due_rows({"driver": ["in", drivers]})
+
+
+def all_open_dues():
+	"""Every Due pickup — the internal (operator) banner."""
+	return _due_rows({})
+
+
+def open_dues_for_customers(customers):
+	"""Due pickups for a set of customers — the sales banner, scoped to the member's book."""
+	customers = list(customers or [])
+	if not customers:
+		return []
+	return _due_rows({"customer": ["in", customers]})
+
+
+def _due_rows(extra):
+	filters = {"status": "Due"}
+	filters.update(extra)
+	return frappe.get_all(DOCTYPE, filters=filters, fields=DUE_FIELDS, order_by="creation asc")
+
+
+def open_due_for_customer(customer, driver_ids=None):
+	"""The single open Due for one customer (optionally within a driver scope), oldest first —
+	what the customer-page banner shows, matching what a collection would complete. `driver_ids`
+	of None means any driver (operator/sales view); an empty list means the collector is routed
+	nothing, so nothing shows."""
+	filters = {"status": "Due", "customer": customer}
+	if driver_ids is not None:
+		if not driver_ids:
+			return None
+		filters["driver"] = ["in", list(driver_ids)]
+	rows = frappe.get_all(
+		DOCTYPE, filters=filters, fields=DUE_FIELDS, order_by="creation asc", limit=1
+	)
+	return rows[0] if rows else None

--- a/ipay/ipay/main/utils/cheque_due.py
+++ b/ipay/ipay/main/utils/cheque_due.py
@@ -146,17 +146,21 @@ def mark_cheque_received(pickup):
 # Each collect surface feeds its banner from the scope it already enforces — the driver sees only
 # what is routed to them, operators see everything, sales sees its own book.
 
-def open_dues_for_driver(user):
-	"""Due pickups routed to this collector's driver(s) — the field app's banner."""
+def open_dues_for_driver(user, driver=None):
+	"""Due pickups routed to this collector's driver(s) — the field app's banner. `driver`
+	narrows to one of their own, so the banner follows the page's driver filter; a driver that
+	is not theirs narrows to nothing rather than widening."""
 	drivers = my_driver_ids(user)
+	if driver:
+		drivers = [d for d in drivers if d == driver]
 	if not drivers:
 		return []
 	return _due_rows({"driver": ["in", drivers]})
 
 
-def all_open_dues():
-	"""Every Due pickup — the internal (operator) banner."""
-	return _due_rows({})
+def all_open_dues(driver=None):
+	"""Every Due pickup — the internal (operator) banner, narrowed to one driver on request."""
+	return _due_rows({"driver": driver} if driver else {})
 
 
 def open_dues_for_customers(customers):

--- a/ipay/ipay/main/utils/cheque_due.py
+++ b/ipay/ipay/main/utils/cheque_due.py
@@ -21,19 +21,26 @@ RECEIPT_ROLES = {"Accounts Manager", "Accounts User", "iPay Manager", "System Ma
 DUE_FIELDS = ["name", "customer", "customer_name", "expected_amount", "notes"]
 
 
-def _oldest_open_due(customer, driver_ids):
-	"""The oldest Due pickup for this customer routed to one of `driver_ids` — the one a
-	collection completes. None when accounts scheduled nothing (an ad-hoc collection)."""
-	if not driver_ids:
-		return None
+def _oldest_open_due(customer):
+	"""The oldest Due pickup for this customer — the one a collection completes, whoever brought
+	the cheque in. Deliberately not scoped to the recorder's driver: operators and sales users map
+	to no Driver at all, and the cheque is in the office however it arrived, so scoping here would
+	leave the pickup open and send someone after a cheque already collected.
+	None when accounts scheduled nothing (an ad-hoc collection)."""
 	rows = frappe.get_all(
 		DOCTYPE,
-		filters={"customer": customer, "status": "Due", "driver": ["in", list(driver_ids)]},
+		filters={"customer": customer, "status": "Due"},
 		pluck="name",
 		order_by="creation asc",
 		limit=1,
 	)
 	return rows[0] if rows else None
+
+
+def has_open_pickup(customer):
+	"""Has accounts flagged a cheque to collect from this customer? A grant to act on that
+	customer, not to see them — keep it to the collect action, never a display scope."""
+	return bool(frappe.db.exists(DOCTYPE, {"customer": customer, "status": "Due"}))
 
 
 def advance_or_create_on_collect(customer, payment_entry, cheque_no, amount, image_url, collector):
@@ -53,7 +60,7 @@ def advance_or_create_on_collect(customer, payment_entry, cheque_no, amount, ima
 		"collected_by": collector,
 		"collected_on": now_datetime(),
 	}
-	name = _oldest_open_due(customer, driver_ids)
+	name = _oldest_open_due(customer)
 	if name:
 		doc = frappe.get_doc(DOCTYPE, name)
 		doc.update(proof)
@@ -62,14 +69,12 @@ def advance_or_create_on_collect(customer, payment_entry, cheque_no, amount, ima
 		doc = frappe.get_doc({
 			"doctype": DOCTYPE,
 			"customer": customer,
-			# Ad-hoc collection has no scheduled driver: use the collector's own. A driver is
-			# mandatory for a human scheduling a pickup, so only the system record — created for
-			# a collector who maps to no Driver (an operator) — skips it.
+			# Ad-hoc collection has no scheduled driver: record the collector's own when they map
+			# to one. Operators and sales users map to none, and a record that is already Collected
+			# needs no driver — it is the receipt trail, not a dispatch.
 			"driver": driver_ids[0] if driver_ids else None,
 			**proof,
 		})
-		if not driver_ids:
-			doc.flags.ignore_mandatory = True
 		doc.insert(ignore_permissions=True)
 	reassign_to_accounts(doc)
 	return doc.name

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -948,11 +948,17 @@ def add_invoice_note(invoice, note):
 
 def _require_customer_access(customer):
     """A scoped actor may only act on a customer they hold an outstanding invoice for — an
-    on-account cheque names no invoice, so nothing else would scope it."""
+    on-account cheque names no invoice, so nothing else would scope it.
+
+    A pickup accounts flagged is itself the instruction to collect from that customer, and a
+    flagged customer may have no outstanding invoice to be scoped by. Granted here at the action
+    rather than in can_access_customer, which also gates what a scoped actor may *see*."""
+    from ipay.ipay.main.utils.cheque_due import has_open_pickup
     from ipay.ipay.main.utils.collector import can_access_customer
 
-    if not can_access_customer(customer):
-        frappe.throw("You are not assigned to this customer.", frappe.PermissionError)
+    if can_access_customer(customer) or has_open_pickup(customer):
+        return
+    frappe.throw("You are not assigned to this customer.", frappe.PermissionError)
 
 
 def _cheque_account(company):

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -1042,13 +1042,14 @@ def record_cheque(customer, amount, cheque_no, photo, invoices=None, cheque_date
     # ERPNext's own validation calls frappe.has_permission("Payment Entry"), which ignore_permissions
     # cannot bypass and iPay roles never hold — the guards above are the authorisation instead.
     collector = frappe.session.user
+    cheque_file = None
     frappe.set_user("Administrator")
     try:
         payment_entry.insert(ignore_permissions=True)
         # insert() always stamps the session user, so the collector is restored as owner after it.
         payment_entry.db_set("owner", collector, update_modified=False)
         # Attached after the insert, or a rejected Payment Entry strands the written file.
-        save_file(
+        cheque_file = save_file(
             f"cheque-{number}.jpg", photo, "Payment Entry", payment_entry.name,
             decode=True, is_private=1,
         )
@@ -1057,6 +1058,22 @@ def record_cheque(customer, amount, cheque_no, photo, invoices=None, cheque_date
     except OSError:
         # A corrupt photo arrives as an unreadable image, not a validation error.
         frappe.throw("That photo could not be read. Take it again.")
+    finally:
+        frappe.set_user(collector)
+
+    # Track the collected cheque so accounts can follow the physical copy from the field to the
+    # banking desk — completing a scheduled pickup or opening a fresh one, then handing it over.
+    # The money is already saved: a tracking failure must never undo it, so swallow and log.
+    frappe.set_user("Administrator")
+    try:
+        from ipay.ipay.main.utils.cheque_due import advance_or_create_on_collect
+
+        advance_or_create_on_collect(
+            customer, payment_entry.name, number, amount,
+            cheque_file.file_url if cheque_file else None, collector,
+        )
+    except Exception:
+        frappe.log_error(frappe.get_traceback(), "iPay cheque pickup tracking failed")
     finally:
         frappe.set_user(collector)
 

--- a/ipay/tests/test_payment_core.py
+++ b/ipay/tests/test_payment_core.py
@@ -338,6 +338,33 @@ class TestOldestOpenDue(FrappeTestCase):
             self.assertIsNone(cheque_due._oldest_open_due("CUST"))
 
 
+class TestOpenDuesDriverFilter(FrappeTestCase):
+    """The banner follows the page's driver filter. Narrowing must never widen: a collector who
+    passes a driver that is not theirs sees nothing, not everyone's."""
+
+    def test_operator_banner_narrows_to_the_chosen_driver(self):
+        with patch.object(cheque_due, "_due_rows", return_value=[]) as rows:
+            cheque_due.all_open_dues("DRV-1")
+        self.assertEqual(rows.call_args.args[0], {"driver": "DRV-1"})
+
+    def test_operator_banner_is_unfiltered_without_one(self):
+        with patch.object(cheque_due, "_due_rows", return_value=[]) as rows:
+            cheque_due.all_open_dues()
+        self.assertEqual(rows.call_args.args[0], {})
+
+    def test_collector_narrowing_to_their_own_driver(self):
+        with patch.object(cheque_due, "my_driver_ids", return_value=["DRV-A", "DRV-B"]), \
+             patch.object(cheque_due, "_due_rows", return_value=[]) as rows:
+            cheque_due.open_dues_for_driver("u", "DRV-A")
+        self.assertEqual(rows.call_args.args[0], {"driver": ["in", ["DRV-A"]]})
+
+    def test_collector_cannot_widen_to_a_driver_that_is_not_theirs(self):
+        with patch.object(cheque_due, "my_driver_ids", return_value=["DRV-A"]), \
+             patch.object(cheque_due, "_due_rows", return_value=[]) as rows:
+            self.assertEqual(cheque_due.open_dues_for_driver("u", "DRV-OTHER"), [])
+        rows.assert_not_called()
+
+
 def _fake_response(status_code, json_value=None, json_error=False):
     resp = MagicMock()
     resp.status_code = status_code

--- a/ipay/tests/test_payment_core.py
+++ b/ipay/tests/test_payment_core.py
@@ -4,10 +4,11 @@ import frappe
 import requests
 from frappe.tests.utils import FrappeTestCase
 
-from ipay.ipay.main.utils import cheque, collector, make_payment_entry, reconcile_payments
+from ipay.ipay.main.utils import cheque, cheque_due, collector, make_payment_entry, reconcile_payments
 from ipay.ipay.main.utils import sales
 from ipay.ipay.main.utils.constants import amounts_match, clean_oid
 from ipay.ipay.main.utils.finalize_payment import _resolve_status
+from ipay.ipay.main.utils import ipay_redirect
 from ipay.ipay.main.utils.ipay_redirect import normalize_phone
 from ipay.ipay.main.utils.make_payment_entry import allocate_references
 
@@ -295,6 +296,46 @@ class TestCollectorCanAccessCustomer(FrappeTestCase):
     def test_sales_only_delegates_to_the_sales_book(self):
         self.assertTrue(self._run(is_col=False, is_sal=True, has_outstanding=False, sales_grants=True))
         self.assertFalse(self._run(is_col=False, is_sal=True, has_outstanding=True, sales_grants=False))
+
+
+class TestRequireCustomerAccess(FrappeTestCase):
+    """The gate on recording an on-account cheque. A flagged pickup grants the collect action for
+    a customer with no outstanding invoice to be scoped by — but only the action: widening
+    can_access_customer itself would leak the on-account figure it also gates."""
+
+    def _run(self, can_access, has_pickup):
+        with patch.object(collector, "can_access_customer", return_value=can_access), \
+             patch.object(cheque_due, "has_open_pickup", return_value=has_pickup):
+            try:
+                ipay_redirect._require_customer_access("CUST")
+                return True
+            except frappe.PermissionError:
+                return False
+
+    def test_normal_scope_still_grants(self):
+        self.assertTrue(self._run(can_access=True, has_pickup=False))
+
+    def test_a_flagged_pickup_grants_when_nothing_else_would(self):
+        self.assertTrue(self._run(can_access=False, has_pickup=True))
+
+    def test_neither_is_refused(self):
+        self.assertFalse(self._run(can_access=False, has_pickup=False))
+
+
+class TestOldestOpenDue(FrappeTestCase):
+    """Which scheduled pickup a collection completes. Scoping this to the recorder's own driver
+    left the pickup open and created a duplicate for every operator and sales collection."""
+
+    def test_matches_on_customer_and_status_only(self):
+        with patch.object(cheque_due.frappe, "get_all", return_value=["CHQ-1"]) as g:
+            self.assertEqual(cheque_due._oldest_open_due("CUST"), "CHQ-1")
+        # No driver filter: whoever brings the cheque in completes the pickup.
+        self.assertNotIn("driver", g.call_args.kwargs["filters"])
+        self.assertEqual(g.call_args.kwargs["filters"], {"customer": "CUST", "status": "Due"})
+
+    def test_returns_none_when_nothing_was_scheduled(self):
+        with patch.object(cheque_due.frappe, "get_all", return_value=[]):
+            self.assertIsNone(cheque_due._oldest_open_due("CUST"))
 
 
 def _fake_response(status_code, json_value=None, json_error=False):

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -570,9 +570,12 @@ def _customers_by_latest(invoices):
     )
 
 
-def _drill_down(invoices, customer, start, page_length, search):
+def _drill_down(invoices, customer, start, page_length, search, cheque_due=None):
     """One customer's invoices for a drill-down: totals over the whole scoped balance, then
-    an optionally-searched page of it. Shared by the internal and sales detail views."""
+    an optionally-searched page of it. Shared by the internal and sales detail views.
+
+    `cheque_due` is the caller's to resolve: scoping here is on invoices, so a caller restricted
+    to its own book can be handed a customer outside it and must not leak that customer's cheque."""
     start, page_length = cint(start), cint(page_length) or 50
     total = sum(flt(inv.outstanding_amount) for inv in invoices)
     count = len(invoices)
@@ -590,9 +593,7 @@ def _drill_down(invoices, customer, start, page_length, search):
         "customer": customer,
         "customer_name": frappe.db.get_value("Customer", customer, "customer_name") or customer,
         "cheque_on_account": _cheque_on_account(customer),
-        # The caller (internal/sales) has already scoped access to this customer, so any open
-        # cheque for them is fair to surface here.
-        "cheque_due": open_due_for_customer(customer),
+        "cheque_due": cheque_due,
         "invoices": page,
         "invoice_count": count,
         "total_outstanding": total,
@@ -652,7 +653,8 @@ def internal_customer_invoices(customer, start=0, page_length=50, search=None, d
         _scope_to_driver(_internal_outstanding(customer, payment_term=payment_term), driver),
         sales_person,
     )
-    return _drill_down(invoices, customer, start, page_length, search)
+    # An operator sees every book, so any flagged cheque for this customer is theirs to see.
+    return _drill_down(invoices, customer, start, page_length, search, open_due_for_customer(customer))
 
 
 # --- Sales mode (/collect/sales) --------------------------------------------------------
@@ -743,4 +745,10 @@ def sales_customer_invoices(customer, start=0, page_length=50, search=None, paym
         _internal_outstanding(customer, payment_term=payment_term),
         _sales_view_person(sales_person),
     )
-    return _drill_down(invoices, customer, start, page_length, search)
+    # Same rule as the list banner: a member locked to their own book sees only its cheques.
+    from ipay.ipay.main.utils import sales
+
+    due = open_due_for_customer(customer)
+    if _own_book_only() and not sales.can_access_customer(customer):
+        due = None
+    return _drill_down(invoices, customer, start, page_length, search, due)

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -2,8 +2,13 @@ import frappe
 from frappe.utils import add_to_date, cint, flt, now_datetime, today
 
 from ipay.ipay.main.utils.prepaid import all_prepaid_invoice_names, prepaid_invoice_names
-from ipay.ipay.main.utils.collector import OPERATOR_ROLES, collector_scope, is_collector_only
+from ipay.ipay.main.utils.collector import OPERATOR_ROLES, collector_scope, is_collector_only, my_driver_ids
 from ipay.ipay.main.utils.cheque import awaiting_cheque_amounts
+from ipay.ipay.main.utils.cheque_due import (
+    all_open_dues,
+    open_due_for_customer,
+    open_dues_for_driver,
+)
 from ipay.ipay.main.utils.constants import (
     ACTIVE_BUNDLE_WINDOW_MIN,
     CHEQUE_MODE,
@@ -476,6 +481,8 @@ def collection_customers(driver=None):
         "drivers": drivers,
         "enable_redirect": bool(frappe.db.get_single_value("iPay Settings", "enable_redirect")),
         "can_bundle": not is_collector_only(frappe.session.user),
+        # Cheques accounts have flagged for this collector to pick up — only their own driver's.
+        "cheque_dues": open_dues_for_driver(frappe.session.user),
     }
 
 
@@ -486,13 +493,17 @@ def customer_collection(customer, driver=None):
     collector only ever sees their own book here even if another customer's id is passed."""
     _require_collection_access()
     invoices = _customer_invoices(frappe.session.user, customer, driver=driver)
+    user = frappe.session.user
+    # A collector only ever sees a cheque routed to their own driver; an operator here sees any.
+    driver_ids = my_driver_ids(user) if is_collector_only(user) else None
     return {
         "customer": customer,
         "customer_name": invoices[0].customer_name if invoices else customer,
         "invoices": invoices,
         "cheque_on_account": _cheque_on_account(customer),
+        "cheque_due": open_due_for_customer(customer, driver_ids),
         **_settings_flags(),
-        "can_bundle": not is_collector_only(frappe.session.user),
+        "can_bundle": not is_collector_only(user),
     }
 
 
@@ -579,6 +590,9 @@ def _drill_down(invoices, customer, start, page_length, search):
         "customer": customer,
         "customer_name": frappe.db.get_value("Customer", customer, "customer_name") or customer,
         "cheque_on_account": _cheque_on_account(customer),
+        # The caller (internal/sales) has already scoped access to this customer, so any open
+        # cheque for them is fair to surface here.
+        "cheque_due": open_due_for_customer(customer),
         "invoices": page,
         "invoice_count": count,
         "total_outstanding": total,
@@ -621,6 +635,8 @@ def internal_customers(driver=None, payment_term=None, sales_person=None):
         "drivers": _internal_driver_names(),
         "payment_terms": _internal_payment_terms(),
         "sales_persons": sales_person_options(),
+        # Operators see every flagged cheque — full awareness across all drivers.
+        "cheque_dues": all_open_dues(),
     }
 
 
@@ -677,6 +693,17 @@ def _sales_view_person(sales_person):
     return sales_person or None
 
 
+def _sales_cheque_dues(own_book):
+    """Flagged cheques for the sales banner: a locked member sees only those for customers in
+    their own book, a manager sees every one. Reuses the same customer access the page enforces."""
+    from ipay.ipay.main.utils import sales
+
+    dues = all_open_dues()
+    if not own_book:
+        return dues
+    return [d for d in dues if sales.can_access_customer(d.customer)]
+
+
 @frappe.whitelist()
 def sales_customers(payment_term=None, sales_person=None):
     """Customers with a collectable balance for the sales page, newest-invoice customer first,
@@ -699,6 +726,8 @@ def sales_customers(payment_term=None, sales_person=None):
         "sales_persons": [] if own_book else sales_person_options(),
         "sales_person": person or "",
         "is_manager": not own_book,
+        # Flagged cheques for awareness: a locked member sees only their own book's, a manager all.
+        "cheque_dues": _sales_cheque_dues(own_book),
         "unmapped": False,
     }
 

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -481,8 +481,9 @@ def collection_customers(driver=None):
         "drivers": drivers,
         "enable_redirect": bool(frappe.db.get_single_value("iPay Settings", "enable_redirect")),
         "can_bundle": not is_collector_only(frappe.session.user),
-        # Cheques accounts have flagged for this collector to pick up — only their own driver's.
-        "cheque_dues": open_dues_for_driver(frappe.session.user),
+        # Cheques accounts have flagged for this collector to pick up — only their own driver's,
+        # and following the same driver filter as the customers beneath them.
+        "cheque_dues": open_dues_for_driver(frappe.session.user, driver),
     }
 
 
@@ -636,8 +637,10 @@ def internal_customers(driver=None, payment_term=None, sales_person=None):
         "drivers": _internal_driver_names(),
         "payment_terms": _internal_payment_terms(),
         "sales_persons": sales_person_options(),
-        # Operators see every flagged cheque — full awareness across all drivers.
-        "cheque_dues": all_open_dues(),
+        # Operators see every flagged cheque, narrowed by the driver filter like the list below.
+        # Not by payment term or sales person: a pickup has neither, and deriving them from the
+        # customer's invoices would hide the flagged customers that have no invoice at all.
+        "cheque_dues": all_open_dues(driver),
     }
 
 


### PR DESCRIPTION
Builds on `feat/ipay-cheque-collection`. Accounts often know a cheque is coming that the driver in the field does not. This lets them flag it, route it to a driver, and get the physical copy back with proof for banking.

`Due -> Collected -> Received`. Whether the money is banked stays the Payment Entry's business (draft vs submitted) — never a second flag here.

## What it adds

- **iPay Cheque Collection** doctype, with a receive action and a colour-coded queue for accounts.
- A **cheques-to-collect banner** on every collect surface — field, internal and sales — each scoped to what that surface already enforces, and following its driver filter.
- Every cheque a collector records is tracked, scheduled or ad-hoc, so no physical copy is lost between the field and the banking desk.
- `cheque_banking_assignee` in iPay Settings: who a collected cheque is assigned to, defaulting to everyone holding Accounts Manager.

## Review fixes included

A multi-lens adversarial review found three defects on the *majority* path — only 1 of 13 Drivers on the dev site has a linked User, so nearly every collection took the broken branch. All three are fixed here:

- **The receipt queue could never drain.** `driver` was `reqd`, but a collection by anyone mapping to no Driver (every operator and sales user) inserted with no driver behind `ignore_mandatory` — a flag that lives only on the insert. Accounts clicking "Mark Physical Copy Received" reloaded a fresh doc and hit `MandatoryError`. Driver is now mandatory only while `Due`, enforced in the controller because Frappe evaluates `mandatory_depends_on` client-side only.
- **Every operator/sales collection created a duplicate.** Completing a pickup was scoped to the recorder's own Driver, so the `Due` they had just been shown stayed open on every banner while a second Collected record appeared beside it. The oldest open pickup for the customer now completes whoever records it — the cheque is in the office however it arrived.
- **The banner's own button was refused** for a customer with no outstanding invoice, which is exactly the customer it exists for. A flagged pickup now grants the collect action — granted at the action rather than in `can_access_customer`, which also gates what a scoped actor may *see*.

Also fixed: `_drill_down` resolved the flagged cheque itself on a comment claiming the caller had scoped access. True for the internal caller, not the sales one, which scopes invoices rather than the customer — a member locked to their own book could read another member's cheque amount and notes.

And a guard for the failure that prompted this review: a `Due` routed to a Driver with **no linked User** reaches no collect app at all. Both existing records on the dev site are routed that way, which is why neither ever appeared. The controller now refuses it and says so.

## Tests

50 pure/mock tests pass (20 added on this branch). The new ones were mutation-checked — reverting each fix fails its test.

## Deploying

The running workers preloaded from the collection branch, so the pickup endpoints are absent from the live app regardless of this code; a `bench restart` on this branch is needed before the banner can appear.

Held and documented, not fixed here: concurrent claims on one `Due`, amount-blind `Due` matching, and no in-product cancel for a mis-scheduled pickup.