### PR TITLE
fix(ipay): pause the reconcile poller until it polls selectively

### DIFF
--- a/ipay/hooks.py
+++ b/ipay/hooks.py
@@ -148,11 +148,14 @@ scheduler_events = {
 	"daily": [
 		"ipay.ipay.main.utils.log_cleanup.del_old_logs"
 	],
-	"cron": {
-		"*/5 * * * *": [
-			"ipay.ipay.main.utils.reconcile_payments.reconcile_pending_payments"
-		]
-	},
+	# PAUSED: the reconcile poller re-queries iPay for every undelivered request on every run
+	# (no per-request backoff), so its call volume grows with the backlog. Off until it is
+	# reworked — see reconcile_pending_payments, which also returns early while paused.
+	# "cron": {
+	# 	"*/5 * * * *": [
+	# 		"ipay.ipay.main.utils.reconcile_payments.reconcile_pending_payments"
+	# 	]
+	# },
 # 	"hourly": [
 # 		"ipay.tasks.hourly"
 # 	],

--- a/ipay/ipay/main/utils/reconcile_payments.py
+++ b/ipay/ipay/main/utils/reconcile_payments.py
@@ -7,6 +7,11 @@ from ipay.ipay.main.utils.ipay_logs import create_log_entry
 from ipay.ipay.main.utils.constants import clean_oid, search_hash
 from ipay.ipay.main.utils.alerts import notify_money_at_risk
 
+# Master switch for the scheduled backstop. Set False to resume once it polls selectively
+# (only genuinely-unknown requests) and backs off per request instead of re-querying the
+# whole backlog every run.
+RECONCILE_PAUSED = True
+
 # Only reconcile requests created within this window; older unconfirmed requests
 # are assumed abandoned (marked terminal below) so we don't poll them forever.
 RECONCILE_WINDOW_HOURS = 24
@@ -40,6 +45,13 @@ def reconcile_pending_payments():
     Entry is deduped on the transaction code and the callback on the
     callback_delivered flag.
     """
+    # PAUSED pending a rework: one iPay lookup per undelivered request per run, with no
+    # per-request backoff, so the call volume grows with the backlog. Guarded here as well as
+    # in hooks so an already-registered Scheduled Job Type stops the moment this code deploys,
+    # without waiting for the migrate that removes it.
+    if RECONCILE_PAUSED:
+        return
+
     settings = frappe.get_single("iPay Settings")
     vid = (settings.vendor_id or "").lower()
     secret_key = settings.api_key


### PR DESCRIPTION
## Why now

The scheduler is enabled in production, so this job is live. It makes **one iPay `/transaction/search` call per undelivered request, per run, every 5 minutes** — with no memory between runs. There is no `last_polled` stamp and no attempt counter on `iPay Request`, so every run re-queries the whole backlog from scratch.

Consequences measured on dev (36 undelivered):

| | |
|---|---|
| iPay calls per run | 36 |
| **per day** | **10,368** |
| worst-case run duration (36 × 15s timeout) | **9 min**, against a 5-min cron |

It also polls requests whose outcome is already known — 10 of those 36 are `Failed` (a definitive decline, stored in `result_detail`) and 3 are `Success` needing only callback re-delivery. Only the 23 `Pending` are genuinely unknown.

At production volume it degrades badly: 200 pending → ~57,600 calls/day and a worst-case 50-minute run; 1,000 pending → ~288,000 calls/day.

## What this does

Turns the scheduled sweep off in two places, deliberately:

- **`hooks.py`** — the cron entry is commented out, so `sync_jobs()` on the next migrate deletes the `Scheduled Job Type` row (`clear_events` removes job types no longer defined in hooks).
- **`reconcile_pending_payments()`** — returns early on a `RECONCILE_PAUSED` constant. Needed because `sync_jobs()` only runs on **migrate**; without this guard the already-registered job would keep firing against the method until someone migrates.

## What is NOT paused

`reconcile_request()` — the on-demand path `ipay_return` uses when the browser returns from hosted checkout — is untouched. In-session finalisation still works. Only the every-5-minutes backlog sweep stops.

Verified: with the first post-guard calls booby-trapped, `reconcile_pending_payments()` returns having done zero work and made no network call.

## Accepted tradeoff

While paused there is no automatic recovery for payments whose callback was lost, no callback retry, and no `Abandoned` sweep. That exposure is understood and accepted; the poller in its current form was the worse option.

## Resuming

Flip `RECONCILE_PAUSED` and uncomment the hook, once it polls only genuinely-unknown (`Pending`) requests and backs off per request instead of re-querying the whole backlog.

56 tests pass.