### PR TITLE
fix(ipay): scope and filter the cheques-to-collect banner like the list beneath it

### DIFF
--- a/ipay/ipay/main/utils/cheque_due.py
+++ b/ipay/ipay/main/utils/cheque_due.py
@@ -146,21 +146,33 @@ def mark_cheque_received(pickup):
 # Each collect surface feeds its banner from the scope it already enforces — the driver sees only
 # what is routed to them, operators see everything, sales sees its own book.
 
-def open_dues_for_driver(user, driver=None):
-	"""Due pickups routed to this collector's driver(s) — the field app's banner. `driver`
-	narrows to one of their own, so the banner follows the page's driver filter; a driver that
-	is not theirs narrows to nothing rather than widening."""
+def _driver_ids_named(driver_name):
+	"""Driver records carrying this full name. The collect pages filter by the driver name shown
+	on a delivery note, while a pickup is routed to the Driver record itself — without this the
+	two never match and choosing a driver empties the banner."""
+	return frappe.get_all("Driver", filters={"full_name": driver_name}, pluck="name")
+
+
+def open_dues_for_driver(user, driver_name=None):
+	"""Due pickups routed to this collector's own driver(s) — the field banner for a collector.
+	`driver_name` narrows to one of their own; a driver that is not theirs narrows to nothing
+	rather than widening."""
 	drivers = my_driver_ids(user)
-	if driver:
-		drivers = [d for d in drivers if d == driver]
+	if driver_name:
+		named = set(_driver_ids_named(driver_name))
+		drivers = [d for d in drivers if d in named]
 	if not drivers:
 		return []
 	return _due_rows({"driver": ["in", drivers]})
 
 
-def all_open_dues(driver=None):
-	"""Every Due pickup — the internal (operator) banner, narrowed to one driver on request."""
-	return _due_rows({"driver": driver} if driver else {})
+def all_open_dues(driver_name=None):
+	"""Every Due pickup — the banner for anyone who sees every customer, narrowed to one driver
+	on request."""
+	if not driver_name:
+		return _due_rows({})
+	drivers = _driver_ids_named(driver_name)
+	return _due_rows({"driver": ["in", drivers]}) if drivers else []
 
 
 def open_dues_for_customers(customers):

--- a/ipay/ipay/main/utils/sales.py
+++ b/ipay/ipay/main/utils/sales.py
@@ -110,8 +110,13 @@ def customers_in_book(sales_person):
     named, customers = _cached_scope(sales_person)
     if not named:
         return set(customers)
+    # Submitted only: a Sales Team row survives on a draft or cancelled invoice, and counting
+    # those would put customers in the book that the customer list can never show.
     return set(customers) | set(frappe.get_all(
-        "Sales Invoice", filters={"name": ["in", list(named)]}, pluck="customer", distinct=True
+        "Sales Invoice",
+        filters={"name": ["in", list(named)], "docstatus": 1},
+        pluck="customer",
+        distinct=True,
     ))
 
 

--- a/ipay/ipay/main/utils/sales.py
+++ b/ipay/ipay/main/utils/sales.py
@@ -101,6 +101,20 @@ def _cached_scope(sales_person):
     return cache[sales_person]
 
 
+def customers_in_book(sales_person):
+    """Every customer in a member's book: those they are named on, plus the customers of the
+    invoices they are named on — the same either/or reading as scope_to_sales_person.
+
+    Unlike can_access_customer this asks for no outstanding invoice: a flagged cheque may be the
+    only thing left on a customer, and that is exactly the one their banner must still show."""
+    named, customers = _cached_scope(sales_person)
+    if not named:
+        return set(customers)
+    return set(customers) | set(frappe.get_all(
+        "Sales Invoice", filters={"name": ["in", list(named)]}, pluck="customer", distinct=True
+    ))
+
+
 def _in_book(sales_invoice, named, customers):
     """True when the invoice is in a book described by (named invoices, named customers)."""
     if not sales_invoice:

--- a/ipay/tests/test_payment_core.py
+++ b/ipay/tests/test_payment_core.py
@@ -10,6 +10,7 @@ from ipay.ipay.main.utils.constants import amounts_match, clean_oid
 from ipay.ipay.main.utils.finalize_payment import _resolve_status
 from ipay.ipay.main.utils import ipay_redirect
 from ipay.ipay.main.utils.ipay_redirect import normalize_phone
+from ipay.www import collect_payments as cp
 from ipay.ipay.main.utils.make_payment_entry import allocate_references
 
 
