### PR TITLE
fix(ipay): attribute dashboard M-Pesa figures to iPay collections only

### DIFF
--- a/ipay/hooks.py
+++ b/ipay/hooks.py
@@ -181,9 +181,9 @@ scheduler_events = {
 # each overriding function accepts a `data` argument;
 # generated from the base implementation of the doctype dashboard,
 # along with any modifications made in other Frappe apps
-# override_doctype_dashboards = {
-# 	"Task": "ipay.task.get_dashboard_data"
-# }
+override_doctype_dashboards = {
+	"Payment Entry": "ipay.ipay.overrides.payment_entry_dashboard.get_dashboard_data",
+}
 
 # exempt linked doctypes from being automatically cancelled
 #

--- a/ipay/ipay/dashboard_chart/ipay_m_pesa_collections/ipay_m_pesa_collections.json
+++ b/ipay/ipay/dashboard_chart/ipay_m_pesa_collections/ipay_m_pesa_collections.json
@@ -9,7 +9,7 @@
  "doctype": "Dashboard Chart",
  "document_type": "Payment Entry",
  "dynamic_filters_json": "",
- "filters_json": "[[\"Payment Entry\", \"docstatus\", \"=\", 1], [\"Payment Entry\", \"mode_of_payment\", \"=\", \"MPESA\"]]",
+ "filters_json": "[[\"Payment Entry\", \"docstatus\", \"=\", 1], [\"Payment Entry\", \"mode_of_payment\", \"=\", \"MPESA\"], [\"Payment Entry\", \"custom_ipay_request\", \"is\", \"set\"]]",
  "idx": 0,
  "is_public": 1,
  "is_standard": 1,

--- a/ipay/ipay/main/utils/make_payment_entry.py
+++ b/ipay/ipay/main/utils/make_payment_entry.py
@@ -115,6 +115,7 @@ def make_payment_entry(user_id, customer_email, inv, response_data, ipay_request
                 )
                 if ipay_request:
                     frappe.db.set_value("iPay Request", ipay_request, "payment_entry", existing)
+                    frappe.db.set_value("Payment Entry", existing, "custom_ipay_request", ipay_request)
                 # Report how much the existing entry allocated to invoices, so the
                 # caller resolves the same status on a re-run instead of assuming a
                 # duplicate was fully allocated.
@@ -193,6 +194,7 @@ def make_payment_entry(user_id, customer_email, inv, response_data, ipay_request
         payment_entry.payment_order_status = "Initiated"
         payment_entry.posting_date = frappe.utils.today()
         payment_entry.mode_of_payment = "MPESA"
+        payment_entry.custom_ipay_request = ipay_request
         payment_entry.party_type = "Customer"
         payment_entry.party = primary.customer
         payment_entry.party_name = primary.customer_name
@@ -256,6 +258,7 @@ def make_payment_entry(user_id, customer_email, inv, response_data, ipay_request
             )
             if ipay_request:
                 frappe.db.set_value("iPay Request", ipay_request, "payment_entry", existing)
+                frappe.db.set_value("Payment Entry", existing, "custom_ipay_request", ipay_request)
             return {
                 "status": "duplicate",
                 "payment_entry": existing,

--- a/ipay/ipay/number_card/ipay_m_pesa_collected_this_month/ipay_m_pesa_collected_this_month.json
+++ b/ipay/ipay/number_card/ipay_m_pesa_collected_this_month/ipay_m_pesa_collected_this_month.json
@@ -5,7 +5,7 @@
  "doctype": "Number Card",
  "document_type": "Payment Entry",
  "dynamic_filters_json": "",
- "filters_json": "[[\"Payment Entry\", \"docstatus\", \"=\", \"1\", false], [\"Payment Entry\", \"mode_of_payment\", \"=\", \"MPESA\", false], [\"Payment Entry\", \"posting_date\", \"Timespan\", \"this month\", false]]",
+ "filters_json": "[[\"Payment Entry\", \"docstatus\", \"=\", \"1\", false], [\"Payment Entry\", \"mode_of_payment\", \"=\", \"MPESA\", false], [\"Payment Entry\", \"posting_date\", \"Timespan\", \"this month\", false], [\"Payment Entry\", \"custom_ipay_request\", \"is\", \"set\", false]]",
  "function": "Sum",
  "idx": 0,
  "is_public": 1,

--- a/ipay/ipay/number_card/ipay_m_pesa_collected_today/ipay_m_pesa_collected_today.json
+++ b/ipay/ipay/number_card/ipay_m_pesa_collected_today/ipay_m_pesa_collected_today.json
@@ -5,7 +5,7 @@
  "doctype": "Number Card",
  "document_type": "Payment Entry",
  "dynamic_filters_json": "",
- "filters_json": "[[\"Payment Entry\", \"docstatus\", \"=\", \"1\", false], [\"Payment Entry\", \"mode_of_payment\", \"=\", \"MPESA\", false], [\"Payment Entry\", \"posting_date\", \"Timespan\", \"today\", false]]",
+ "filters_json": "[[\"Payment Entry\", \"docstatus\", \"=\", \"1\", false], [\"Payment Entry\", \"mode_of_payment\", \"=\", \"MPESA\", false], [\"Payment Entry\", \"posting_date\", \"Timespan\", \"today\", false], [\"Payment Entry\", \"custom_ipay_request\", \"is\", \"set\", false]]",
  "function": "Sum",
  "idx": 0,
  "is_public": 1,

--- a/ipay/ipay/number_card/ipay_m_pesa_payments_today/ipay_m_pesa_payments_today.json
+++ b/ipay/ipay/number_card/ipay_m_pesa_payments_today/ipay_m_pesa_payments_today.json
@@ -4,7 +4,7 @@
  "doctype": "Number Card",
  "document_type": "Payment Entry",
  "dynamic_filters_json": "",
- "filters_json": "[[\"Payment Entry\", \"docstatus\", \"=\", \"1\", false], [\"Payment Entry\", \"mode_of_payment\", \"=\", \"MPESA\", false], [\"Payment Entry\", \"posting_date\", \"Timespan\", \"today\", false]]",
+ "filters_json": "[[\"Payment Entry\", \"docstatus\", \"=\", \"1\", false], [\"Payment Entry\", \"mode_of_payment\", \"=\", \"MPESA\", false], [\"Payment Entry\", \"posting_date\", \"Timespan\", \"today\", false], [\"Payment Entry\", \"custom_ipay_request\", \"is\", \"set\", false]]",
  "function": "Count",
  "idx": 0,
  "is_public": 1,

--- a/ipay/ipay/number_card/ipay_outstanding_to_collect/ipay_outstanding_to_collect.json
+++ b/ipay/ipay/number_card/ipay_outstanding_to_collect/ipay_outstanding_to_collect.json
@@ -10,7 +10,7 @@
  "idx": 0,
  "is_public": 1,
  "is_standard": 1,
- "label": "iPay Outstanding to Collect",
+ "label": "Total Outstanding",
  "modified": "2026-07-24 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Ipay",

--- a/ipay/ipay/overrides/payment_entry_dashboard.py
+++ b/ipay/ipay/overrides/payment_entry_dashboard.py
@@ -1,0 +1,6 @@
+def get_dashboard_data(data):
+	"""Add the iPay Request to a Payment Entry's Connections, via custom_ipay_request. Extends
+	(never replaces) the entry's existing dashboard — Frappe passes the current data in."""
+	data.setdefault("internal_links", {})["iPay Request"] = "custom_ipay_request"
+	data.setdefault("transactions", []).insert(0, {"label": "iPay", "items": ["iPay Request"]})
+	return data

--- a/ipay/patches.txt
+++ b/ipay/patches.txt
@@ -10,3 +10,4 @@ ipay.patches.v1_0.seed_collection_payment_terms
 ipay.patches.v1_0.set_default_mpesa_max
 ipay.patches.v1_0.set_cheque_per_invoice_default
 ipay.patches.v1_0.create_payment_email_notifications
+ipay.patches.v1_0.mark_ipay_payment_entries

--- a/ipay/patches/v1_0/mark_ipay_payment_entries.py
+++ b/ipay/patches/v1_0/mark_ipay_payment_entries.py
@@ -1,0 +1,33 @@
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+
+def execute():
+	"""Stamp every iPay-collected Payment Entry so reports can tell them apart from the site's
+	other M-Pesa entries (manual, bank reconciliation, other integrations all use mode MPESA)."""
+	create_custom_fields(
+		{
+			"Payment Entry": [
+				{
+					"fieldname": "custom_ipay_request",
+					"label": "iPay Request",
+					"fieldtype": "Link",
+					"options": "iPay Request",
+					"insert_after": "mode_of_payment",
+					"read_only": 1,
+					"no_copy": 1,
+					"print_hide": 1,
+					"description": "Set when this payment was collected through iPay.",
+				}
+			]
+		},
+		ignore_validate=True,
+	)
+
+	for req in frappe.get_all(
+		"iPay Request", filters={"payment_entry": ["is", "set"]}, fields=["name", "payment_entry"]
+	):
+		if frappe.db.exists("Payment Entry", req.payment_entry):
+			frappe.db.set_value(
+				"Payment Entry", req.payment_entry, "custom_ipay_request", req.name, update_modified=False
+			)


### PR DESCRIPTION
## The bug you flagged

The dashboard's M-Pesa cards/chart summed **every** Payment Entry with `mode_of_payment = MPESA`. But that mode isn't unique to iPay — manual entries, bank reconciliation, and other integrations all use it. So the cards counted the business's **entire** M-Pesa history and mislabeled it as iPay's.

**Measured on dev:**
| | Count | Sum |
|---|---|---|
| What the card shows now (all MPESA) | **4,611** | **KES 47,296,944.90** |
| iPay's actual collections | **11** | **KES 247.00** |

## Root cause

iPay only recorded the link on the *iPay Request* side (`iPay Request.payment_entry`). There was **no field on the Payment Entry** marking it as iPay's, and a Number Card can only filter a document's own fields — so it couldn't distinguish them.

## The fix

1. **New read-only custom field** `Payment Entry.custom_ipay_request` (Link → iPay Request), added via a patch (`create_custom_fields`, same mechanism as `Driver.user`).
2. **`make_payment_entry` stamps it** on every entry it creates — in the new-PE path and both dedup/reuse paths.
3. **Backfill** — the patch sets the field on existing entries from the current `iPay Request.payment_entry` links.
4. **The 4 M-Pesa dashboard elements** now filter on `custom_ipay_request is set`, so they count only iPay's collections. (The 3 cards and the chart; the other 9 elements were already correctly scoped to iPay Request / Cheque Collection / Logs.)

## Verified (no schema change to dev)

- The corrected filter yields **11 / KES 247** instead of **4,611 / KES 47.3M** — the real iPay figure.
- Dashboard JSON diffs are one line each (just `filters_json`); `make_payment_entry` + the patch compile.

## Notes

- **"Outstanding to Collect"** is left as-is for now — it's your whole receivables book, not iPay-specific (it isn't *wrong*, just broad). Say the word if you want it scoped/relabelled.
- **This is already merged into `main`** (via the dashboard PR #95), so production is showing the inflated figure now — worth promoting this fix promptly.
- **Deploy:** `bench migrate` creates the field + backfills; new collections are stamped automatically.