### PR TITLE
feat(ipay): nudge mobile users to install the Collect PWA

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,10 @@
+<script setup>
+import InstallPrompt from './components/InstallPrompt.vue'
+</script>
+
 <template>
   <div class="h-full bg-gray-50 text-gray-900">
     <router-view />
+    <InstallPrompt />
   </div>
 </template>

--- a/frontend/src/components/InstallPrompt.vue
+++ b/frontend/src/components/InstallPrompt.vue
@@ -1,0 +1,105 @@
+<script setup>
+import { computed, ref } from 'vue'
+import { useRoute } from 'vue-router'
+import BaseDialog from './BaseDialog.vue'
+import { useInstallPrompt } from '@/composables/useInstallPrompt'
+
+// The nudge belongs on the pages a user lands on after login — not over a customer's invoice
+// list, where a floating bar would sit on top of the collect action.
+const LANDING_ROUTES = ['Collect', 'Sales', 'Internal']
+
+const route = useRoute()
+const { visible, platform, canNativeInstall, install, snooze } = useInstallPrompt()
+const showGuide = ref(false)
+
+const showBanner = computed(() => visible.value && LANDING_ROUTES.includes(route.name))
+
+// Bound (not a static src) so Vite serves it from the app's runtime asset path rather than
+// trying to resolve and bundle it from the frontend source tree at build time.
+const APP_ICON = '/assets/ipay/manifest/favicon-196.png'
+
+// Static, per-platform copy — safe to render with v-html (no user input). iOS never gets a
+// native prompt; Android does only when the app is installable (see useInstallPrompt).
+const GUIDE_STEPS = {
+  ios: [
+    'Tap the <strong>Share</strong> button in the browser toolbar.',
+    'Scroll down and tap <strong>Add to Home Screen</strong>.',
+    'Tap <strong>Add</strong> in the top corner.',
+  ],
+  android: [
+    'Tap the <strong>⋮ menu</strong> at the top-right of the browser.',
+    'Tap <strong>Install app</strong> (or <strong>Add to Home screen</strong>).',
+    'Tap <strong>Install</strong> to confirm.',
+  ],
+  other: [
+    'Open your browser menu.',
+    'Choose <strong>Install app</strong> or <strong>Add to Home Screen</strong>.',
+    'Confirm to add it to your home screen.',
+  ],
+}
+const steps = computed(() => GUIDE_STEPS[platform.value] || GUIDE_STEPS.other)
+
+async function onPrimary() {
+  // When the native install dialog is available, it owns the whole interaction — don't
+  // second-guess a user who dismisses it by then showing manual steps.
+  if (canNativeInstall.value) return install()
+  // No native dialog (iOS always, Android when the SW is self-destroying) → show the steps.
+  showGuide.value = true
+}
+</script>
+
+<template>
+  <div v-if="showBanner" class="fixed inset-x-0 bottom-0 z-40 p-3 sm:p-4">
+    <div
+      class="mx-auto flex max-w-md items-center gap-3 rounded-2xl border border-hairline bg-white p-3 shadow-lg"
+    >
+      <img :src="APP_ICON" alt="" class="h-10 w-10 shrink-0 rounded-xl" />
+      <div class="min-w-0 flex-1">
+        <p class="font-display text-sm font-semibold text-ink">Install iPay Collect</p>
+        <p class="text-xs text-ink/60">Add it to your home screen for quick, full-screen access.</p>
+      </div>
+      <button
+        type="button"
+        class="shrink-0 rounded-xl bg-mpesa px-3 py-2 text-xs font-semibold text-white"
+        @click="onPrimary"
+      >
+        {{ canNativeInstall ? 'Install' : 'How' }}
+      </button>
+      <button
+        type="button"
+        aria-label="Dismiss"
+        class="shrink-0 rounded-lg p-1.5 text-lg leading-none text-ink/40"
+        @click="snooze"
+      >
+        ✕
+      </button>
+    </div>
+  </div>
+
+  <BaseDialog
+    :open="showGuide"
+    labelledby="install-guide-title"
+    focus="panel"
+    @close="showGuide = false"
+  >
+    <h2 id="install-guide-title" class="font-display text-lg font-semibold text-ink">
+      Add iPay Collect to your home screen
+    </h2>
+    <ol class="mt-4 space-y-3">
+      <li v-for="(step, i) in steps" :key="i" class="flex items-start gap-3 text-sm text-ink">
+        <span
+          class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-mpesa/10 text-xs font-semibold text-mpesa"
+          >{{ i + 1 }}</span
+        >
+        <span v-html="step" />
+      </li>
+    </ol>
+    <button
+      type="button"
+      class="mt-6 w-full rounded-xl bg-ink py-2.5 text-sm font-semibold text-white"
+      @click="showGuide = false"
+    >
+      Got it
+    </button>
+  </BaseDialog>
+</template>

