### PR TITLE
feat(ipay): first-run guided tour of the collect pages

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "serve": "vite preview"
   },
   "dependencies": {
+    "driver.js": "^1.8.0",
     "frappe-ui": "^0.1.171",
     "pinia": "^2.0.33",
     "vue": "^3.5.13",

--- a/frontend/src/components/CollectBar.vue
+++ b/frontend/src/components/CollectBar.vue
@@ -24,6 +24,7 @@ defineEmits(['collect', 'clear', 'cheque'])
   <div v-if="showBar" class="flex gap-2">
     <button
       type="button"
+      data-tour="collect-bar"
       class="h-14 flex-1 rounded-xl bg-mpesa text-lg font-semibold text-white transition active:scale-[.98] disabled:opacity-50"
       :disabled="creatingBundle || bundleBlocked"
       :aria-busy="creatingBundle"

--- a/frontend/src/components/CustomerListShell.vue
+++ b/frontend/src/components/CustomerListShell.vue
@@ -1,10 +1,9 @@
 <script setup>
-import { watch } from 'vue'
 import RoundHeader from '@/components/RoundHeader.vue'
 import CustomerCard from '@/components/CustomerCard.vue'
 import ChequeDueBanner from '@/components/ChequeDueBanner.vue'
 import ErrorRetry from '@/components/ErrorRetry.vue'
-import { useTour } from '@/composables/useTour'
+import { useFirstRunTour } from '@/composables/useTour'
 
 // The shared customer-list screen (field /collect and internal /collect/internal): title,
 // today's-round header, a filters row (slotted, since each mode's filters differ), and the
@@ -34,18 +33,8 @@ const props = defineProps({
 defineEmits(['retry'])
 
 // Kick the first-run tour once the list has loaded, so its anchors (stats, filters, a
-// customer card) are on the page. Fires only on the first load, not on every re-fetch.
-const { start } = useTour()
-let tourTried = false
-watch(
-  () => props.listLoading,
-  (loading) => {
-    if (loading || tourTried || !props.tourKey || !props.tourSteps.length) return
-    tourTried = true
-    start(props.tourKey, props.tourSteps)
-  },
-  { immediate: true },
-)
+// customer card) are on the page.
+useFirstRunTour(() => !props.listLoading, props.tourKey, props.tourSteps)
 </script>
 
 <template>

--- a/frontend/src/components/CustomerListShell.vue
+++ b/frontend/src/components/CustomerListShell.vue
@@ -1,14 +1,16 @@
 <script setup>
+import { watch } from 'vue'
 import RoundHeader from '@/components/RoundHeader.vue'
 import CustomerCard from '@/components/CustomerCard.vue'
 import ChequeDueBanner from '@/components/ChequeDueBanner.vue'
 import ErrorRetry from '@/components/ErrorRetry.vue'
+import { useTour } from '@/composables/useTour'
 
 // The shared customer-list screen (field /collect and internal /collect/internal): title,
 // today's-round header, a filters row (slotted, since each mode's filters differ), and the
 // loading / not-permitted / error / empty / grid states. Each page owns its data + filters
 // and passes the rest as props, so behaviour stays per-page.
-defineProps({
+const props = defineProps({
   containerClass: { type: String, default: '' }, // per-mode max width
   title: { type: String, default: 'Collect' },
   collectedToday: { type: Number, default: 0 },
@@ -26,8 +28,24 @@ defineProps({
   cardPaymentTerm: { type: String, default: '' },
   cardSalesPerson: { type: String, default: '' },
   chequeDues: { type: Array, default: () => [] }, // cheques accounts flagged to collect here
+  tourKey: { type: String, default: '' }, // first-run walkthrough id; empty = no tour
+  tourSteps: { type: Array, default: () => [] },
 })
 defineEmits(['retry'])
+
+// Kick the first-run tour once the list has loaded, so its anchors (stats, filters, a
+// customer card) are on the page. Fires only on the first load, not on every re-fetch.
+const { start } = useTour()
+let tourTried = false
+watch(
+  () => props.listLoading,
+  (loading) => {
+    if (loading || tourTried || !props.tourKey || !props.tourSteps.length) return
+    tourTried = true
+    start(props.tourKey, props.tourSteps)
+  },
+  { immediate: true },
+)
 </script>
 
 <template>
@@ -35,17 +53,19 @@ defineEmits(['retry'])
     <h1 class="pt-1 font-display text-2xl font-bold tracking-tight text-ink">{{ title }}</h1>
 
     <!-- Sales mode supplies its own header: "Today's round" is a driver framing. -->
-    <slot name="header">
-      <RoundHeader
-        :collected-today="collectedToday"
-        :outstanding-today="outstandingToday"
-        :remaining="remaining"
-        :count-label="countLabel"
-        :loading="statsLoading"
-      />
-    </slot>
+    <div data-tour="stats">
+      <slot name="header">
+        <RoundHeader
+          :collected-today="collectedToday"
+          :outstanding-today="outstandingToday"
+          :remaining="remaining"
+          :count-label="countLabel"
+          :loading="statsLoading"
+        />
+      </slot>
+    </div>
 
-    <div class="flex flex-col gap-2 sm:flex-row">
+    <div data-tour="filters" class="flex flex-col gap-2 sm:flex-row">
       <slot name="filters" />
     </div>
 
@@ -74,7 +94,7 @@ defineEmits(['retry'])
     <p v-else-if="!customers.length" class="py-16 text-center font-display text-ink/70">
       {{ emptyMessage }}
     </p>
-    <div v-else class="grid grid-cols-1 gap-3 md:grid-cols-2">
+    <div v-else data-tour="list" class="grid grid-cols-1 gap-3 md:grid-cols-2">
       <CustomerCard
         v-for="c in customers"
         :key="c.customer"

--- a/frontend/src/components/InvoiceCard.vue
+++ b/frontend/src/components/InvoiceCard.vue
@@ -146,6 +146,7 @@ async function payViaIpay() {
         <button
           v-if="!mpesaBlocked"
           type="button"
+          data-tour="prompt"
           class="h-12 flex-1 rounded-xl bg-mpesa font-semibold text-white transition active:scale-[.98] disabled:opacity-40"
           :disabled="actionsDisabled"
           @click="$emit('prompt')"

--- a/frontend/src/composables/useTour.js
+++ b/frontend/src/composables/useTour.js
@@ -1,0 +1,46 @@
+import { nextTick } from 'vue'
+import { driver } from 'driver.js'
+import 'driver.js/dist/driver.css'
+import { useSession } from '@/stores/session'
+import { safeGet, safeSet } from '@/utils/storage'
+
+// A first-run walkthrough of a page. It runs once per user, then never again (the "seen"
+// flag persists in localStorage), and can be closed at any step via the ✕ or the backdrop —
+// closing still counts as seen, so we don't nag on the next visit. Keyed per user so a
+// shared device walks each collector through once.
+const seenKey = (key, user) => `ipay:tour-seen:${key}:${user || 'anon'}`
+
+export function useTour() {
+  const session = useSession()
+
+  function hasSeen(key) {
+    return Boolean(safeGet(seenKey(key, session.user)))
+  }
+
+  // steps: [{ element?: string, title, description }]. An element-less step is a centred
+  // intro card; steps whose anchor isn't on the page (an empty list, a filter a role never
+  // sees) are dropped so the tour never points at nothing.
+  async function start(key, steps) {
+    if (hasSeen(key)) return
+    await nextTick() // let the page (and its list) finish rendering so anchors exist
+    const present = steps.filter((s) => !s.element || document.querySelector(s.element))
+    // If nothing anchored survives (e.g. the whole list is empty), don't spend the one run.
+    if (!present.some((s) => s.element)) return
+
+    const markSeen = () => safeSet(seenKey(key, session.user), '1')
+    driver({
+      showProgress: true,
+      popoverClass: 'ipay-tour',
+      nextBtnText: 'Next',
+      prevBtnText: 'Back',
+      doneBtnText: 'Done',
+      steps: present.map((s) => ({
+        element: s.element,
+        popover: { title: s.title, description: s.description },
+      })),
+      onDestroyed: markSeen, // fires on Done and on close/backdrop alike — persists either way
+    }).drive()
+  }
+
+  return { start, hasSeen }
+}

--- a/frontend/src/composables/useTour.js
+++ b/frontend/src/composables/useTour.js
@@ -1,4 +1,4 @@
-import { nextTick } from 'vue'
+import { nextTick, watch } from 'vue'
 import { driver } from 'driver.js'
 import 'driver.js/dist/driver.css'
 import { useSession } from '@/stores/session'
@@ -43,4 +43,21 @@ export function useTour() {
   }
 
   return { start, hasSeen }
+}
+
+// Run a page's first-run tour once its content is ready (e.g. the list finished loading), so
+// the anchors exist. Fires only on the first ready transition — not on later re-fetches (a
+// foreground resume, a filter change). `isReady` is a getter, e.g. () => !loading.value.
+export function useFirstRunTour(isReady, key, steps) {
+  const { start } = useTour()
+  let tried = false
+  watch(
+    isReady,
+    (ready) => {
+      if (!ready || tried || !key || !steps.length) return
+      tried = true
+      start(key, steps)
+    },
+    { immediate: true },
+  )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -19,3 +19,45 @@ body {
     transition-duration: 0.001ms !important;
   }
 }
+
+/* First-run tour (driver.js) — themed to the app palette. Scoped to .ipay-tour (set as the
+   popoverClass in useTour) so these win over driver.css without !important. */
+.driver-popover.ipay-tour {
+  background-color: #f2f5f1; /* paper */
+  color: #10241b; /* ink */
+  border-radius: 1rem;
+  max-width: 20rem;
+  font-family: 'Archivo', ui-sans-serif, sans-serif;
+}
+.driver-popover.ipay-tour .driver-popover-title {
+  font-weight: 700;
+  font-size: 1rem;
+}
+.driver-popover.ipay-tour .driver-popover-description {
+  color: rgba(16, 36, 27, 0.7);
+}
+.driver-popover.ipay-tour .driver-popover-progress-text {
+  color: rgba(16, 36, 27, 0.5);
+}
+.driver-popover.ipay-tour .driver-popover-arrow {
+  border-color: #f2f5f1; /* keep the arrow the same paper as the panel */
+}
+.driver-popover.ipay-tour .driver-popover-close-btn {
+  color: rgba(16, 36, 27, 0.5);
+}
+.driver-popover.ipay-tour .driver-popover-next-btn,
+.driver-popover.ipay-tour .driver-popover-prev-btn {
+  text-shadow: none;
+  border: none;
+  border-radius: 0.5rem;
+  font-weight: 600;
+  font-family: inherit;
+}
+.driver-popover.ipay-tour .driver-popover-next-btn {
+  background-color: #007a36; /* mpesa */
+  color: #fff;
+}
+.driver-popover.ipay-tour .driver-popover-prev-btn {
+  background-color: transparent;
+  color: rgba(16, 36, 27, 0.6);
+}

--- a/frontend/src/pages/Collect.vue
+++ b/frontend/src/pages/Collect.vue
@@ -70,6 +70,29 @@ function refreshAll() {
 
 useResumeRefresh(refreshAll) // re-pull when the PWA returns to the foreground
 onMounted(refreshAll)
+
+// First-run walkthrough (runs once, skippable). Anchors live in CustomerListShell.
+const TOUR_STEPS = [
+  {
+    title: 'Welcome to iPay Collect',
+    description: "A quick tour of your collection page — tap Next, or close it any time.",
+  },
+  {
+    element: '[data-tour="stats"]',
+    title: "Today's round",
+    description: "What you've collected today and what's still owed, at a glance.",
+  },
+  {
+    element: '[data-tour="filters"]',
+    title: 'Find a customer',
+    description: 'Search by customer, invoice or delivery note — or filter by driver.',
+  },
+  {
+    element: '[data-tour="list"] > :first-child',
+    title: 'Open a customer',
+    description: 'Tap a customer to see their invoices and prompt them to pay by M-Pesa.',
+  },
+]
 </script>
 
 <template>
@@ -86,6 +109,8 @@ onMounted(refreshAll)
     :cheque-dues="chequeDues"
     :empty-message="emptyMessage"
     :card-driver="driver"
+    tour-key="collect"
+    :tour-steps="TOUR_STEPS"
     @retry="loadCustomers"
   >
     <template #filters>

--- a/frontend/src/pages/CustomerDetail.vue
+++ b/frontend/src/pages/CustomerDetail.vue
@@ -5,6 +5,7 @@ import { createBundle, fetchCustomerCollection } from '@/data/collection'
 import { formatKES } from '@/utils/format'
 import { useResumeRefresh } from '@/composables/useResumeRefresh'
 import { useInvoiceSelection } from '@/composables/useInvoiceSelection'
+import { useFirstRunTour } from '@/composables/useTour'
 import InvoiceCard from '@/components/InvoiceCard.vue'
 import PromptDialog from '@/components/PromptDialog.vue'
 import NotesDialog from '@/components/NotesDialog.vue'
@@ -181,6 +182,24 @@ function onNoteSaved({ invoice, count, latest }) {
 
 useResumeRefresh(load) // re-pull when the PWA returns to the foreground
 onMounted(load)
+
+// First-run walkthrough of the customer page — where payment is actually prompted. Runs once
+// (shared key across every customer page), after invoices load so the anchors exist. Steps
+// whose anchor is absent (nothing collectable, no bundle bar) are dropped.
+const TOUR_STEPS = [
+  {
+    element: '[data-tour="prompt"]',
+    title: 'Prompt for payment',
+    description:
+      "Tap M-Pesa to send this invoice's request to the customer's phone — they approve it with their M-Pesa PIN.",
+  },
+  {
+    element: '[data-tour="collect-bar"]',
+    title: 'Collect several at once',
+    description: 'More than one invoice? Collect them together in a single request.',
+  },
+]
+useFirstRunTour(() => !loading.value, 'customer', TOUR_STEPS)
 </script>
 
 <template>

--- a/frontend/src/pages/InternalCollect.vue
+++ b/frontend/src/pages/InternalCollect.vue
@@ -76,6 +76,29 @@ function refreshAll() {
 
 useResumeRefresh(refreshAll) // re-pull when the PWA returns to the foreground
 onMounted(refreshAll)
+
+// First-run walkthrough (runs once, skippable). Anchors live in CustomerListShell.
+const TOUR_STEPS = [
+  {
+    title: 'Welcome to internal collections',
+    description: 'A quick tour of this page — tap Next, or close it any time.',
+  },
+  {
+    element: '[data-tour="stats"]',
+    title: 'Business at a glance',
+    description: "Collected today and what's still outstanding across every customer.",
+  },
+  {
+    element: '[data-tour="filters"]',
+    title: 'Search and filter',
+    description: 'Find a customer, or narrow the list by driver, payment term or sales person.',
+  },
+  {
+    element: '[data-tour="list"] > :first-child',
+    title: 'Open a customer',
+    description: 'Tap a customer to see their invoices and collect a payment.',
+  },
+]
 </script>
 
 <template>
@@ -97,6 +120,8 @@ onMounted(refreshAll)
     :card-driver="driver"
     :card-payment-term="paymentTerm"
     :card-sales-person="salesPerson"
+    tour-key="internal"
+    :tour-steps="TOUR_STEPS"
     @retry="loadCustomers"
   >
     <template #filters>

--- a/frontend/src/pages/PagedCustomerDetail.vue
+++ b/frontend/src/pages/PagedCustomerDetail.vue
@@ -9,6 +9,7 @@ import {
 import { formatKES } from '@/utils/format'
 import { useResumeRefresh } from '@/composables/useResumeRefresh'
 import { useInvoiceSelection } from '@/composables/useInvoiceSelection'
+import { useFirstRunTour } from '@/composables/useTour'
 import InvoiceCard from '@/components/InvoiceCard.vue'
 import PromptDialog from '@/components/PromptDialog.vue'
 import NotesDialog from '@/components/NotesDialog.vue'
@@ -241,6 +242,24 @@ function onNoteSaved({ invoice, count, latest }) {
 
 useResumeRefresh(() => load(true)) // re-pull when the PWA returns to the foreground
 onMounted(() => load(true))
+
+// First-run walkthrough of the customer page — where payment is actually prompted. Runs once
+// (shared key across every customer page), after invoices load so the anchors exist. Steps
+// whose anchor is absent (nothing collectable, no bundle bar) are dropped.
+const TOUR_STEPS = [
+  {
+    element: '[data-tour="prompt"]',
+    title: 'Prompt for payment',
+    description:
+      "Tap M-Pesa to send this invoice's request to the customer's phone — they approve it with their M-Pesa PIN.",
+  },
+  {
+    element: '[data-tour="collect-bar"]',
+    title: 'Collect several at once',
+    description: 'More than one invoice? Collect them together in a single request.',
+  },
+]
+useFirstRunTour(() => !loading.value, 'customer', TOUR_STEPS)
 </script>
 
 <template>

--- a/frontend/src/pages/SalesCollect.vue
+++ b/frontend/src/pages/SalesCollect.vue
@@ -66,6 +66,30 @@ async function loadCustomers() {
 
 useResumeRefresh(loadCustomers) // re-pull when the PWA returns to the foreground
 onMounted(loadCustomers)
+
+// First-run walkthrough (runs once, skippable). Anchors live in CustomerListShell.
+const TOUR_STEPS = [
+  {
+    title: 'Welcome to iPay Collect',
+    description: 'A quick tour of your collections book — tap Next, or close it any time.',
+  },
+  {
+    element: '[data-tour="stats"]',
+    title: 'Your book',
+    description: 'The total outstanding across the customers you look after.',
+  },
+  {
+    element: '[data-tour="filters"]',
+    title: 'Find a customer',
+    description:
+      'Search your customers, or filter by payment term. Managers can also pick a team member.',
+  },
+  {
+    element: '[data-tour="list"] > :first-child',
+    title: 'Open a customer',
+    description: 'Tap a customer to see their invoices and record a payment.',
+  },
+]
 </script>
 
 <template>
@@ -80,6 +104,8 @@ onMounted(loadCustomers)
     card-route-name="SalesCustomer"
     :card-payment-term="paymentTerm"
     :card-sales-person="salesPerson"
+    tour-key="sales"
+    :tour-steps="TOUR_STEPS"
     @retry="loadCustomers"
   >
     <template #header>

--- a/frontend/src/utils/storage.js
+++ b/frontend/src/utils/storage.js
@@ -1,0 +1,18 @@
+// Wrappers around localStorage that never throw. Safari private mode and some in-app
+// webviews disable storage, and a one-off tour is not worth crashing the app over — a
+// failed read/write just means the flag doesn't persist.
+export function safeGet(key) {
+  try {
+    return window.localStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+export function safeSet(key, value) {
+  try {
+    window.localStorage.setItem(key, value)
+  } catch {
+    // storage unavailable — nothing to do; the flag simply won't persist
+  }
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2081,6 +2081,11 @@ dompurify@^3.2.6:
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 
+driver.js@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/driver.js/-/driver.js-1.8.0.tgz#928c5bdee5f6dd5cb23e45906d22281835679c89"
+  integrity sha512-+8/IO7h1v14IzWh2GP60N7T3PFZweXwdn5e5POuxRSBoCYUojsBxzqawPeXh3YZIibRy7EehYNEyxe7slwwtdg==
+
 dunder-proto@^1.0.0, dunder-proto@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"


### PR DESCRIPTION
## What

A one-time guided walkthrough that runs on a user's **first visit** to each collect landing page — pointing out the day's totals, the search/filters, and how to open a customer to collect. This is the second onboarding piece (the mobile install nudge is #96).

Built on **driver.js** (MIT, ~5kb) — highlighting, tooltip positioning, scroll-into-view and resize handling for free; no hand-rolled overlay math.

## Behaviour

- **Runs once per user, per page.** A `seen` flag in `localStorage`, keyed off the session `user_id`, so a shared device walks each collector through once.
- **Always skippable.** Close at any step via the `✕` or the backdrop — closing still marks it seen, so it never nags on the next visit.
- **Never points at nothing.** Steps whose anchor isn't on the page (an empty list, a filter a role doesn't have) are dropped before the tour starts; if nothing anchored survives, the one-time run isn't spent.
- **Fires after the list loads** (not on every foreground re-fetch), so the customer-card anchor exists.

## Coverage — all three landings, role-appropriate copy

| Page | Tour key | Framing |
|------|----------|---------|
| `Collect.vue` (field collector) | `collect` | "Today's round" |
| `SalesCollect.vue` (sales) | `sales` | "Your book" |
| `InternalCollect.vue` (operators) | `internal` | "Business at a glance" |

Each walks through: **stats → search/filters → open a customer**, plus a short welcome card.

## How it's wired

- Anchors (`data-tour="stats|filters|list"`) live once in the shared `CustomerListShell`, which all three pages already use; each page passes `tour-key` + its own `tour-steps` copy.
- `composables/useTour.js` — gating, anchor filtering, driver.js setup, persistence.
- Popover themed to the app palette (`mpesa`/`ink`/`paper`) via a scoped `.ipay-tour` class in `index.css`.

## Notes

- `utils/storage.js` is shared with the install-nudge PR (#96) — identical file. Whichever merges second, dedupe the trivial overlap (or just accept the identical add).
- New runtime dependency: `driver.js@1.8.0` (bundled into the `CustomerListShell` chunk).

**Deploy:** run `yarn build` in `frontend/` (as usual) to regenerate the served SPA.