### PR TITLE
fix(ipay): label the collect M-Pesa option just "M-Pesa"

### DIFF
--- a/frontend/src/components/InvoiceCard.vue
+++ b/frontend/src/components/InvoiceCard.vue
@@ -150,7 +150,7 @@ async function payViaIpay() {
           :disabled="actionsDisabled"
           @click="$emit('prompt')"
         >
-          Prompt M-Pesa
+          M-Pesa
         </button>
         <button
           v-if="enableRedirect"

--- a/frontend/src/components/PromptDialog.vue
+++ b/frontend/src/components/PromptDialog.vue
@@ -189,7 +189,7 @@ onUnmounted(() => {
       <!-- Prompt form -->
       <template v-else>
         <p class="font-display text-xs font-semibold uppercase tracking-widest text-ink/60">
-          Prompt M-Pesa
+          M-Pesa
         </p>
         <p id="prompt-title" class="mt-1 text-lg font-semibold leading-snug text-ink">
           {{ target.title }}

--- a/frontend/src/pages/RequestDetail.vue
+++ b/frontend/src/pages/RequestDetail.vue
@@ -310,7 +310,7 @@ onMounted(load)
           class="h-14 rounded-xl bg-mpesa text-lg font-semibold text-white transition active:scale-[.98]"
           @click="promptNow"
         >
-          Prompt M-Pesa — {{ formatKES(detail.amount) }}
+          M-Pesa — {{ formatKES(detail.amount) }}
         </button>
         <p v-else class="rounded-xl bg-owed/10 px-3 py-2 text-sm text-owed">
           M-Pesa isn't available for amounts over {{ formatKES(detail.mpesa_max) }}.


### PR DESCRIPTION
A small cosmetic change, independent of the cheque work — cut from `main`.

"Prompt M-Pesa" on the two collect buttons (`InvoiceCard.vue`, `RequestDetail.vue`) and the prompt dialog eyebrow (`PromptDialog.vue`) read as jargon; the action is plainly M-Pesa. Text only, three user-facing spots, no logic touched.