### PR TITLE
feat(ipay): persistent, push-capable service worker (push groundwork)

### DIFF
--- a/frontend/src/sw.js
+++ b/frontend/src/sw.js
@@ -1,60 +1,41 @@
-/* Service worker for iPay Collect.
- *
- * Built via vite-plugin-pwa's injectManifest strategy. Its only job today is Web Push —
- * receiving push messages and turning them into notifications — so it does not precache the
- * app shell (see vite.config.js: globPatterns is empty). Offline caching can be added later
- * by consuming the precache manifest below with workbox-precaching.
- */
-
-// injectManifest replaces self.__WB_MANIFEST with the precache list (empty for now). It's
-// assigned to a global rather than a local so bundler dead-code elimination can't drop the
-// reference before workbox performs the injection; it's consumed for real once offline
-// precaching is enabled.
+// injectManifest requires this token even though precaching is off (empty globPatterns).
 self.__ipayPrecache = self.__WB_MANIFEST
-
-// Activate a new SW immediately and take control, so a deploy's push handler is live without
-// waiting for every tab to close.
-self.addEventListener('install', () => self.skipWaiting())
-self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()))
-
-// A registered fetch handler is part of what makes the app installable across browsers (and
-// helps Android's install prompt fire). It intentionally does nothing — no respondWith means
-// every request falls through to the network unchanged, so nothing is cached or intercepted.
-self.addEventListener('fetch', () => {})
 
 const ICON = '/assets/ipay/manifest/manifest-icon-192.maskable.png'
 const BADGE = '/assets/ipay/manifest/favicon-196.png'
 
-// A push arrives as JSON: { title, body, tag?, url? }. Fall back gracefully if the payload is
-// missing or not JSON, so a malformed message still surfaces something rather than nothing.
-self.addEventListener('push', (event) => {
-  let payload = {}
-  try {
-    payload = event.data ? event.data.json() : {}
-  } catch {
-    payload = { body: event.data ? event.data.text() : '' }
-  }
-  const title = payload.title || 'iPay Collect'
-  const options = {
-    body: payload.body || '',
-    icon: ICON,
-    badge: BADGE,
-    tag: payload.tag, // same tag collapses duplicates rather than stacking
-    data: { url: payload.url || '/collect' },
-  }
-  event.waitUntil(self.registration.showNotification(title, options))
-})
+self.addEventListener('install', () => self.skipWaiting())
+self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()))
+self.addEventListener('fetch', () => {})
 
-// Tapping a notification focuses an existing collect tab if one is open, otherwise opens it.
-self.addEventListener('notificationclick', (event) => {
-  event.notification.close()
-  const target = (event.notification.data && event.notification.data.url) || '/collect'
+self.addEventListener('push', (event) => {
+  const { title, body, tag, url } = readPush(event)
   event.waitUntil(
-    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clients) => {
-      for (const client of clients) {
-        if (client.url.includes('/collect') && 'focus' in client) return client.focus()
-      }
-      return self.clients.openWindow(target)
+    self.registration.showNotification(title || 'iPay Collect', {
+      body: body || '',
+      icon: ICON,
+      badge: BADGE,
+      tag,
+      data: { url: url || '/collect' },
     }),
   )
 })
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close()
+  event.waitUntil(focusOrOpenCollect(event.notification.data?.url || '/collect'))
+})
+
+function readPush(event) {
+  try {
+    return event.data ? event.data.json() : {}
+  } catch {
+    return { body: event.data ? event.data.text() : '' }
+  }
+}
+
+async function focusOrOpenCollect(url) {
+  const windows = await self.clients.matchAll({ type: 'window', includeUncontrolled: true })
+  const open = windows.find((client) => client.url.includes('/collect') && 'focus' in client)
+  return open ? open.focus() : self.clients.openWindow(url)
+}

