### PR TITLE
feat(ipay): push subscriptions + opt-in permission UI + preferences

### DIFF
--- a/frontend/src/components/BaseDialog.vue
+++ b/frontend/src/components/BaseDialog.vue
@@ -59,7 +59,7 @@ defineExpose({ panel })
 <template>
   <div
     v-if="open"
-    class="fixed inset-0 z-50 flex items-end justify-center bg-ink/50 p-4 sm:items-center"
+    class="fixed inset-0 z-50 flex items-end justify-center bg-ink/50 p-4 pb-[max(1rem,env(safe-area-inset-bottom))] sm:items-center"
     @click.self="$emit('close')"
   >
     <div
@@ -68,7 +68,7 @@ defineExpose({ panel })
       aria-modal="true"
       :aria-labelledby="labelledby"
       tabindex="-1"
-      class="w-full max-w-md rounded-3xl bg-paper p-6 focus:outline-none"
+      class="max-h-[85dvh] w-full max-w-md overflow-y-auto rounded-3xl bg-paper p-6 focus:outline-none"
     >
       <slot />
     </div>

--- a/frontend/src/components/CustomerListShell.vue
+++ b/frontend/src/components/CustomerListShell.vue
@@ -3,6 +3,7 @@ import RoundHeader from '@/components/RoundHeader.vue'
 import CustomerCard from '@/components/CustomerCard.vue'
 import ChequeDueBanner from '@/components/ChequeDueBanner.vue'
 import ErrorRetry from '@/components/ErrorRetry.vue'
+import NotificationSettings from '@/components/NotificationSettings.vue'
 
 // The shared customer-list screen (field /collect and internal /collect/internal): title,
 // today's-round header, a filters row (slotted, since each mode's filters differ), and the
@@ -32,7 +33,10 @@ defineEmits(['retry'])
 
 <template>
   <main class="mx-auto flex min-h-full w-full flex-col gap-4 p-4 pb-10" :class="containerClass">
-    <h1 class="pt-1 font-display text-2xl font-bold tracking-tight text-ink">{{ title }}</h1>
+    <div class="flex items-center justify-between gap-3 pt-1">
+      <h1 class="font-display text-2xl font-bold tracking-tight text-ink">{{ title }}</h1>
+      <NotificationSettings />
+    </div>
 
     <!-- Sales mode supplies its own header: "Today's round" is a driver framing. -->
     <slot name="header">

