### PR TITLE
feat(ipay): payment links in emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Without an iPay account, this application cannot process mobile money transactio
 -  **Real-Time Payment Verification**: Verify payments as they happen, ensuring immediate confirmation and reducing delays in processing.
 -  **Secure Transaction Logging**: Maintain a tamper-proof, detailed record of all payment transactions, including timestamps, amounts, and statuses, for compliance and auditing purposes.
 -  **Cheque Collection**: Collectors record a customer's cheque as a draft Payment Entry for the accounts team to submit — see [docs/cheque-collection.md](docs/cheque-collection.md) for how it works, the settings, and the operational notes.
+-  **Payment Links in Emails**: Add a "Pay now" link to any invoice or reminder email — the customer opens a no-login page and prompts themselves to pay. A Jinja helper for your own ERPNext emails, plus two ready-made (disabled) notifications; see [docs/payment-links-in-emails.md](docs/payment-links-in-emails.md).
 
 ## Payment Workflow
 

--- a/docs/payment-links-in-emails.md
+++ b/docs/payment-links-in-emails.md
@@ -1,0 +1,81 @@
+# Payment Links in Emails
+
+Put a **"Pay now"** link into any invoice or reminder email. The customer clicks it, lands on a
+no-login page showing their live balance, and prompts *themselves* to pay by M-Pesa (or hosted
+checkout). It's the same tokenised `/pay` link the Collect app shares — just generated at
+send time.
+
+---
+
+## Prerequisite
+
+Turn on **iPay Settings → Use Hosted Checkout Redirect** (`enable_redirect`). This is the master
+switch for every payment link. With it off, the helper returns nothing and no link appears —
+the email just omits the button.
+
+Link validity is **iPay Settings → Payment Link TTL Days** (default 7).
+
+## Add the link to your own ERPNext emails
+
+iPay registers a Jinja helper, `ipay_payment_link(invoice)`, available in **any** Email Template,
+Notification, or Print Format. Drop this into the message body:
+
+```jinja
+{% set link = ipay_payment_link(doc.name) %}
+{% if link %}
+  <a href="{{ link }}"
+     style="background:#007a36;color:#fff;padding:10px 18px;border-radius:6px;text-decoration:none;">
+    Pay now
+  </a>
+{% endif %}
+```
+
+It returns the URL for the invoice, or **nothing** when there's no balance to collect — so the
+`{% if link %}` guard cleanly hides the button when it doesn't apply (see *When there's no link*).
+
+## Or use the emails iPay ships
+
+iPay ships two ready-made **Notifications** (Desk → *Notification*), **disabled by default** and
+fully editable — enable, edit, or delete them freely (they're created once and never
+re-synced):
+
+| Notification | Fires | Note |
+|---|---|---|
+| **iPay: Invoice Issued** | when a Sales Invoice is submitted | includes the Pay now link |
+| **iPay: Payment Reminder** | 3 days after the due date, while unpaid | change the days / wording in the Desk |
+
+Both email the invoice's `contact_email` and skip fully-paid invoices. They're a starting point —
+adjust the copy (e.g. add your M-Pesa Paybill instructions) before enabling.
+
+## How the link behaves
+
+- **One link per invoice, idempotent.** Generating it again (a reminder run, a re-send) reuses
+  the same request and token — the customer always gets the same link, not a new one each time.
+- **Always shows the live balance.** A partly-paid invoice shows the remaining amount.
+- **Self-managing.** The `/pay` page handles every state: **paid** → "Thank you", **expired** →
+  "request a new one", **cancelled / cheque received** → the right message.
+
+### When there's no link
+
+`ipay_payment_link` returns nothing (so the button is hidden) when:
+
+- the master switch is off,
+- the invoice is fully paid, not submitted, or has no balance,
+- a **cheque** has already been collected for it, or
+- the invoice is **prepaid** (settles automatically — no iPay request is needed).
+
+## Security
+
+The link carries only a 24-character random token tied to that one invoice/bundle. A recipient
+opens the `/pay` page and pays **without logging in**; they can't reach anything else, and the
+guest pay endpoint is rate-limited per token. Cancelled, expired, and cheque-covered tokens are
+refused.
+
+## Files
+
+| Area | Path |
+|---|---|
+| Link function + `/pay` flow | `ipay/ipay/main/utils/ipay_redirect.py` (`payment_link_for_invoice`) |
+| Jinja helper | `ipay/ipay/main/utils/jinja.py` (`ipay_payment_link`), registered in `ipay/hooks.py` |
+| Shipped notifications | `ipay/patches/v1_0/create_payment_email_notifications.py` |
+| Customer pay page | `ipay/www/pay.py` (route `/pay`) |