@@ -339,30 +340,80 @@ class TestOldestOpenDue(FrappeTestCase):
 
 
 class TestOpenDuesDriverFilter(FrappeTestCase):
-    """The banner follows the page's driver filter. Narrowing must never widen: a collector who
-    passes a driver that is not theirs sees nothing, not everyone's."""
+    """The banner follows the page's driver filter. That filter carries the driver NAME shown on a
+    delivery note while a pickup is routed to the Driver record, so the name must be resolved —
+    comparing the two directly silently emptied the banner. Narrowing must never widen."""
 
-    def test_operator_banner_narrows_to_the_chosen_driver(self):
-        with patch.object(cheque_due, "_due_rows", return_value=[]) as rows:
-            cheque_due.all_open_dues("DRV-1")
-        self.assertEqual(rows.call_args.args[0], {"driver": "DRV-1"})
+    def test_operator_banner_resolves_the_driver_name_to_its_records(self):
+        with patch.object(cheque_due, "_driver_ids_named", return_value=["HR-DRI-1"]), \
+             patch.object(cheque_due, "_due_rows", return_value=[]) as rows:
+            cheque_due.all_open_dues("Pickup")
+        self.assertEqual(rows.call_args.args[0], {"driver": ["in", ["HR-DRI-1"]]})
+
+    def test_an_unknown_driver_name_shows_nothing_rather_than_everything(self):
+        with patch.object(cheque_due, "_driver_ids_named", return_value=[]), \
+             patch.object(cheque_due, "_due_rows", return_value=[]) as rows:
+            self.assertEqual(cheque_due.all_open_dues("No Such Driver"), [])
+        rows.assert_not_called()
 
     def test_operator_banner_is_unfiltered_without_one(self):
         with patch.object(cheque_due, "_due_rows", return_value=[]) as rows:
             cheque_due.all_open_dues()
         self.assertEqual(rows.call_args.args[0], {})
 
-    def test_collector_narrowing_to_their_own_driver(self):
-        with patch.object(cheque_due, "my_driver_ids", return_value=["DRV-A", "DRV-B"]), \
+    def test_collector_narrowing_intersects_the_name_with_their_own(self):
+        with patch.object(cheque_due, "my_driver_ids", return_value=["HR-DRI-A", "HR-DRI-B"]), \
+             patch.object(cheque_due, "_driver_ids_named", return_value=["HR-DRI-A"]), \
              patch.object(cheque_due, "_due_rows", return_value=[]) as rows:
-            cheque_due.open_dues_for_driver("u", "DRV-A")
-        self.assertEqual(rows.call_args.args[0], {"driver": ["in", ["DRV-A"]]})
+            cheque_due.open_dues_for_driver("u", "Anne")
+        self.assertEqual(rows.call_args.args[0], {"driver": ["in", ["HR-DRI-A"]]})
 
     def test_collector_cannot_widen_to_a_driver_that_is_not_theirs(self):
-        with patch.object(cheque_due, "my_driver_ids", return_value=["DRV-A"]), \
+        with patch.object(cheque_due, "my_driver_ids", return_value=["HR-DRI-A"]), \
+             patch.object(cheque_due, "_driver_ids_named", return_value=["HR-DRI-OTHER"]), \
              patch.object(cheque_due, "_due_rows", return_value=[]) as rows:
-            self.assertEqual(cheque_due.open_dues_for_driver("u", "DRV-OTHER"), [])
+            self.assertEqual(cheque_due.open_dues_for_driver("u", "Someone Else"), [])
         rows.assert_not_called()