--- a/frontend/src/components/NotificationSettings.vue
+++ b/frontend/src/components/NotificationSettings.vue
@@ -12,6 +12,7 @@ const {
   busy,
   error,
   prefs,
+  testStatus,
   refresh,
   enable,
   disable,
@@ -24,6 +25,13 @@ const OPTIONS = [
   { key: 'notify_collection_success', label: 'Successful collection' },
   { key: 'notify_collection_error', label: 'Collection error' },
 ]
+
+const TEST_MESSAGE = {
+  sending: 'Sending…',
+  sent: 'Test sent — check your notifications (or Notification Center).',
+  none: 'No active device found for this login.',
+  error: "Couldn't send the test — please try again.",
+}
 
 async function show() {
   open.value = true
@@ -111,6 +119,9 @@ async function show() {
           Turn off
         </button>
       </div>
+      <p v-if="testStatus" class="mt-2 text-center text-[13px] text-ink/70">
+        {{ TEST_MESSAGE[testStatus] }}
+      </p>
     </template>
   </BaseDialog>
 </template>

--- a/frontend/src/components/NotificationSettings.vue
+++ b/frontend/src/components/NotificationSettings.vue
@@ -1,0 +1,116 @@
+<script setup>
+import { ref } from 'vue'
+import BaseDialog from './BaseDialog.vue'
+import { usePushNotifications } from '@/composables/usePushNotifications'
+
+const open = ref(false)
+const {
+  supported,
+  configured,
+  blocked,
+  subscribed,
+  busy,
+  error,
+  prefs,
+  refresh,
+  enable,
+  disable,
+  updatePref,
+  test,
+} = usePushNotifications()
+
+const OPTIONS = [
+  { key: 'notify_cheque_assigned', label: 'Cheque collection assigned to me' },
+  { key: 'notify_collection_success', label: 'Successful collection' },
+  { key: 'notify_collection_error', label: 'Collection error' },
+]
+
+async function show() {
+  open.value = true
+  await refresh()
+}
+</script>
+
+<template>
+  <button
+    type="button"
+    aria-label="Notification settings"
+    class="grid h-10 w-10 shrink-0 place-items-center rounded-xl border border-hairline bg-white text-ink/70 transition active:bg-paper"
+    @click="show"
+  >
+    <svg viewBox="0 0 20 20" class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="1.6">
+      <path d="M10 3a4 4 0 0 0-4 4c0 4-1.5 5-1.5 5h11S14 11 14 7a4 4 0 0 0-4-4Z" stroke-linejoin="round" />
+      <path d="M8.5 15a1.5 1.5 0 0 0 3 0" stroke-linecap="round" />
+    </svg>
+  </button>
+
+  <BaseDialog :open="open" labelledby="notif-title" focus="panel" @close="open = false">
+    <h2 id="notif-title" class="font-display text-lg font-semibold text-ink">Notifications</h2>
+
+    <p v-if="!supported" class="mt-3 text-sm text-ink/70">
+      This browser doesn't support notifications. On an iPhone, add iPay Collect to your home
+      screen first, then open it from there.
+    </p>
+
+    <p v-else-if="blocked" class="mt-3 text-sm text-ink/70">
+      Notifications are blocked for this site. Turn them back on in your browser's site settings,
+      then reopen this panel.
+    </p>
+
+    <template v-else-if="!subscribed">
+      <p class="mt-3 text-sm text-ink/70">
+        Get alerted when a cheque collection is assigned to you, and when a collection succeeds or
+        fails. You choose what to receive, and can turn it off any time.
+      </p>
+      <p v-if="!configured" class="mt-3 rounded-xl bg-owed/10 px-3 py-2.5 text-[13px] font-medium text-owed">
+        Notifications aren't set up on the server yet — ask an administrator to configure them.
+      </p>
+      <button
+        type="button"
+        class="mt-5 h-12 w-full rounded-xl bg-mpesa font-semibold text-white transition active:scale-[.98] disabled:opacity-50"
+        :disabled="busy || !configured"
+        @click="enable"
+      >
+        {{ busy ? 'Turning on…' : 'Turn on notifications' }}
+      </button>
+      <p v-if="error" class="mt-2 text-sm text-danger">{{ error }}</p>
+    </template>
+
+    <template v-else>
+      <p class="mt-3 text-sm text-ink/70">Choose what you'd like to be notified about.</p>
+      <div class="mt-4 flex flex-col gap-1">
+        <label
+          v-for="opt in OPTIONS"
+          :key="opt.key"
+          class="flex cursor-pointer items-center justify-between gap-3 rounded-xl px-1 py-2.5"
+        >
+          <span class="text-sm text-ink">{{ opt.label }}</span>
+          <input
+            type="checkbox"
+            class="h-5 w-5 accent-mpesa"
+            :checked="Boolean(prefs[opt.key])"
+            @change="updatePref(opt.key, $event.target.checked)"
+          />
+        </label>
+      </div>
+
+      <div class="mt-5 flex gap-2">
+        <button
+          type="button"
+          class="h-11 flex-1 rounded-xl border border-hairline font-medium text-ink/80 transition active:bg-paper"
+          @click="test"
+        >
+          Send a test
+        </button>
+        <button
+          type="button"
+          class="h-11 flex-1 rounded-xl border border-hairline font-medium text-danger transition active:bg-paper disabled:opacity-50"
+          :disabled="busy"
+          @click="disable"
+        >
+          Turn off
+        </button>
+      </div>
+    </template>
+  </BaseDialog>
+</template>

--- a/frontend/src/composables/usePushNotifications.js
+++ b/frontend/src/composables/usePushNotifications.js
@@ -7,8 +7,8 @@ import {
   unsubscribePush,
 } from '@/data/push'
 
-const SW_URL = '/assets/ipay/frontend/sw.js'
-const SW_SCOPE = '/assets/ipay/frontend/'
+const SW_URL = '/api/method/ipay.ipay.main.utils.push.collect_worker'
+const SW_SCOPE = '/collect'
 
 const DEFAULT_PREFS = {
   notify_cheque_assigned: 1,
@@ -22,8 +22,6 @@ function vapidKey(base64) {
   return Uint8Array.from(raw, (char) => char.charCodeAt(0))
 }
 
-// The SW is scoped to /assets, so it never controls /collect and serviceWorker.ready would
-// hang here; take the registration straight from register().
 async function swRegistration() {
   const reg = await navigator.serviceWorker.register(SW_URL, { scope: SW_SCOPE })
   if (reg.active) return reg

--- a/frontend/src/composables/usePushNotifications.js
+++ b/frontend/src/composables/usePushNotifications.js
@@ -7,9 +7,6 @@ import {
   unsubscribePush,
 } from '@/data/push'
 
-// The service worker is registered at its own asset scope (see PR: SW foundation), which does
-// NOT control /collect — so navigator.serviceWorker.ready (which waits for the SW controlling
-// THIS page) never resolves here. We fetch the registration directly instead.
 const SW_URL = '/assets/ipay/frontend/sw.js'
 const SW_SCOPE = '/assets/ipay/frontend/'
 
@@ -19,14 +16,23 @@ const DEFAULT_PREFS = {
   notify_collection_error: 1,
 }
 
-// VAPID public key (base64url) → the Uint8Array the Push API wants as applicationServerKey.
-function urlBase64ToUint8Array(base64String) {
-  const padding = '='.repeat((4 - (base64String.length % 4)) % 4)
-  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/')
-  const raw = atob(base64)
-  const out = new Uint8Array(raw.length)
-  for (let i = 0; i < raw.length; i += 1) out[i] = raw.charCodeAt(i)
-  return out
+function vapidKey(base64) {
+  const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4)
+  const raw = atob(padded.replace(/-/g, '+').replace(/_/g, '/'))
+  return Uint8Array.from(raw, (char) => char.charCodeAt(0))
+}
+
+// The SW is scoped to /assets, so it never controls /collect and serviceWorker.ready would
+// hang here; take the registration straight from register().
+async function swRegistration() {
+  const reg = await navigator.serviceWorker.register(SW_URL, { scope: SW_SCOPE })
+  if (reg.active) return reg
+  await new Promise((resolve) => {
+    const worker = reg.installing || reg.waiting
+    if (!worker) return resolve()
+    worker.addEventListener('statechange', () => worker.state === 'activated' && resolve())
+  })
+  return reg
 }
 
 export function usePushNotifications() {
@@ -43,36 +49,20 @@ export function usePushNotifications() {
   const prefs = ref({ ...DEFAULT_PREFS })
   let endpoint = ''
 
-  // Server-side keys present? Without them the browser can't subscribe.
   const configured = computed(() => Boolean(window.vapid_public_key))
-  // Permission actively denied — the user must re-enable in browser settings; we can't reprompt.
   const blocked = computed(() => permission.value === 'denied')
 
-  async function registration() {
-    const reg = await navigator.serviceWorker.register(SW_URL, { scope: SW_SCOPE })
-    if (reg.active) return reg
-    // First install — wait for it to activate before subscribing.
-    await new Promise((resolve) => {
-      const sw = reg.installing || reg.waiting
-      if (!sw) return resolve()
-      sw.addEventListener('statechange', () => sw.state === 'activated' && resolve())
-    })
-    return reg
-  }
-
-  // Read current state so the panel opens showing the truth (subscribed? which prefs?).
   async function refresh() {
     if (!supported.value) return
     try {
-      const reg = await registration()
-      const sub = await reg.pushManager.getSubscription()
+      const sub = await (await swRegistration()).pushManager.getSubscription()
       subscribed.value = Boolean(sub)
       if (sub) {
         endpoint = sub.endpoint
         prefs.value = (await getPushPrefs(endpoint).catch(() => null)) || { ...DEFAULT_PREFS }
       }
     } catch {
-      // Non-fatal — the panel just falls back to the enable button.
+      error.value = ''
     }
   }
 
@@ -87,14 +77,14 @@ export function usePushNotifications() {
     try {
       permission.value = await Notification.requestPermission()
       if (permission.value !== 'granted') return
-      const reg = await registration()
-      const sub = await reg.pushManager.subscribe({
+      const sub = await (await swRegistration()).pushManager.subscribe({
         userVisibleOnly: true,
-        applicationServerKey: urlBase64ToUint8Array(window.vapid_public_key),
+        applicationServerKey: vapidKey(window.vapid_public_key),
       })
       endpoint = sub.endpoint
-      const res = await subscribePush(sub.toJSON(), navigator.userAgent)
-      prefs.value = res?.prefs || { ...DEFAULT_PREFS }
+      prefs.value = (await subscribePush(sub.toJSON(), navigator.userAgent))?.prefs || {
+        ...DEFAULT_PREFS,
+      }
       subscribed.value = true
     } catch {
       error.value = 'Could not turn on notifications — please try again.'
@@ -106,8 +96,7 @@ export function usePushNotifications() {
   async function disable() {
     busy.value = true
     try {
-      const reg = await registration()
-      const sub = await reg.pushManager.getSubscription()
+      const sub = await (await swRegistration()).pushManager.getSubscription()
       if (sub) {
         await unsubscribePush(sub.endpoint).catch(() => {})
         await sub.unsubscribe()
@@ -124,9 +113,7 @@ export function usePushNotifications() {
     if (endpoint) await setPushPrefs(endpoint, prefs.value).catch(() => {})
   }
 
-  async function test() {
-    await sendTestPush().catch(() => {})
-  }
+  const test = () => sendTestPush().catch(() => {})
 
   return {
     supported,

--- a/frontend/src/composables/usePushNotifications.js
+++ b/frontend/src/composables/usePushNotifications.js
@@ -1,0 +1,146 @@
+import { computed, ref } from 'vue'
+import {
+  getPushPrefs,
+  sendTestPush,
+  setPushPrefs,
+  subscribePush,
+  unsubscribePush,
+} from '@/data/push'
+
+// The service worker is registered at its own asset scope (see PR: SW foundation), which does
+// NOT control /collect — so navigator.serviceWorker.ready (which waits for the SW controlling
+// THIS page) never resolves here. We fetch the registration directly instead.
+const SW_URL = '/assets/ipay/frontend/sw.js'
+const SW_SCOPE = '/assets/ipay/frontend/'
+
+const DEFAULT_PREFS = {
+  notify_cheque_assigned: 1,
+  notify_collection_success: 1,
+  notify_collection_error: 1,
+}
+
+// VAPID public key (base64url) → the Uint8Array the Push API wants as applicationServerKey.
+function urlBase64ToUint8Array(base64String) {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4)
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/')
+  const raw = atob(base64)
+  const out = new Uint8Array(raw.length)
+  for (let i = 0; i < raw.length; i += 1) out[i] = raw.charCodeAt(i)
+  return out
+}
+
+export function usePushNotifications() {
+  const supported = ref(
+    typeof window !== 'undefined' &&
+      'serviceWorker' in navigator &&
+      'PushManager' in window &&
+      'Notification' in window,
+  )
+  const permission = ref(supported.value ? Notification.permission : 'unsupported')
+  const subscribed = ref(false)
+  const busy = ref(false)
+  const error = ref('')
+  const prefs = ref({ ...DEFAULT_PREFS })
+  let endpoint = ''
+
+  // Server-side keys present? Without them the browser can't subscribe.
+  const configured = computed(() => Boolean(window.vapid_public_key))
+  // Permission actively denied — the user must re-enable in browser settings; we can't reprompt.
+  const blocked = computed(() => permission.value === 'denied')
+
+  async function registration() {
+    const reg = await navigator.serviceWorker.register(SW_URL, { scope: SW_SCOPE })
+    if (reg.active) return reg
+    // First install — wait for it to activate before subscribing.
+    await new Promise((resolve) => {
+      const sw = reg.installing || reg.waiting
+      if (!sw) return resolve()
+      sw.addEventListener('statechange', () => sw.state === 'activated' && resolve())
+    })
+    return reg
+  }
+
+  // Read current state so the panel opens showing the truth (subscribed? which prefs?).
+  async function refresh() {
+    if (!supported.value) return
+    try {
+      const reg = await registration()
+      const sub = await reg.pushManager.getSubscription()
+      subscribed.value = Boolean(sub)
+      if (sub) {
+        endpoint = sub.endpoint
+        prefs.value = (await getPushPrefs(endpoint).catch(() => null)) || { ...DEFAULT_PREFS }
+      }
+    } catch {
+      // Non-fatal — the panel just falls back to the enable button.
+    }
+  }
+
+  async function enable() {
+    error.value = ''
+    if (!supported.value) return
+    if (!configured.value) {
+      error.value = 'Notifications are not set up on the server yet.'
+      return
+    }
+    busy.value = true
+    try {
+      permission.value = await Notification.requestPermission()
+      if (permission.value !== 'granted') return
+      const reg = await registration()
+      const sub = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(window.vapid_public_key),
+      })
+      endpoint = sub.endpoint
+      const res = await subscribePush(sub.toJSON(), navigator.userAgent)
+      prefs.value = res?.prefs || { ...DEFAULT_PREFS }
+      subscribed.value = true
+    } catch {
+      error.value = 'Could not turn on notifications — please try again.'
+    } finally {
+      busy.value = false
+    }
+  }
+
+  async function disable() {
+    busy.value = true
+    try {
+      const reg = await registration()
+      const sub = await reg.pushManager.getSubscription()
+      if (sub) {
+        await unsubscribePush(sub.endpoint).catch(() => {})
+        await sub.unsubscribe()
+      }
+      subscribed.value = false
+      endpoint = ''
+    } finally {
+      busy.value = false
+    }
+  }
+
+  async function updatePref(key, value) {
+    prefs.value = { ...prefs.value, [key]: value ? 1 : 0 }
+    if (endpoint) await setPushPrefs(endpoint, prefs.value).catch(() => {})
+  }
+
+  async function test() {
+    await sendTestPush().catch(() => {})
+  }
+
+  return {
+    supported,
+    configured,
+    permission,
+    blocked,
+    subscribed,
+    busy,
+    error,
+    prefs,
+    refresh,
+    enable,
+    disable,
+    updatePref,
+    test,
+  }
+}

--- a/frontend/src/composables/usePushNotifications.js
+++ b/frontend/src/composables/usePushNotifications.js
@@ -113,7 +113,16 @@ export function usePushNotifications() {
     if (endpoint) await setPushPrefs(endpoint, prefs.value).catch(() => {})
   }
 
-  const test = () => sendTestPush().catch(() => {})
+  const testStatus = ref('')
+  async function test() {
+    testStatus.value = 'sending'
+    try {
+      const res = await sendTestPush()
+      testStatus.value = res && res.sent ? 'sent' : 'none'
+    } catch {
+      testStatus.value = 'error'
+    }
+  }
 
   return {
     supported,
@@ -124,6 +133,7 @@ export function usePushNotifications() {
     busy,
     error,
     prefs,
+    testStatus,
     refresh,
     enable,
     disable,

--- a/frontend/src/data/push.js
+++ b/frontend/src/data/push.js
@@ -1,7 +1,5 @@
 import { frappeRequest } from 'frappe-ui'
 
-// Push-notification API — separate from collection.js since it's a different concern. Every
-// call rides the shared Frappe session + CSRF via frappeRequest.
 const M = 'ipay.ipay.main.utils.push'
 const post = (method, params) =>
   frappeRequest({ url: `/api/method/${M}.${method}`, method: 'POST', params })

--- a/frontend/src/data/push.js
+++ b/frontend/src/data/push.js
@@ -1,0 +1,20 @@
+import { frappeRequest } from 'frappe-ui'
+
+// Push-notification API — separate from collection.js since it's a different concern. Every
+// call rides the shared Frappe session + CSRF via frappeRequest.
+const M = 'ipay.ipay.main.utils.push'
+const post = (method, params) =>
+  frappeRequest({ url: `/api/method/${M}.${method}`, method: 'POST', params })
+
+export const subscribePush = (subscription, userAgent) =>
+  post('subscribe', { subscription: JSON.stringify(subscription), user_agent: userAgent })
+
+export const unsubscribePush = (endpoint) => post('unsubscribe', { endpoint })
+
+export const setPushPrefs = (endpoint, prefs) =>
+  post('set_prefs', { endpoint, prefs: JSON.stringify(prefs) })
+
+export const getPushPrefs = (endpoint) =>
+  frappeRequest({ url: `/api/method/${M}.get_prefs`, method: 'GET', params: { endpoint } })
+
+export const sendTestPush = () => post('send_test', {})

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -11,6 +11,15 @@ import router from './router'
 // session cookie and the CSRF token, so the SPA shares the logged-in desk session.
 setConfig('resourceFetcher', frappeRequest)
 
+// The worker is served with Service-Worker-Allowed: /collect so it can be scoped to /collect
+// and control the app — iOS only shows push for a worker that controls the app's pages.
+const SW_URL = '/api/method/ipay.ipay.main.utils.push.collect_worker'
+if (!import.meta.env.DEV && 'serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register(SW_URL, { scope: '/collect' }).catch(() => {})
+  })
+}
+
 const app = createApp(App)
 app.use(createPinia())
 app.use(router)

--- a/frontend/src/sw.js
+++ b/frontend/src/sw.js
@@ -1,0 +1,60 @@
+/* Service worker for iPay Collect.
+ *
+ * Built via vite-plugin-pwa's injectManifest strategy. Its only job today is Web Push —
+ * receiving push messages and turning them into notifications — so it does not precache the
+ * app shell (see vite.config.js: globPatterns is empty). Offline caching can be added later
+ * by consuming the precache manifest below with workbox-precaching.
+ */
+
+// injectManifest replaces self.__WB_MANIFEST with the precache list (empty for now). It's
+// assigned to a global rather than a local so bundler dead-code elimination can't drop the
+// reference before workbox performs the injection; it's consumed for real once offline
+// precaching is enabled.
+self.__ipayPrecache = self.__WB_MANIFEST
+
+// Activate a new SW immediately and take control, so a deploy's push handler is live without
+// waiting for every tab to close.
+self.addEventListener('install', () => self.skipWaiting())
+self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()))
+
+// A registered fetch handler is part of what makes the app installable across browsers (and
+// helps Android's install prompt fire). It intentionally does nothing — no respondWith means
+// every request falls through to the network unchanged, so nothing is cached or intercepted.
+self.addEventListener('fetch', () => {})
+
+const ICON = '/assets/ipay/manifest/manifest-icon-192.maskable.png'
+const BADGE = '/assets/ipay/manifest/favicon-196.png'
+
+// A push arrives as JSON: { title, body, tag?, url? }. Fall back gracefully if the payload is
+// missing or not JSON, so a malformed message still surfaces something rather than nothing.
+self.addEventListener('push', (event) => {
+  let payload = {}
+  try {
+    payload = event.data ? event.data.json() : {}
+  } catch {
+    payload = { body: event.data ? event.data.text() : '' }
+  }
+  const title = payload.title || 'iPay Collect'
+  const options = {
+    body: payload.body || '',
+    icon: ICON,
+    badge: BADGE,
+    tag: payload.tag, // same tag collapses duplicates rather than stacking
+    data: { url: payload.url || '/collect' },
+  }
+  event.waitUntil(self.registration.showNotification(title, options))
+})
+
+// Tapping a notification focuses an existing collect tab if one is open, otherwise opens it.
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close()
+  const target = (event.notification.data && event.notification.data.url) || '/collect'
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clients) => {
+      for (const client of clients) {
+        if (client.url.includes('/collect') && 'focus' in client) return client.focus()
+      }
+      return self.clients.openWindow(target)
+    }),
+  )
+})

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -22,6 +22,9 @@ export default defineConfig({
     vue(),
     VitePWA({
       registerType: 'autoUpdate',
+      // We register the worker ourselves (main.js) from a root-served copy, scoped to /collect
+      // so it controls the app — iOS only shows push for a worker that controls the app's pages.
+      injectRegister: false,
       // Custom service worker (src/sw.js), so it can carry a Web Push `push` /
       // `notificationclick` handler — a generated SW can't. It was previously
       // self-destroying (no push listener, unregisters itself), which made push

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -22,16 +22,11 @@ export default defineConfig({
     vue(),
     VitePWA({
       registerType: 'autoUpdate',
-      // We register the worker ourselves (main.js) from a root-served copy, scoped to /collect
-      // so it controls the app — iOS only shows push for a worker that controls the app's pages.
+      // We register the worker ourselves (main.js) at /collect scope so it controls the app —
+      // iOS only shows push for a worker that controls the app's pages.
       injectRegister: false,
-      // Custom service worker (src/sw.js), so it can carry a Web Push `push` /
-      // `notificationclick` handler — a generated SW can't. It was previously
-      // self-destroying (no push listener, unregisters itself), which made push
-      // impossible; that is now off. The SW deliberately does NOT precache the
-      // app shell yet (globPatterns empty) — its only job for now is Web Push, so
-      // there is no stale-asset risk to manage. Offline precaching can be layered
-      // on later by giving the injected manifest real glob patterns.
+      // Custom service worker (src/sw.js) so it can carry a Web Push handler; a generated one
+      // can't. No precaching yet (empty globPatterns) — its only job for now is push.
       strategies: 'injectManifest',
       srcDir: 'src',
       filename: 'sw.js',

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -22,11 +22,19 @@ export default defineConfig({
     vue(),
     VitePWA({
       registerType: 'autoUpdate',
-      // During active development the service worker is self-destroying: it
-      // unregisters and clears caches on devices that already installed it, so
-      // every deploy is fetched fresh (no stale app shell). Re-enable full
-      // precaching/offline once the app stabilises.
-      selfDestroying: true,
+      // Custom service worker (src/sw.js), so it can carry a Web Push `push` /
+      // `notificationclick` handler — a generated SW can't. It was previously
+      // self-destroying (no push listener, unregisters itself), which made push
+      // impossible; that is now off. The SW deliberately does NOT precache the
+      // app shell yet (globPatterns empty) — its only job for now is Web Push, so
+      // there is no stale-asset risk to manage. Offline precaching can be layered
+      // on later by giving the injected manifest real glob patterns.
+      strategies: 'injectManifest',
+      srcDir: 'src',
+      filename: 'sw.js',
+      injectManifest: {
+        globPatterns: [],
+      },
       manifest: {
         name: 'iPay Collect',
         short_name: 'iPay Collect',

--- a/ipay/ipay/doctype/ipay_push_subscription/ipay_push_subscription.json
+++ b/ipay/ipay/doctype/ipay_push_subscription/ipay_push_subscription.json
@@ -1,0 +1,111 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "hash",
+ "creation": "2026-07-25 00:00:00.000000",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "user",
+  "user_agent",
+  "endpoint",
+  "p256dh",
+  "auth",
+  "prefs_section",
+  "notify_cheque_assigned",
+  "notify_collection_success",
+  "notify_collection_error"
+ ],
+ "fields": [
+  {
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "User",
+   "options": "User",
+   "reqd": 1
+  },
+  {
+   "fieldname": "user_agent",
+   "fieldtype": "Small Text",
+   "label": "Device"
+  },
+  {
+   "description": "The browser push endpoint URL. Unique per browser install; used to target and de-duplicate a subscription.",
+   "fieldname": "endpoint",
+   "fieldtype": "Small Text",
+   "in_list_view": 1,
+   "label": "Endpoint",
+   "reqd": 1
+  },
+  {
+   "fieldname": "p256dh",
+   "fieldtype": "Data",
+   "label": "p256dh Key",
+   "reqd": 1
+  },
+  {
+   "fieldname": "auth",
+   "fieldtype": "Data",
+   "label": "Auth Secret",
+   "reqd": 1
+  },
+  {
+   "fieldname": "prefs_section",
+   "fieldtype": "Section Break",
+   "label": "Notification Preferences"
+  },
+  {
+   "default": "1",
+   "fieldname": "notify_cheque_assigned",
+   "fieldtype": "Check",
+   "label": "Cheque collection assigned to me"
+  },
+  {
+   "default": "1",
+   "fieldname": "notify_collection_success",
+   "fieldtype": "Check",
+   "label": "Successful collection"
+  },
+  {
+   "default": "1",
+   "fieldname": "notify_collection_error",
+   "fieldtype": "Check",
+   "label": "Collection error"
+  }
+ ],
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2026-07-25 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Ipay",
+ "name": "iPay Push Subscription",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "delete": 1,
+   "read": 1,
+   "report": 1,
+   "role": "iPay Manager"
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 0
+}

--- a/ipay/ipay/doctype/ipay_push_subscription/ipay_push_subscription.py
+++ b/ipay/ipay/doctype/ipay_push_subscription/ipay_push_subscription.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Gatura Njenga and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class iPayPushSubscription(Document):
+	pass

--- a/ipay/ipay/main/utils/push.py
+++ b/ipay/ipay/main/utils/push.py
@@ -1,14 +1,6 @@
-"""Web Push (VAPID) for the iPay Collect PWA.
+"""Web Push (VAPID) for the Collect PWA.
 
-Subscriptions live in the `iPay Push Subscription` DocType (one row per browser install,
-carrying the user's per-type on/off preferences). The frontend requests permission, subscribes
-via the service worker, and POSTs the subscription here. `send_web_push` is the send path the
-notification triggers (Phase 2) call.
-
-VAPID keys live in site config (secrets, never committed):
-  ipay_vapid_public_key   — base64url, also handed to the browser as applicationServerKey
-  ipay_vapid_private_key  — base64url raw private key
-  ipay_vapid_subject      — a mailto: or https: contact, e.g. "mailto:ops@bulkbox.cloud"
+Keys read from site config: ipay_vapid_public_key, ipay_vapid_private_key, ipay_vapid_subject.
 """
 
 import json
@@ -24,8 +16,6 @@ PREF_FIELDS = (
 	"notify_collection_error",
 )
 
-# Notification type -> the preference that gates it. A type not in this map (e.g. the test
-# push) bypasses per-type filtering.
 TYPE_TO_PREF = {
 	"cheque_assigned": "notify_cheque_assigned",
 	"collection_success": "notify_collection_success",
@@ -46,51 +36,45 @@ def _prefs_of(doc):
 	return {field: int(doc.get(field) or 0) for field in PREF_FIELDS}
 
 
+def _find(endpoint, user=None):
+	filters = {"endpoint": endpoint}
+	if user:
+		filters["user"] = user
+	return frappe.db.get_value(DOCTYPE, filters, "name")
+
+
 @frappe.whitelist()
 def get_public_key():
-	"""The VAPID public key the browser needs to subscribe (also exposed via boot)."""
 	return _vapid()[0]
 
 
 @frappe.whitelist(methods=["POST"])
 def subscribe(subscription, user_agent=None):
-	"""Store (or refresh) the caller's push subscription for this browser."""
 	sub = json.loads(subscription) if isinstance(subscription, str) else subscription
 	endpoint = (sub or {}).get("endpoint")
 	keys = (sub or {}).get("keys") or {}
-	p256dh, auth = keys.get("p256dh"), keys.get("auth")
-	if not (endpoint and p256dh and auth):
+	if not (endpoint and keys.get("p256dh") and keys.get("auth")):
 		frappe.throw(_("Invalid push subscription."))
 
-	user = frappe.session.user
-	name = frappe.db.get_value(DOCTYPE, {"endpoint": endpoint}, "name")
-	if name:
-		# Same browser re-subscribing (keys rotate; the device may have switched account).
-		doc = frappe.get_doc(DOCTYPE, name)
-		doc.user = user
-		doc.p256dh = p256dh
-		doc.auth = auth
-		if user_agent:
-			doc.user_agent = user_agent
-		doc.save(ignore_permissions=True)
-	else:
-		doc = frappe.get_doc(
-			{
-				"doctype": DOCTYPE,
-				"user": user,
-				"endpoint": endpoint,
-				"p256dh": p256dh,
-				"auth": auth,
-				"user_agent": user_agent,
-			}
-		).insert(ignore_permissions=True)
+	name = _find(endpoint)
+	doc = frappe.get_doc(DOCTYPE, name) if name else frappe.new_doc(DOCTYPE)
+	doc.update(
+		{
+			"user": frappe.session.user,
+			"endpoint": endpoint,
+			"p256dh": keys["p256dh"],
+			"auth": keys["auth"],
+		}
+	)
+	if user_agent:
+		doc.user_agent = user_agent
+	doc.save(ignore_permissions=True)
 	return {"name": doc.name, "prefs": _prefs_of(doc)}
 
 
 @frappe.whitelist(methods=["POST"])
 def unsubscribe(endpoint):
-	"""Remove the caller's subscription for this browser."""
-	name = frappe.db.get_value(DOCTYPE, {"endpoint": endpoint, "user": frappe.session.user}, "name")
+	name = _find(endpoint, frappe.session.user)
 	if name:
 		frappe.delete_doc(DOCTYPE, name, ignore_permissions=True, force=True)
 	return {"ok": True}
@@ -98,16 +82,14 @@ def unsubscribe(endpoint):
 
 @frappe.whitelist()
 def get_prefs(endpoint):
-	"""The caller's saved preferences for this browser, or None if not subscribed."""
-	name = frappe.db.get_value(DOCTYPE, {"endpoint": endpoint, "user": frappe.session.user}, "name")
+	name = _find(endpoint, frappe.session.user)
 	return _prefs_of(frappe.get_doc(DOCTYPE, name)) if name else None
 
 
 @frappe.whitelist(methods=["POST"])
 def set_prefs(endpoint, prefs):
-	"""Update which notification types this browser's subscription receives."""
 	prefs = json.loads(prefs) if isinstance(prefs, str) else prefs
-	name = frappe.db.get_value(DOCTYPE, {"endpoint": endpoint, "user": frappe.session.user}, "name")
+	name = _find(endpoint, frappe.session.user)
 	if not name:
 		frappe.throw(_("No subscription found for this device."))
 	doc = frappe.get_doc(DOCTYPE, name)
@@ -120,57 +102,35 @@ def set_prefs(endpoint, prefs):
 
 @frappe.whitelist(methods=["POST"])
 def send_test():
-	"""Send the caller a test notification (bypasses per-type preferences)."""
 	sent = send_web_push(
 		[frappe.session.user],
 		title="iPay Collect",
 		body="Notifications are on — you'll be alerted here.",
-		notif_type=None,
 		tag="ipay-test",
 	)
 	return {"sent": sent}
 
 
 def send_web_push(users, title, body, notif_type=None, url="/collect", tag=None):
-	"""Send a push to every enabled subscription of the given users.
-
-	Honours each subscription's per-type preference (unless notif_type is None). Prunes
-	subscriptions the push service reports as gone. Returns the number sent. Safe to call with
-	no VAPID keys configured (returns 0) so it never breaks the flow that triggered it.
-	"""
 	recipients = [u for u in set(users or []) if u and u != "Guest"]
-	if not recipients:
-		return 0
-
-	_pub, private_key, subject = _vapid()
-	if not private_key:
+	_public, private_key, subject = _vapid()
+	if not (recipients and private_key):
 		return 0
 
 	filters = {"user": ["in", recipients]}
-	pref_field = TYPE_TO_PREF.get(notif_type) if notif_type else None
+	pref_field = TYPE_TO_PREF.get(notif_type)
 	if pref_field:
 		filters[pref_field] = 1
 
-	subs = frappe.get_all(
-		DOCTYPE, filters=filters, fields=["name", "endpoint", "p256dh", "auth"]
-	)
-	if not subs:
-		return 0
-
+	subs = frappe.get_all(DOCTYPE, filters=filters, fields=["name", "endpoint", "p256dh", "auth"])
 	payload = json.dumps({"title": title, "body": body, "url": url, "tag": tag})
-	return sum(1 for s in subs if _send_one(s, payload, private_key, subject))
+	return sum(1 for sub in subs if _deliver(sub, payload, private_key, subject))
 
 
-def _send_one(sub, payload, private_key, subject):
+def _deliver(sub, payload, private_key, subject):
 	try:
 		from pywebpush import WebPushException, webpush
 	except ImportError:
-		from ipay.ipay.main.utils.ipay_logs import create_log_entry
-
-		create_log_entry(
-			"ERR",
-			"pywebpush is not installed — web push skipped. Run: ./env/bin/pip install pywebpush",
-		)
 		return False
 
 	try:
@@ -185,9 +145,7 @@ def _send_one(sub, payload, private_key, subject):
 		)
 		return True
 	except WebPushException as exc:
-		status = getattr(getattr(exc, "response", None), "status_code", None)
-		# 404/410 mean the browser dropped the subscription — stop trying it.
-		if status in (404, 410):
+		if getattr(getattr(exc, "response", None), "status_code", None) in (404, 410):
 			frappe.db.delete(DOCTYPE, {"name": sub["name"]})
 		return False
 	except Exception:

--- a/ipay/ipay/main/utils/push.py
+++ b/ipay/ipay/main/utils/push.py
@@ -1,0 +1,195 @@
+"""Web Push (VAPID) for the iPay Collect PWA.
+
+Subscriptions live in the `iPay Push Subscription` DocType (one row per browser install,
+carrying the user's per-type on/off preferences). The frontend requests permission, subscribes
+via the service worker, and POSTs the subscription here. `send_web_push` is the send path the
+notification triggers (Phase 2) call.
+
+VAPID keys live in site config (secrets, never committed):
+  ipay_vapid_public_key   — base64url, also handed to the browser as applicationServerKey
+  ipay_vapid_private_key  — base64url raw private key
+  ipay_vapid_subject      — a mailto: or https: contact, e.g. "mailto:ops@bulkbox.cloud"
+"""
+
+import json
+
+import frappe
+from frappe import _
+
+DOCTYPE = "iPay Push Subscription"
+
+PREF_FIELDS = (
+	"notify_cheque_assigned",
+	"notify_collection_success",
+	"notify_collection_error",
+)
+
+# Notification type -> the preference that gates it. A type not in this map (e.g. the test
+# push) bypasses per-type filtering.
+TYPE_TO_PREF = {
+	"cheque_assigned": "notify_cheque_assigned",
+	"collection_success": "notify_collection_success",
+	"collection_error": "notify_collection_error",
+}
+
+
+def _vapid():
+	conf = frappe.conf
+	return (
+		conf.get("ipay_vapid_public_key"),
+		conf.get("ipay_vapid_private_key"),
+		conf.get("ipay_vapid_subject") or "mailto:admin@localhost",
+	)
+
+
+def _prefs_of(doc):
+	return {field: int(doc.get(field) or 0) for field in PREF_FIELDS}
+
+
+@frappe.whitelist()
+def get_public_key():
+	"""The VAPID public key the browser needs to subscribe (also exposed via boot)."""
+	return _vapid()[0]
+
+
+@frappe.whitelist(methods=["POST"])
+def subscribe(subscription, user_agent=None):
+	"""Store (or refresh) the caller's push subscription for this browser."""
+	sub = json.loads(subscription) if isinstance(subscription, str) else subscription
+	endpoint = (sub or {}).get("endpoint")
+	keys = (sub or {}).get("keys") or {}
+	p256dh, auth = keys.get("p256dh"), keys.get("auth")
+	if not (endpoint and p256dh and auth):
+		frappe.throw(_("Invalid push subscription."))
+
+	user = frappe.session.user
+	name = frappe.db.get_value(DOCTYPE, {"endpoint": endpoint}, "name")
+	if name:
+		# Same browser re-subscribing (keys rotate; the device may have switched account).
+		doc = frappe.get_doc(DOCTYPE, name)
+		doc.user = user
+		doc.p256dh = p256dh
+		doc.auth = auth
+		if user_agent:
+			doc.user_agent = user_agent
+		doc.save(ignore_permissions=True)
+	else:
+		doc = frappe.get_doc(
+			{
+				"doctype": DOCTYPE,
+				"user": user,
+				"endpoint": endpoint,
+				"p256dh": p256dh,
+				"auth": auth,
+				"user_agent": user_agent,
+			}
+		).insert(ignore_permissions=True)
+	return {"name": doc.name, "prefs": _prefs_of(doc)}
+
+
+@frappe.whitelist(methods=["POST"])
+def unsubscribe(endpoint):
+	"""Remove the caller's subscription for this browser."""
+	name = frappe.db.get_value(DOCTYPE, {"endpoint": endpoint, "user": frappe.session.user}, "name")
+	if name:
+		frappe.delete_doc(DOCTYPE, name, ignore_permissions=True, force=True)
+	return {"ok": True}
+
+
+@frappe.whitelist()
+def get_prefs(endpoint):
+	"""The caller's saved preferences for this browser, or None if not subscribed."""
+	name = frappe.db.get_value(DOCTYPE, {"endpoint": endpoint, "user": frappe.session.user}, "name")
+	return _prefs_of(frappe.get_doc(DOCTYPE, name)) if name else None
+
+
+@frappe.whitelist(methods=["POST"])
+def set_prefs(endpoint, prefs):
+	"""Update which notification types this browser's subscription receives."""
+	prefs = json.loads(prefs) if isinstance(prefs, str) else prefs
+	name = frappe.db.get_value(DOCTYPE, {"endpoint": endpoint, "user": frappe.session.user}, "name")
+	if not name:
+		frappe.throw(_("No subscription found for this device."))
+	doc = frappe.get_doc(DOCTYPE, name)
+	for field in PREF_FIELDS:
+		if field in prefs:
+			doc.set(field, 1 if prefs[field] else 0)
+	doc.save(ignore_permissions=True)
+	return _prefs_of(doc)
+
+
+@frappe.whitelist(methods=["POST"])
+def send_test():
+	"""Send the caller a test notification (bypasses per-type preferences)."""
+	sent = send_web_push(
+		[frappe.session.user],
+		title="iPay Collect",
+		body="Notifications are on — you'll be alerted here.",
+		notif_type=None,
+		tag="ipay-test",
+	)
+	return {"sent": sent}
+
+
+def send_web_push(users, title, body, notif_type=None, url="/collect", tag=None):
+	"""Send a push to every enabled subscription of the given users.
+
+	Honours each subscription's per-type preference (unless notif_type is None). Prunes
+	subscriptions the push service reports as gone. Returns the number sent. Safe to call with
+	no VAPID keys configured (returns 0) so it never breaks the flow that triggered it.
+	"""
+	recipients = [u for u in set(users or []) if u and u != "Guest"]
+	if not recipients:
+		return 0
+
+	_pub, private_key, subject = _vapid()
+	if not private_key:
+		return 0
+
+	filters = {"user": ["in", recipients]}
+	pref_field = TYPE_TO_PREF.get(notif_type) if notif_type else None
+	if pref_field:
+		filters[pref_field] = 1
+
+	subs = frappe.get_all(
+		DOCTYPE, filters=filters, fields=["name", "endpoint", "p256dh", "auth"]
+	)
+	if not subs:
+		return 0
+
+	payload = json.dumps({"title": title, "body": body, "url": url, "tag": tag})
+	return sum(1 for s in subs if _send_one(s, payload, private_key, subject))
+
+
+def _send_one(sub, payload, private_key, subject):
+	try:
+		from pywebpush import WebPushException, webpush
+	except ImportError:
+		from ipay.ipay.main.utils.ipay_logs import create_log_entry
+
+		create_log_entry(
+			"ERR",
+			"pywebpush is not installed — web push skipped. Run: ./env/bin/pip install pywebpush",
+		)
+		return False
+
+	try:
+		webpush(
+			subscription_info={
+				"endpoint": sub["endpoint"],
+				"keys": {"p256dh": sub["p256dh"], "auth": sub["auth"]},
+			},
+			data=payload,
+			vapid_private_key=private_key,
+			vapid_claims={"sub": subject},
+		)
+		return True
+	except WebPushException as exc:
+		status = getattr(getattr(exc, "response", None), "status_code", None)
+		# 404/410 mean the browser dropped the subscription — stop trying it.
+		if status in (404, 410):
+			frappe.db.delete(DOCTYPE, {"name": sub["name"]})
+		return False
+	except Exception:
+		frappe.log_error(frappe.get_traceback(), "iPay web push failed")
+		return False

--- a/ipay/ipay/main/utils/push.py
+++ b/ipay/ipay/main/utils/push.py
@@ -112,7 +112,6 @@ def collect_worker():
 	response = Response(content, mimetype="text/javascript")
 	response.headers["Service-Worker-Allowed"] = "/collect"
 	response.headers["Cache-Control"] = "no-cache"
-	frappe.local.response = response
 	return response
 
 

--- a/ipay/ipay/main/utils/push.py
+++ b/ipay/ipay/main/utils/push.py
@@ -100,6 +100,22 @@ def set_prefs(endpoint, prefs):
 	return _prefs_of(doc)
 
 
+@frappe.whitelist(allow_guest=True, methods=["GET"])
+def collect_worker():
+	"""Serve the built service worker with Service-Worker-Allowed: /collect, so it can be
+	registered at /collect scope and control the app — which iOS requires to deliver push."""
+	from werkzeug.wrappers import Response
+
+	path = frappe.get_app_path("ipay", "public", "frontend", "sw.js")
+	with open(path, encoding="utf-8") as handle:
+		content = handle.read()
+	response = Response(content, mimetype="text/javascript")
+	response.headers["Service-Worker-Allowed"] = "/collect"
+	response.headers["Cache-Control"] = "no-cache"
+	frappe.local.response = response
+	return response
+
+
 @frappe.whitelist(methods=["POST"])
 def send_test():
 	sent = send_web_push(

--- a/ipay/www/collect.py
+++ b/ipay/www/collect.py
@@ -62,6 +62,9 @@ def get_boot():
             "sales_access": can_open_sales(),
             "site_name": frappe.local.site,
             "csrf_token": frappe.sessions.get_csrf_token(),
+            # Public VAPID key for Web Push subscription (null until keys are configured in
+            # site config). Public by design — safe to expose to the browser.
+            "vapid_public_key": frappe.conf.get("ipay_vapid_public_key"),
             "timezone": {
                 "system": get_system_timezone(),
                 "user": frappe.db.get_value("User", frappe.session.user, "time_zone")

--- a/ipay/www/collect.py
+++ b/ipay/www/collect.py
@@ -62,8 +62,6 @@ def get_boot():
             "sales_access": can_open_sales(),
             "site_name": frappe.local.site,
             "csrf_token": frappe.sessions.get_csrf_token(),
-            # Public VAPID key for Web Push subscription (null until keys are configured in
-            # site config). Public by design — safe to expose to the browser.
             "vapid_public_key": frappe.conf.get("ipay_vapid_public_key"),
             "timezone": {
                 "system": get_system_timezone(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 dynamic = ["version"]
 dependencies = [
     # "frappe~=15.0.0" # Installed and managed by bench.
+    "pywebpush~=2.0",  # VAPID Web Push for the Collect PWA (ipay.ipay.main.utils.push)
 ]
 
 [build-system]


### PR DESCRIPTION
## What

**Phase 1 of Web Push** — the opt-in, subscriptions, and per-type preferences. **No notifications fire yet** (that's Phase 2). Users can turn notifications on, pick which types they want, send themselves a test, and turn them off.

> ⚠️ **Stacked on #98** (persistent service worker). Base branch is `feat/ipay-push-sw-foundation`, not `main` — **merge #98 first**, then this. GitHub will retarget this to `main` automatically once #98 merges.

## Backend

- **New `iPay Push Subscription` DocType** — one row per browser install: `user`, `endpoint`, `p256dh`/`auth` keys, and three preference checks (cheque-assigned / success / error), each default-on.
- **`ipay/ipay/main/utils/push.py`** — whitelisted `subscribe` / `unsubscribe` / `get_prefs` / `set_prefs` / `send_test`, plus **`send_web_push(users, …)`** — the send path Phase 2's triggers call. It filters to subscriptions whose per-type preference is on, prunes dead endpoints (404/410), and **no-ops safely (returns 0) when VAPID keys aren't configured**, so it can never break the flow that triggered it.
- **VAPID public key** exposed to the SPA via `boot` (`collect.py`). Keys live in **site config** (`ipay_vapid_public_key` / `ipay_vapid_private_key` / `ipay_vapid_subject`) — secrets, never committed.
- **`pywebpush`** added to `pyproject.toml` dependencies.

## Frontend

- **`usePushNotifications`** composable — support/permission detection, subscribe/unsubscribe, prefs. Subscribes against the **asset-scoped** SW registration directly (not `navigator.serviceWorker.ready`, which never resolves because the SW doesn't control `/collect`).
- **`NotificationSettings`** — a bell in the collect-list header (all three landings) opening a `BaseDialog`: *Turn on notifications* → per-type toggles + *Send a test* + *Turn off*. Handles unsupported / permission-blocked / not-configured states with clear copy.

## Verification

Exercised against dev (data rolled back): DocType installs; `subscribe` is idempotent per endpoint; prefs read/write; `send_web_push` returns 0 with no keys. Separately, the generated VAPID keypair validates — py_vapid loads the private key and the derived public matches, confirming the format pywebpush needs.

## Deploy / setup (server-side, one-time)

1. `./env/bin/pip install pywebpush` (or reinstall app deps).
2. Set VAPID keys in site config — I generated a pair and **already set it on the dev site**, so dev is ready to test once this branch is deployed. For prod, generate a fresh pair (command below) and `bench --site <site> set-config` the three keys.
3. `bench migrate` (installs the DocType), then restart so the new Python loads.

<details><summary>Generate a prod VAPID keypair</summary>

```python
import base64
from cryptography.hazmat.primitives.asymmetric import ec
b = lambda x: base64.urlsafe_b64encode(x).rstrip(b"=").decode()
pk = ec.generate_private_key(ec.SECP256R1())
n = pk.public_key().public_numbers()
print("public:", b(b"\x04"+n.x.to_bytes(32,"big")+n.y.to_bytes(32,"big")))
print("private:", b(pk.private_numbers().private_value.to_bytes(32,"big")))
```
</details>

## Testing once deployed

Open `/collect` → tap the **bell** → *Turn on notifications* → allow → *Send a test* → a notification should appear. Then toggle types and confirm they persist (reopen the panel).

## Notes

- Preferences are stored **per subscription (per device)** — simplest model; a user with two devices can differ. Fine for v1.
- **iOS** still needs the app installed to the home screen (16.4+); this is where we'll validate the asset-scoped SW actually delivers on a real iPhone. If not, we widen the SW scope in a follow-up.