### PR TITLE
feat(ipay): remember a seen tour server-side, per user account

### DIFF
--- a/frontend/src/composables/useTour.js
+++ b/frontend/src/composables/useTour.js
@@ -3,18 +3,17 @@ import { driver } from 'driver.js'
 import 'driver.js/dist/driver.css'
 import { useSession } from '@/stores/session'
 import { safeGet, safeSet } from '@/utils/storage'
+import { markTourSeen } from '@/data/onboarding'
 
-// A first-run walkthrough of a page. It runs once per user, then never again (the "seen"
-// flag persists in localStorage), and can be closed at any step via the ✕ or the backdrop —
-// closing still counts as seen, so we don't nag on the next visit. Keyed per user so a
-// shared device walks each collector through once.
+// "Seen" is authoritative on the account (boot.tours_seen); localStorage mirrors it per browser.
 const seenKey = (key, user) => `ipay:tour-seen:${key}:${user || 'anon'}`
+const serverSeen = () => (typeof window !== 'undefined' && window.tours_seen) || []
 
 export function useTour() {
   const session = useSession()
 
   function hasSeen(key) {
-    return Boolean(safeGet(seenKey(key, session.user)))
+    return serverSeen().includes(key) || Boolean(safeGet(seenKey(key, session.user)))
   }
 
   // steps: [{ element?: string, title, description }]. An element-less step is a centred
@@ -27,7 +26,13 @@ export function useTour() {
     // If nothing anchored survives (e.g. the whole list is empty), don't spend the one run.
     if (!present.some((s) => s.element)) return
 
-    const markSeen = () => safeSet(seenKey(key, session.user), '1')
+    const markSeen = () => {
+      safeSet(seenKey(key, session.user), '1')
+      if (!serverSeen().includes(key)) {
+        window.tours_seen = [...serverSeen(), key]
+        markTourSeen(key).catch(() => {})
+      }
+    }
     driver({
       showProgress: true,
       popoverClass: 'ipay-tour',

--- a/frontend/src/data/onboarding.js
+++ b/frontend/src/data/onboarding.js
@@ -1,0 +1,6 @@
+import { frappeRequest } from 'frappe-ui'
+
+const M = 'ipay.ipay.main.utils.onboarding'
+
+export const markTourSeen = (tour) =>
+  frappeRequest({ url: `/api/method/${M}.mark_seen`, method: 'POST', params: { tour } })

--- a/ipay/ipay/doctype/ipay_onboarding/ipay_onboarding.json
+++ b/ipay/ipay/doctype/ipay_onboarding/ipay_onboarding.json
@@ -1,0 +1,61 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "field:user",
+ "creation": "2026-07-25 00:00:00.000000",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "user",
+  "seen_tours"
+ ],
+ "fields": [
+  {
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "User",
+   "options": "User",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "description": "JSON list of first-run tour keys this user has completed or skipped (e.g. [\"collect\", \"customer\"]).",
+   "fieldname": "seen_tours",
+   "fieldtype": "Small Text",
+   "label": "Seen Tours"
+  }
+ ],
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2026-07-25 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Ipay",
+ "name": "iPay Onboarding",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "read": 1,
+   "report": 1,
+   "role": "iPay Manager"
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 0
+}

--- a/ipay/ipay/doctype/ipay_onboarding/ipay_onboarding.py
+++ b/ipay/ipay/doctype/ipay_onboarding/ipay_onboarding.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Gatura Njenga and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class iPayOnboarding(Document):
+	pass

--- a/ipay/ipay/main/utils/onboarding.py
+++ b/ipay/ipay/main/utils/onboarding.py
@@ -1,0 +1,35 @@
+"""Per-user record of which first-run tours a user has seen — kept server-side so it survives a
+cache clear, a new device or a PWA reinstall. Read into boot; written by mark_seen."""
+
+import json
+
+import frappe
+
+DOCTYPE = "iPay Onboarding"
+
+
+def seen_tours(user=None):
+	user = user or frappe.session.user
+	if not user or user == "Guest":
+		return []
+	raw = frappe.db.get_value(DOCTYPE, user, "seen_tours")
+	try:
+		return json.loads(raw) if raw else []
+	except (ValueError, TypeError):
+		return []
+
+
+@frappe.whitelist(methods=["POST"])
+def mark_seen(tour):
+	user = frappe.session.user
+	if not tour or user == "Guest":
+		return {"seen": []}
+	current = set(seen_tours(user))
+	if tour in current:
+		return {"seen": sorted(current)}
+	current.add(tour)
+	doc = frappe.get_doc(DOCTYPE, user) if frappe.db.exists(DOCTYPE, user) else frappe.new_doc(DOCTYPE)
+	doc.user = user
+	doc.seen_tours = json.dumps(sorted(current))
+	doc.save(ignore_permissions=True)
+	return {"seen": sorted(current)}

--- a/ipay/www/collect.py
+++ b/ipay/www/collect.py
@@ -50,6 +50,7 @@ def get_context_for_dev():
 
 
 def get_boot():
+    from ipay.ipay.main.utils import onboarding
     from ipay.www.collect_payments import can_open_sales, lands_on_sales
 
     return frappe._dict(
@@ -63,6 +64,7 @@ def get_boot():
             "site_name": frappe.local.site,
             "csrf_token": frappe.sessions.get_csrf_token(),
             "vapid_public_key": frappe.conf.get("ipay_vapid_public_key"),
+            "tours_seen": onboarding.seen_tours(),
             "timezone": {
                 "system": get_system_timezone(),
                 "user": frappe.db.get_value("User", frappe.session.user, "time_zone")


### PR DESCRIPTION
> Reopened for review — this was previously auto-merged into `develop` (#103) before you could review it; I've pulled it back off `develop` so you decide when it lands. Also trimmed the comments and removed an unused endpoint (Occam/YAGNI) — see below.

## What

Makes the guided-tour **"seen once"** promise hold across a cache clear, a new browser, a different device, or a PWA reinstall — by keeping the flag **server-side, per user account** instead of localStorage-only.

## How

- New **`iPay Onboarding`** DocType: one row per user (autonamed by `user`), a JSON list of seen tour keys.
- `onboarding.seen_tours()` + whitelisted **`mark_seen(tour)`** (idempotent, upserts only the caller's own record).
- The list is handed to the SPA via **boot** (`window.tours_seen`).
- `useTour` treats the account list as the source of truth and mirrors localStorage per browser as a fast/offline fallback; on tour end it writes both and POSTs `mark_seen`.

## Code-quality pass (addressing the review)

- **Removed `get_seen`** — it was unused (the frontend reads the list from boot, not an endpoint). YAGNI.
- **Cut the comments right back** — one line in `useTour` for the non-obvious dual-source, a 2-line module docstring in `onboarding.py`, nothing narrative elsewhere.

## Verified on dev (rolled back)

DocType installs; `seen_tours` empty → `mark_seen("collect")` → `["collect"]`; accumulates; idempotent; autonamed by user; `get_seen` is gone; frontend builds.

**Deploy:** `bench migrate` installs the DocType.