--- a/frontend/src/composables/useInstallPrompt.js
+++ b/frontend/src/composables/useInstallPrompt.js
@@ -1,0 +1,72 @@
+import { onMounted, onUnmounted, ref } from 'vue'
+import { useSession } from '@/stores/session'
+import { getPlatform, isMobileOrTablet, isStandalone } from '@/utils/device'
+import { safeGet, safeSet } from '@/utils/storage'
+
+// Re-nudge at most this often: show it, and if it's ignored or dismissed don't show it
+// again for two weeks. Keyed per user so a shared device nudges each collector once.
+const SNOOZE_MS = 14 * 24 * 60 * 60 * 1000
+
+export function useInstallPrompt() {
+  const session = useSession()
+  const visible = ref(false)
+  const platform = ref(getPlatform())
+  const canNativeInstall = ref(false)
+  let deferredPrompt = null
+
+  const who = () => session.user || 'anon'
+  const snoozeKey = () => `ipay:install-nudge:snoozed-at:${who()}`
+  const installedKey = () => `ipay:install-nudge:installed:${who()}`
+
+  function shouldShow() {
+    if (!isMobileOrTablet()) return false // phones/tablets only, never a laptop
+    if (isStandalone()) return false // already running as an installed app
+    if (safeGet(installedKey())) return false // installed earlier this device/user
+    const snoozedAt = Number(safeGet(snoozeKey()) || 0)
+    return !snoozedAt || Date.now() - snoozedAt > SNOOZE_MS
+  }
+
+  // Chromium fires this when the app is installable; stash it so one tap can open the native
+  // install dialog. With the service worker currently self-destroying this may never fire —
+  // the banner then falls back to manual "how to install" instructions.
+  function onBeforeInstallPrompt(e) {
+    e.preventDefault()
+    deferredPrompt = e
+    canNativeInstall.value = true
+  }
+  function onAppInstalled() {
+    safeSet(installedKey(), '1')
+    visible.value = false
+  }
+
+  async function install() {
+    if (!deferredPrompt) return null
+    deferredPrompt.prompt()
+    const { outcome } = await deferredPrompt.userChoice
+    deferredPrompt = null
+    canNativeInstall.value = false
+    if (outcome === 'accepted') {
+      safeSet(installedKey(), '1')
+      visible.value = false
+    }
+    return outcome
+  }
+
+  // Dismiss ("✕") means "not now" — snooze for the window rather than hiding forever.
+  function snooze() {
+    safeSet(snoozeKey(), String(Date.now()))
+    visible.value = false
+  }
+
+  onMounted(() => {
+    window.addEventListener('beforeinstallprompt', onBeforeInstallPrompt)
+    window.addEventListener('appinstalled', onAppInstalled)
+    if (shouldShow()) visible.value = true
+  })
+  onUnmounted(() => {
+    window.removeEventListener('beforeinstallprompt', onBeforeInstallPrompt)
+    window.removeEventListener('appinstalled', onAppInstalled)
+  })
+
+  return { visible, platform, canNativeInstall, install, snooze }
+}