--- a/frontend/src/sw.js
+++ b/frontend/src/sw.js
@@ -1,0 +1,60 @@
+/* Service worker for iPay Collect.
+ *
+ * Built via vite-plugin-pwa's injectManifest strategy. Its only job today is Web Push —
+ * receiving push messages and turning them into notifications — so it does not precache the
+ * app shell (see vite.config.js: globPatterns is empty). Offline caching can be added later
+ * by consuming the precache manifest below with workbox-precaching.
+ */
+
+// injectManifest replaces self.__WB_MANIFEST with the precache list (empty for now). It's
+// assigned to a global rather than a local so bundler dead-code elimination can't drop the
+// reference before workbox performs the injection; it's consumed for real once offline
+// precaching is enabled.
+self.__ipayPrecache = self.__WB_MANIFEST
+
+// Activate a new SW immediately and take control, so a deploy's push handler is live without
+// waiting for every tab to close.
+self.addEventListener('install', () => self.skipWaiting())
+self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()))
+
+// A registered fetch handler is part of what makes the app installable across browsers (and
+// helps Android's install prompt fire). It intentionally does nothing — no respondWith means
+// every request falls through to the network unchanged, so nothing is cached or intercepted.
+self.addEventListener('fetch', () => {})
+
+const ICON = '/assets/ipay/manifest/manifest-icon-192.maskable.png'
+const BADGE = '/assets/ipay/manifest/favicon-196.png'
+
+// A push arrives as JSON: { title, body, tag?, url? }. Fall back gracefully if the payload is
+// missing or not JSON, so a malformed message still surfaces something rather than nothing.
+self.addEventListener('push', (event) => {
+  let payload = {}
+  try {
+    payload = event.data ? event.data.json() : {}
+  } catch {
+    payload = { body: event.data ? event.data.text() : '' }
+  }
+  const title = payload.title || 'iPay Collect'
+  const options = {
+    body: payload.body || '',
+    icon: ICON,
+    badge: BADGE,
+    tag: payload.tag, // same tag collapses duplicates rather than stacking
+    data: { url: payload.url || '/collect' },
+  }
+  event.waitUntil(self.registration.showNotification(title, options))
+})
+
+// Tapping a notification focuses an existing collect tab if one is open, otherwise opens it.
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close()
+  const target = (event.notification.data && event.notification.data.url) || '/collect'
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clients) => {
+      for (const client of clients) {
+        if (client.url.includes('/collect') && 'focus' in client) return client.focus()
+      }
+      return self.clients.openWindow(target)
+    }),
+  )
+})

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -22,13 +22,8 @@ export default defineConfig({
     vue(),
     VitePWA({
       registerType: 'autoUpdate',
-      // Custom service worker (src/sw.js), so it can carry a Web Push `push` /
-      // `notificationclick` handler — a generated SW can't. It was previously
-      // self-destroying (no push listener, unregisters itself), which made push
-      // impossible; that is now off. The SW deliberately does NOT precache the
-      // app shell yet (globPatterns empty) — its only job for now is Web Push, so
-      // there is no stale-asset risk to manage. Offline precaching can be layered
-      // on later by giving the injected manifest real glob patterns.
+      // Custom service worker (src/sw.js) so it can carry a Web Push handler; a generated one
+      // can't. No precaching yet (empty globPatterns) — its only job for now is push.
       strategies: 'injectManifest',
       srcDir: 'src',
       filename: 'sw.js',

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -22,11 +22,19 @@ export default defineConfig({
     vue(),
     VitePWA({
       registerType: 'autoUpdate',
-      // During active development the service worker is self-destroying: it
-      // unregisters and clears caches on devices that already installed it, so
-      // every deploy is fetched fresh (no stale app shell). Re-enable full
-      // precaching/offline once the app stabilises.
-      selfDestroying: true,
+      // Custom service worker (src/sw.js), so it can carry a Web Push `push` /
+      // `notificationclick` handler — a generated SW can't. It was previously
+      // self-destroying (no push listener, unregisters itself), which made push
+      // impossible; that is now off. The SW deliberately does NOT precache the
+      // app shell yet (globPatterns empty) — its only job for now is Web Push, so
+      // there is no stale-asset risk to manage. Offline precaching can be layered
+      // on later by giving the injected manifest real glob patterns.
+      strategies: 'injectManifest',
+      srcDir: 'src',
+      filename: 'sw.js',
+      injectManifest: {
+        globPatterns: [],
+      },
       manifest: {
         name: 'iPay Collect',
         short_name: 'iPay Collect',


### PR DESCRIPTION
## What

**Phase 0 of Web Push notifications** — the service-worker groundwork, on its own so the caching-behaviour change is isolated and easy to reason about. No user-facing change yet.

Swaps the PWA's **self-destroying** service worker for a **persistent, custom** one (`frontend/src/sw.js`, built via vite-plugin-pwa's `injectManifest` strategy) that can receive Web Push.

## Why this first

Web Push **requires** a persistent service worker with a `push` listener. The old SW deliberately unregistered itself on every deploy (to avoid stale caches while the app changed fast), which makes push impossible. This turns that off and replaces it — but keeps the "no stale caches" property by **not precaching anything** (empty `globPatterns`). The SW has **no fetch interception**, so app content still comes straight from the network exactly as before.

## What the SW does

- `push` → renders the notification (`{title, body, tag?, url?}` payload, with graceful fallback).
- `notificationclick` → focuses an open `/collect` tab, or opens one.
- `install`/`activate` → `skipWaiting` + `clients.claim` so a new deploy's handler is live promptly.
- a **no-op `fetch`** handler — only to keep the app reliably installable (also helps Android's `beforeinstallprompt` fire, which was the caveat in #96).

## Scope / what's NOT here

- No VAPID keys, no subscriptions, no permission UI, no notification triggers — those are **Phase 1** (subscriptions + opt-in UI + preferences) and **Phase 2** (the cheque-assigned / success / failure triggers).

## How to verify

1. Deploy (`yarn build` in `frontend/`) and open `/collect` on desktop Chrome.
2. DevTools → **Application → Service Workers**: confirm `sw.js` is **activated and running**.
3. Click the **Push** button there (it sends a test payload) → a notification should appear. Optionally paste `{"title":"Test","body":"hello"}` as the payload.

## Notes / known follow-ups

- The SW registers at scope `/assets/ipay/frontend/` (where the plugin emits it). That's fine for push on Chrome/Android/desktop — a push subscription is per-registration, and delivery doesn't require the SW to control the page. **iOS** web push (installed PWA only, 16.4+) with a SW scoped outside `/collect` is the one thing to validate on a real iPhone in Phase 1, when a real subscription exists; if iOS is unhappy we'll widen the SW scope (serve it so it covers `/collect`).
- **Deploy:** `yarn build` in `frontend/` regenerates the SW + served SPA as usual.