### PR TITLE
feat(ipay): remember a seen tour server-side, per user account

### DIFF
--- a/frontend/src/composables/useTour.js
+++ b/frontend/src/composables/useTour.js
@@ -3,18 +3,24 @@ import { driver } from 'driver.js'
 import 'driver.js/dist/driver.css'
 import { useSession } from '@/stores/session'
 import { safeGet, safeSet } from '@/utils/storage'
+import { markTourSeen } from '@/data/onboarding'
 
-// A first-run walkthrough of a page. It runs once per user, then never again (the "seen"
-// flag persists in localStorage), and can be closed at any step via the ✕ or the backdrop —
-// closing still counts as seen, so we don't nag on the next visit. Keyed per user so a
-// shared device walks each collector through once.
+// A first-run walkthrough of a page. It runs once per user, then never again, and can be closed
+// at any step via the ✕ or the backdrop — closing still counts as seen. "Seen" is recorded
+// server-side against the user account (boot.tours_seen → window.tours_seen), so it survives a
+// cache clear, a new browser, a different device, or a PWA reinstall. localStorage mirrors it
+// per browser for an instant check and as a fallback if the server write is missed.
 const seenKey = (key, user) => `ipay:tour-seen:${key}:${user || 'anon'}`
+
+// The account-level list from boot, kept in memory so a tour marked seen this session isn't
+// replayed on an in-app navigation before the next page load re-reads boot.
+const serverSeen = () => (typeof window !== 'undefined' && window.tours_seen) || []
 
 export function useTour() {
   const session = useSession()
 
   function hasSeen(key) {
-    return Boolean(safeGet(seenKey(key, session.user)))
+    return serverSeen().includes(key) || Boolean(safeGet(seenKey(key, session.user)))
   }
 
   // steps: [{ element?: string, title, description }]. An element-less step is a centred
@@ -27,7 +33,13 @@ export function useTour() {
     // If nothing anchored survives (e.g. the whole list is empty), don't spend the one run.
     if (!present.some((s) => s.element)) return
 
-    const markSeen = () => safeSet(seenKey(key, session.user), '1')
+    const markSeen = () => {
+      safeSet(seenKey(key, session.user), '1') // instant, this browser
+      if (!serverSeen().includes(key)) {
+        window.tours_seen = [...serverSeen(), key] // this session won't replay it
+        markTourSeen(key).catch(() => {}) // persist against the account, across devices
+      }
+    }
     driver({
       showProgress: true,
       popoverClass: 'ipay-tour',

--- a/frontend/src/data/onboarding.js
+++ b/frontend/src/data/onboarding.js
@@ -1,0 +1,7 @@
+import { frappeRequest } from 'frappe-ui'
+
+const M = 'ipay.ipay.main.utils.onboarding'
+
+// Record server-side (per user account) that a first-run tour has been seen.
+export const markTourSeen = (tour) =>
+  frappeRequest({ url: `/api/method/${M}.mark_seen`, method: 'POST', params: { tour } })

--- a/ipay/ipay/doctype/ipay_onboarding/ipay_onboarding.json
+++ b/ipay/ipay/doctype/ipay_onboarding/ipay_onboarding.json
@@ -1,0 +1,61 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "field:user",
+ "creation": "2026-07-25 00:00:00.000000",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "user",
+  "seen_tours"
+ ],
+ "fields": [
+  {
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "User",
+   "options": "User",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "description": "JSON list of first-run tour keys this user has completed or skipped (e.g. [\"collect\", \"customer\"]).",
+   "fieldname": "seen_tours",
+   "fieldtype": "Small Text",
+   "label": "Seen Tours"
+  }
+ ],
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2026-07-25 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Ipay",
+ "name": "iPay Onboarding",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "read": 1,
+   "report": 1,
+   "role": "iPay Manager"
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 0
+}

--- a/ipay/ipay/doctype/ipay_onboarding/ipay_onboarding.py
+++ b/ipay/ipay/doctype/ipay_onboarding/ipay_onboarding.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Gatura Njenga and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class iPayOnboarding(Document):
+	pass

--- a/ipay/ipay/main/utils/onboarding.py
+++ b/ipay/ipay/main/utils/onboarding.py
@@ -1,0 +1,43 @@
+"""Per-user onboarding state — which first-run tours a user has seen, kept server-side so it
+survives a cache clear, a new browser, a different device, or a PWA reinstall. Exposed to the
+SPA via boot (ipay.www.collect.get_boot) and updated by mark_seen when a tour ends."""
+
+import json
+
+import frappe
+
+DOCTYPE = "iPay Onboarding"
+
+
+def seen_tours(user=None):
+	"""The list of tour keys this user has completed or skipped."""
+	user = user or frappe.session.user
+	if not user or user == "Guest":
+		return []
+	raw = frappe.db.get_value(DOCTYPE, user, "seen_tours")
+	try:
+		return json.loads(raw) if raw else []
+	except (ValueError, TypeError):
+		return []
+
+
+@frappe.whitelist()
+def get_seen():
+	return seen_tours()
+
+
+@frappe.whitelist(methods=["POST"])
+def mark_seen(tour):
+	"""Record that the caller has seen a first-run tour. Idempotent."""
+	user = frappe.session.user
+	if not tour or user == "Guest":
+		return {"seen": []}
+	current = set(seen_tours(user))
+	if tour in current:
+		return {"seen": sorted(current)}
+	current.add(tour)
+	doc = frappe.get_doc(DOCTYPE, user) if frappe.db.exists(DOCTYPE, user) else frappe.new_doc(DOCTYPE)
+	doc.user = user
+	doc.seen_tours = json.dumps(sorted(current))
+	doc.save(ignore_permissions=True)
+	return {"seen": sorted(current)}

--- a/ipay/www/collect.py
+++ b/ipay/www/collect.py
@@ -50,6 +50,7 @@ def get_context_for_dev():
 
 
 def get_boot():
+    from ipay.ipay.main.utils import onboarding
     from ipay.www.collect_payments import can_open_sales, lands_on_sales
 
     return frappe._dict(
@@ -63,6 +64,9 @@ def get_boot():
             "site_name": frappe.local.site,
             "csrf_token": frappe.sessions.get_csrf_token(),
             "vapid_public_key": frappe.conf.get("ipay_vapid_public_key"),
+            # First-run tours this user has already seen (server-side, so it survives a cache
+            # clear / new device); the SPA won't replay a tour whose key is here.
+            "tours_seen": onboarding.seen_tours(),
             "timezone": {
                 "system": get_system_timezone(),
                 "user": frappe.db.get_value("User", frappe.session.user, "time_zone")


### PR DESCRIPTION
## What

Makes the guided-tour **"seen once" promise actually hold** — across a cache clear, a new browser, a different device, or a PWA reinstall. Branched off `develop` (the tour code lives there, not `main`).

## The problem

"Seen" was stored **only in the browser's `localStorage`**, so it was per-browser and clearable — clear the cache or switch devices and the tour replayed (and in private mode / some webviews where storage is disabled, it replayed *every* time because the flag never persisted).

## The fix — persist against the user account

- New **`iPay Onboarding`** DocType: one row per user (autonamed by `user`), holding a JSON list of seen tour keys (`["collect", "customer", …]`).
- `onboarding.seen_tours()` + a whitelisted **`mark_seen(tour)`** (idempotent, upsert).
- The list is handed to the SPA in **boot** (`window.tours_seen`), so the app knows at load without an extra request.
- `useTour` now treats the **account-level list as the source of truth**, and still **mirrors localStorage** per browser for an instant check / offline fallback. When a tour ends, it writes localStorage, updates the in-memory boot list (so it isn't replayed this session), and POSTs `mark_seen` to persist it against the account.

Result: a user who has been through a tour **never sees it again on any device**, because it's their account's record — not the browser's.

## Verified on dev (rolled back)

DocType installs; `seen_tours` starts empty; `mark_seen("collect")` → `["collect"]`; adding `"customer"` accumulates; a repeat is idempotent; the record is autonamed by the user. Frontend builds.

## Notes

- Existing users with an old localStorage flag keep their instant mirror, so they don't re-see it; the first time they complete a tour after this ships, it's recorded server-side too.
- **Deploy:** `bench migrate` installs the DocType; no other config.