+
+
+class TestSalesChequeDues(FrappeTestCase):
+    """The sales banner must match the customer list beneath it. Matching on book membership, not
+    can_access_customer: that asks for an outstanding invoice, which would drop the flagged
+    customer whose cheque is the last thing owed."""
+
+    def test_a_named_member_sees_only_their_own_book(self):
+        with patch.object(cp, "customers_in_book", return_value={"CUST-A"}) as book, \
+             patch.object(cp, "open_dues_for_customers", return_value=["due"]) as scoped, \
+             patch.object(cp, "all_open_dues", return_value=["everything"]) as everything:
+            self.assertEqual(cp._sales_cheque_dues(True, "Person"), ["due"])
+        book.assert_called_once_with("Person")
+        scoped.assert_called_once_with({"CUST-A"})
+        everything.assert_not_called()
+
+    def test_a_locked_member_with_no_sales_person_sees_nothing(self):
+        # Never every book: an unmapped login must not fall through to the whole company's cheques.
+        with patch.object(cp, "all_open_dues", return_value=["everything"]) as everything:
+            self.assertEqual(cp._sales_cheque_dues(True, None), [])
+        everything.assert_not_called()
+
+    def test_an_unrestricted_manager_picking_nobody_sees_every_book(self):
+        with patch.object(cp, "all_open_dues", return_value=["everything"]):
+            self.assertEqual(cp._sales_cheque_dues(False, None), ["everything"])
+
+
+class TestBannerDues(FrappeTestCase):
+    """The operator banner under the page's own driver and sales-member filters."""
+
+    def test_sales_member_filter_keeps_only_that_book(self):
+        dues = [frappe._dict(name="CHQ-1", customer="MINE"), frappe._dict(name="CHQ-2", customer="THEIRS")]
+        with patch.object(cp, "all_open_dues", return_value=dues), \
+             patch.object(cp, "customers_in_book", return_value={"MINE"}):
+            self.assertEqual([d.name for d in cp._banner_dues(None, "Person")], ["CHQ-1"])
+
+    def test_no_sales_filter_passes_the_driver_scope_through(self):
+        with patch.object(cp, "all_open_dues", return_value=["as-is"]) as everything:
+            self.assertEqual(cp._banner_dues("Pickup", None), ["as-is"])
+        everything.assert_called_once_with("Pickup")
 
 
 def _fake_response(status_code, json_value=None, json_error=False):

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -765,10 +765,10 @@ def sales_customer_invoices(customer, start=0, page_length=50, search=None, paym
         _internal_outstanding(customer, payment_term=payment_term),
         _sales_view_person(sales_person),
     )
-    # Same rule as the list banner: a member locked to their own book sees only its cheques.
-    from ipay.ipay.main.utils import sales
-
+    # Book membership, the same test the list banner uses — can_access_customer would deny the
+    # drill-down the very cheque the banner just linked the member to.
+    person = _sales_view_person(sales_person)
     due = open_due_for_customer(customer)
-    if _own_book_only() and not sales.can_access_customer(customer):
+    if person and customer not in customers_in_book(person):
         due = None
     return _drill_down(invoices, customer, start, page_length, search, due)