--- a/frontend/src/utils/device.js
+++ b/frontend/src/utils/device.js
@@ -1,0 +1,37 @@
+// Device/environment checks for the install nudge. Installing a PWA ("Add to Home Screen")
+// is a phone/tablet gesture, so the nudge must never appear on a laptop or desktop.
+
+// True only for a phone or tablet — not a laptop, even a touchscreen one.
+// A touchscreen laptop's PRIMARY pointer is its mouse/trackpad (pointer: fine), so the
+// coarse-pointer check excludes it; a phone or tablet's primary pointer is coarse.
+export function isMobileOrTablet() {
+  if (typeof window === 'undefined') return false
+  const nav = window.navigator
+  const ua = nav.userAgent || ''
+  // iPadOS 13+ masquerades as desktop Safari ("Macintosh"); a Mac reporting more than one
+  // touch point is really an iPad. A genuine Mac reports maxTouchPoints 0.
+  const isIPad = /Macintosh/.test(ua) && nav.maxTouchPoints > 1
+  if (isIPad) return true
+  const mobileUA = /Android|iPhone|iPod|Windows Phone|webOS|BlackBerry|Mobile/i.test(ua)
+  const coarsePointer = window.matchMedia?.('(pointer: coarse)')?.matches
+  const hasTouch = nav.maxTouchPoints > 0
+  return Boolean(mobileUA && hasTouch && coarsePointer)
+}
+
+// Already launched as an installed app (from the home screen) — no point nudging.
+export function isStandalone() {
+  if (typeof window === 'undefined') return false
+  return Boolean(
+    window.matchMedia?.('(display-mode: standalone)')?.matches ||
+      window.navigator.standalone === true, // iOS Safari's non-standard flag
+  )
+}
+
+// Which install instructions to show. iOS gives no install API, so it is always manual.
+export function getPlatform() {
+  const nav = window.navigator
+  const ua = nav.userAgent || ''
+  if (/iPhone|iPad|iPod/.test(ua) || (/Macintosh/.test(ua) && nav.maxTouchPoints > 1)) return 'ios'
+  if (/Android/.test(ua)) return 'android'
+  return 'other'
+}

--- a/frontend/src/utils/storage.js
+++ b/frontend/src/utils/storage.js
@@ -1,0 +1,18 @@
+// Wrappers around localStorage that never throw. Safari private mode and some in-app
+// webviews disable storage, and a one-off nudge is not worth crashing the app over — a
+// failed read/write just means the flag doesn't persist.
+export function safeGet(key) {
+  try {
+    return window.localStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+export function safeSet(key, value) {
+  try {
+    window.localStorage.setItem(key, value)
+  } catch {
+    // storage unavailable — nothing to do; the flag simply won't persist
+  }
+}


### PR DESCRIPTION
## What

Adds a first-run prompt on the `/collect` landing pages inviting **phone and tablet** users to install the app to their home screen. This is the first of two onboarding pieces — the guided tour follows in a separate PR.

## Behaviour

- **Mobile/tablet only.** Shown only when the primary pointer is coarse **and** the device is touch-capable, backed by a mobile UA check, with the iPadOS-reports-as-desktop case handled (`maxTouchPoints > 1` on "Macintosh" = iPad). A laptop — even a touchscreen one, even resized narrow — never sees it.
- **Not-already-installed only.** Suppressed when running in standalone/installed mode (`display-mode: standalone`, or iOS `navigator.standalone`), and after a successful install.
- **Landing pages only** (`Collect` / `Sales` / `Internal`), so a floating bar never sits over a customer's collect action.
- **Two-week snooze.** Dismissing (`✕`) snoozes for 14 days rather than hiding forever. State is per-user (keyed off the session `user_id`), so a shared device nudges each collector once.

## Install path

- **Android/Chromium:** captures `beforeinstallprompt` and fires the **native** install dialog on tap.
- **iOS Safari** (no install API) and **Android when the SW is unavailable:** opens a `BaseDialog` with platform-specific *Add to Home Screen* steps.
- ⚠️ The service worker is currently `selfDestroying: true`, so `beforeinstallprompt` may **not** fire on Android — the banner degrades gracefully to the manual instructions. Restoring Android's native one-tap install would mean re-enabling real SW precaching, which is deliberately out of scope here.

## Files

All net-new under `frontend/src/` (source of truth; `www/collect.html` + `public/frontend/` are gitignored build output, regenerated by `yarn build` on deploy):

- `utils/device.js` — mobile/tablet, standalone, and platform detection
- `utils/storage.js` — localStorage wrappers that never throw
- `composables/useInstallPrompt.js` — gating, snooze cadence, native-prompt capture
- `components/InstallPrompt.vue` — banner + instructions dialog (built on the existing `BaseDialog`)
- `App.vue` — mounts the prompt globally

## Notes

- Reuses the existing design tokens (`mpesa`, `ink`, `hairline`, `font-display`) and `BaseDialog` — no new UI primitives, no new runtime dependency.
- `utils/storage.js` will also serve the upcoming tour PR; whichever merges second, the small overlap gets deduped.

**Deploy:** run `yarn build` in `frontend/` (as usual) to regenerate the served SPA.