--- a/ipay/hooks.py
+++ b/ipay/hooks.py
@@ -67,10 +67,11 @@ website_route_rules = [
 # ----------
 
 # add methods and filters to jinja environment
-# jinja = {
-# 	"methods": "ipay.utils.jinja_methods",
-# 	"filters": "ipay.utils.jinja_filters"
-# }
+jinja = {
+	"methods": [
+		"ipay.ipay.main.utils.jinja.ipay_payment_link",
+	],
+}
 
 # Installation
 # ------------

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -339,6 +339,32 @@ def resolve_pay_token(token):
     return row.name, "ok"
 
 
+def payment_link_for_invoice(invoice):
+    """A customer-facing /pay link for an invoice, for emails, notifications and print formats.
+
+    Returns the URL, or None when there is nothing to collect (paid / not submitted), a cheque
+    is already held, or hosted checkout is off. Reuses the same idempotent request+token as
+    get_payment_link but without the operator gate — it renders server-side with no logged-in
+    caller, and never raises, so it can't break an email or print render."""
+    if not invoice or not _redirect_enabled():
+        return None
+    si = frappe.db.get_value(
+        "Sales Invoice", invoice, ["docstatus", "outstanding_amount"], as_dict=True
+    )
+    if not si or si.docstatus != 1 or frappe.utils.flt(si.outstanding_amount) <= 0:
+        return None
+    try:
+        token = _ensure_pay_token(_ensure_request(invoice))
+    except frappe.ValidationError:
+        # A cheque already held, a prepaid invoice, or another before_validate refusal — the
+        # invoice simply has no payable link, which is not an error.
+        return None
+    except Exception:
+        frappe.log_error(frappe.get_traceback(), "iPay payment link for email failed")
+        return None
+    return frappe.utils.get_url("/pay?token=" + token)
+
+
 def _request_from_token(token):
     """Resolve a (non-expired) payment-link token to its iPay Request name, or None."""
     return resolve_pay_token(token)[0]

--- a/ipay/ipay/main/utils/jinja.py
+++ b/ipay/ipay/main/utils/jinja.py
@@ -1,0 +1,10 @@
+"""Jinja helpers exposed to email templates, notifications and print formats (see hooks.jinja)."""
+
+from ipay.ipay.main.utils.ipay_redirect import payment_link_for_invoice
+
+
+def ipay_payment_link(invoice):
+	"""A customer-facing pay link for a Sales Invoice, or None. Drop into any template:
+	{% set link = ipay_payment_link(doc.name) %}{% if link %}<a href="{{ link }}">Pay now</a>{% endif %}
+	"""
+	return payment_link_for_invoice(invoice)

--- a/ipay/patches.txt
+++ b/ipay/patches.txt
@@ -9,3 +9,4 @@ ipay.patches.v1_0.seed_mpesa_mode_of_payment
 ipay.patches.v1_0.seed_collection_payment_terms
 ipay.patches.v1_0.set_default_mpesa_max
 ipay.patches.v1_0.set_cheque_per_invoice_default
+ipay.patches.v1_0.create_payment_email_notifications

--- a/ipay/patches/v1_0/create_payment_email_notifications.py
+++ b/ipay/patches/v1_0/create_payment_email_notifications.py
@@ -1,0 +1,65 @@
+import frappe
+
+INVOICE = "iPay: Invoice Issued"
+REMINDER = "iPay: Payment Reminder"
+
+_BUTTON = (
+	"{% set link = ipay_payment_link(doc.name) %}\n"
+	'{% if link %}<p><a href="{{ link }}" '
+	'style="background:#007a36;color:#ffffff;padding:10px 18px;'
+	'border-radius:6px;text-decoration:none;">Pay now</a></p>{% endif %}'
+)
+
+INVOICE_MESSAGE = (
+	"<p>Dear {{ doc.customer_name }},</p>\n"
+	"<p>Invoice <strong>{{ doc.name }}</strong> for "
+	"<strong>{{ frappe.utils.fmt_money(doc.outstanding_amount, currency=doc.currency) }}</strong> "
+	"has been issued{% if doc.due_date %}, due {{ frappe.utils.formatdate(doc.due_date) }}{% endif %}.</p>\n"
+	f"{_BUTTON}\n<p>Thank you.</p>"
+)
+
+REMINDER_MESSAGE = (
+	"<p>Dear {{ doc.customer_name }},</p>\n"
+	"<p>This is a reminder that invoice <strong>{{ doc.name }}</strong> for "
+	"<strong>{{ frappe.utils.fmt_money(doc.outstanding_amount, currency=doc.currency) }}</strong> "
+	"remains unpaid{% if doc.due_date %} (due {{ frappe.utils.formatdate(doc.due_date) }}){% endif %}.</p>\n"
+	f"{_BUTTON}\n<p>Thank you.</p>"
+)
+
+
+def _create(name, subject, message, event, extra):
+	if frappe.db.exists("Notification", name):
+		return
+	doc = frappe.get_doc(
+		{
+			"doctype": "Notification",
+			"name": name,
+			"subject": subject,
+			"document_type": "Sales Invoice",
+			"channel": "Email",
+			"event": event,
+			"enabled": 0,
+			"is_standard": 0,
+			"condition": "doc.outstanding_amount > 0",
+			"message": message,
+			"recipients": [{"receiver_by_document_field": "contact_email"}],
+			**extra,
+		}
+	)
+	doc.flags.ignore_permissions = True
+	doc.flags.ignore_mandatory = True
+	doc.insert()
+
+
+def execute():
+	"""Ship two disabled, editable email notifications that carry the iPay payment link — an
+	'invoice issued' email on submit, and a 'payment reminder' a few days after the due date.
+	Created once and never re-synced, so a site can enable, edit or delete them freely."""
+	_create(INVOICE, "Invoice {{ doc.name }} — payment options", INVOICE_MESSAGE, "Submit", {})
+	_create(
+		REMINDER,
+		"Reminder: invoice {{ doc.name }} is due",
+		REMINDER_MESSAGE,
+		"Days After",
+		{"date_changed": "due_date", "days_in_advance": 3},
+	)


### PR DESCRIPTION
## What

Adds a **"Pay now" link** to invoice and reminder emails. The customer clicks it, lands on the existing no-login `/pay` page showing their **live balance**, and prompts *themselves* to pay by M-Pesa (or hosted checkout). Independent of the push-notification PRs — **branched off `main`**.

## Two parts

**1. A Jinja helper for any email — `ipay_payment_link(invoice)`.**
Registered via `hooks.jinja`, so it works in any Email Template / Notification / Print Format. Drop into a template:
```jinja
{% set link = ipay_payment_link(doc.name) %}
{% if link %}<a href="{{ link }}">Pay now</a>{% endif %}
```
It reuses the app's existing **idempotent request + token** (one stable link per invoice) but without the operator gate — it renders server-side with no logged-in user — and **never raises**, so it can't break an email or print render. It returns nothing (button hidden) when there's no balance, a cheque is held, the invoice is **prepaid**, or hosted checkout is off. This lets you add the link to your *own* existing ERPNext invoice/reminder emails.

**2. Two ready-made emails iPay ships (disabled, editable).**
Via a **create-once** patch (never re-synced, so a site can enable/edit/delete freely):
- **iPay: Invoice Issued** — on Sales Invoice submit
- **iPay: Payment Reminder** — 3 days after due date, while unpaid

Both email the invoice's `contact_email`, skip paid invoices, and carry the link. Shipped **off** so nothing sends until a site opts in.

## Behaviour & safety

- **Master switch:** everything is gated on `iPay Settings → Use Hosted Checkout Redirect` (`enable_redirect`). Off → no links anywhere.
- **Idempotent:** re-generating (reminder runs, re-sends) yields the *same* link, not a new one.
- **Self-managing:** the `/pay` page already handles paid → "Thank you", expired → "request a new one", cancelled/cheque → the right message; always shows the live balance.
- **No-login security:** a 24-char random token tied to one invoice/bundle; guest pay endpoint is rate-limited; cancelled/expired/cheque tokens refused.

## Verified on dev (rolled back)

- Non-prepaid unpaid invoice → real `…/pay?token=…` link.
- Prepaid invoice → `None`, silently (the `ValidationError` catch treats prepaid/cheque/before-validate refusals as "no link", not an error — no log spam).
- The helper renders in a template through the hook (`<a href='…/pay?token=…'>Pay now</a>`).
- The patch creates both notifications, disabled, correct triggers.

## Deploy

`bench migrate` runs the patch (creates the two disabled notifications) and picks up the jinja hook after restart. No new config beyond the existing `enable_redirect` / `payment_link_ttl_days`.

## Docs

`docs/payment-links-in-emails.md` — how to add the link to your own emails, the shipped notifications, behaviour, and security. README feature entry added.