--- a/ipay/www/collect_payments.py
+++ b/ipay/www/collect_payments.py
@@ -7,6 +7,7 @@ from ipay.ipay.main.utils.cheque import awaiting_cheque_amounts
 from ipay.ipay.main.utils.cheque_due import (
     all_open_dues,
     open_due_for_customer,
+    open_dues_for_customers,
     open_dues_for_driver,
 )
 from ipay.ipay.main.utils.constants import (
@@ -18,6 +19,7 @@ from ipay.ipay.main.utils.constants import (
 from ipay.ipay.main.utils.sales import (
     SALES_MANAGER_ROLES,
     SALES_ROLE,
+    customers_in_book,
     is_sales_only,
     my_sales_person,
     sales_person_options,
@@ -481,9 +483,14 @@ def collection_customers(driver=None):
         "drivers": drivers,
         "enable_redirect": bool(frappe.db.get_single_value("iPay Settings", "enable_redirect")),
         "can_bundle": not is_collector_only(frappe.session.user),
-        # Cheques accounts have flagged for this collector to pick up — only their own driver's,
-        # and following the same driver filter as the customers beneath them.
-        "cheque_dues": open_dues_for_driver(frappe.session.user, driver),
+        # Flagged cheques under the same scope as the customers beneath them: a collector sees
+        # only their own driver's, anyone who sees every customer sees every cheque. Both follow
+        # the page's driver filter.
+        "cheque_dues": (
+            open_dues_for_driver(frappe.session.user, driver)
+            if is_collector_only(frappe.session.user)
+            else all_open_dues(driver)
+        ),
     }
 
 
@@ -542,6 +549,17 @@ def _internal_outstanding(customer=None, payment_term=None):
     if prepaid:
         invoices = [inv for inv in invoices if inv.name not in prepaid]
     return _drop_bundled(invoices)
+
+
+def _banner_dues(driver=None, sales_person=None):
+    """Flagged cheques for a banner above an unrestricted customer list, under the page's own
+    filters. The sales-member filter matches on the customer's book rather than their invoices,
+    so a customer flagged with nothing outstanding is still their cheque to collect."""
+    dues = all_open_dues(driver)
+    if sales_person and dues:
+        book = customers_in_book(sales_person)
+        dues = [d for d in dues if d.customer in book]
+    return dues
 
 
 def _internal_driver_names():
@@ -637,10 +655,8 @@ def internal_customers(driver=None, payment_term=None, sales_person=None):
         "drivers": _internal_driver_names(),
         "payment_terms": _internal_payment_terms(),
         "sales_persons": sales_person_options(),
-        # Operators see every flagged cheque, narrowed by the driver filter like the list below.
-        # Not by payment term or sales person: a pickup has neither, and deriving them from the
-        # customer's invoices would hide the flagged customers that have no invoice at all.
-        "cheque_dues": all_open_dues(driver),
+        # Every flagged cheque, under the same driver and sales-member filters as the list below.
+        "cheque_dues": _banner_dues(driver, sales_person),
     }
 
 
@@ -698,15 +714,16 @@ def _sales_view_person(sales_person):
     return sales_person or None
 
 
-def _sales_cheque_dues(own_book):
-    """Flagged cheques for the sales banner: a locked member sees only those for customers in
-    their own book, a manager sees every one. Reuses the same customer access the page enforces."""
-    from ipay.ipay.main.utils import sales
+def _sales_cheque_dues(own_book, person):
+    """Flagged cheques for the sales banner, scoped exactly like the customer list beneath it:
+    one member's book when locked to it or filtered to a member, every book for an unrestricted
+    manager who has picked nobody.
 
-    dues = all_open_dues()
-    if not own_book:
-        return dues
-    return [d for d in dues if sales.can_access_customer(d.customer)]
+    Matched on book membership, not can_access_customer: that asks for an outstanding invoice,
+    which would drop the flagged customer whose cheque is the last thing owed."""
+    if person:
+        return open_dues_for_customers(customers_in_book(person))
+    return [] if own_book else all_open_dues()
 
 
 @frappe.whitelist()
@@ -731,8 +748,8 @@ def sales_customers(payment_term=None, sales_person=None):
         "sales_persons": [] if own_book else sales_person_options(),
         "sales_person": person or "",
         "is_manager": not own_book,
-        # Flagged cheques for awareness: a locked member sees only their own book's, a manager all.
-        "cheque_dues": _sales_cheque_dues(own_book),
+        # Flagged cheques for awareness, under the same book/member scope as the list.
+        "cheque_dues": _sales_cheque_dues(own_book, person),
         "unmapped": False,
     }
 


### PR DESCRIPTION
Builds on `feat/ipay-cheque-collection`. The "cheques to collect" banner disagreed with the customer list under it on all three collect surfaces. Three separate faults, all fixed here.

## The driver filter matched nothing

The collect pages filter by the driver **name** carried on a delivery note (`"Pickup"`), while a pickup is routed to the Driver **record** (`"HR-DRI-2022-00002"`). Comparing them directly never matched, so choosing a driver *emptied* the banner instead of narrowing it. The name is now resolved to its Driver records first; an unknown name shows nothing rather than everything.

## An operator saw no cheques on the field page

`/collect`'s banner asked for the caller's own driver records — which a System Manager has none of — while the customer list on that same page is unrestricted for that caller. It now follows the rule the customer page already used: a collector sees only their own driver's cheques; anyone who sees every customer sees every cheque, filterable by driver.

## Neither the internal nor sales banner followed the sales-member filter

Both do now, matched on the member's **book** (customers they are named on, plus customers of the invoices they are named on). Deliberately not `can_access_customer`, which requires an outstanding invoice and so would drop the flagged customer whose cheque is the last thing owed. A locked member with no sales-person mapping gets nothing rather than falling through to every book.

## Also

`customers_in_book` now counts submitted invoices only — a `Sales Team` row survives on a draft or cancelled invoice, which would otherwise widen a book past the customer list. And the sales drill-down (`sales_customer_invoices`) now gates its cheque on book membership too, so it stops denying the very cheque the banner just linked the member to.

## Tests

56 pure/mock tests pass. New tests cover the driver-name resolution, the narrow-never-widen property, and the sales/operator banner scoping; each was mutation-checked (reverting a fix fails its test).

## Verified on live data (read-only)

`"Samuel // KCK328S // bbx2"` resolves to `HR-DRI-2023-00002` → `CHQ-2026-00002`. Sophia Khalid (owns Bulkbox Office) sees that cheque; Eugene Aaron does not.

Deferred, non-blocking: driver `full_name` is not unique or status-filtered; `payment_term` narrows the lists but not the banner; accounts' `notes` ship to the list banner without being rendered.