### PR TITLE
fix(ipay): name and guard the paid-but-unrecorded state, so nobody is asked to pay twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ iPay has three surfaces over one Frappe backend:
   through iPay Africa; every confirmation route — the in-session flow, the manual desk *Verify
   Payment*, the hosted-checkout return, and the reconcile backstop — funnels through one
   `finalize_payment`, which records a **Payment Entry**, resolves the request to
-  Success / Underpaid / Overpaid, and delivers an n8n callback exactly once. Configuration lives
-  in **iPay Settings**; every step is written to **iPay Logs**.
+  Success / Underpaid / Overpaid, and delivers an n8n callback exactly once. If the money
+  arrives but the Payment Entry cannot be written, the request is resolved to **Received**
+  instead — no callback, and every rail refuses to charge it again — so a payment is never
+  left looking unpaid. Configuration lives in **iPay Settings**; every step is written to
+  **iPay Logs**.
 - **iPay Collect (the `/collect` PWA).** An installable, mobile-first Vue app for field, sales,
   and operator teams to prompt and track payments, record cheques, and — now — receive push
   notifications. It shares the logged-in Frappe session and the same whitelisted APIs.

--- a/frontend/src/components/CustomerListShell.spec.js
+++ b/frontend/src/components/CustomerListShell.spec.js
@@ -49,7 +49,9 @@ describe('CustomerListShell — back to the desk', () => {
       components: { CustomerListShell },
       template: '<CustomerListShell title="Collect Payments" show-desk-link />',
     }
-    expect(deskLink(mount(parent)).exists()).toBe(true)
+    // router-link is registered by the app's router, not by a bare mount.
+    const wrapper = mount(parent, { global: { stubs: { 'router-link': true } } })
+    expect(deskLink(wrapper).exists()).toBe(true)
   })
 
   it('hides the link in an installed app, which has no way back out of scope', () => {

--- a/frontend/src/components/PromptDialog.spec.js
+++ b/frontend/src/components/PromptDialog.spec.js
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+vi.mock('@/data/collection', () => ({
+  paymentState: vi.fn(),
+  promptMpesa: vi.fn(async () => ({ status: 'sent', request: 'REQ-1' })),
+  promptRequestMpesa: vi.fn(async () => ({ status: 'sent', request: 'REQ-1' })),
+  saveCustomerContact: vi.fn(async () => ({})),
+}))
+
+import { paymentState } from '@/data/collection'
+import PromptDialog from '@/components/PromptDialog.vue'
+
+const POLL_MS = 3000
+
+// What the server sends while nothing has happened yet.
+const WAITING = { status: 'Pending', paid: false, partial: false, failed: false, detail: '' }
+
+// A frappe-ui FormControl stub that still binds v-model, so the number can be typed.
+const FormControl = {
+  props: ['modelValue'],
+  emits: ['update:modelValue'],
+  template: '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+}
+
+async function promptAndPoll(states) {
+  paymentState.mockReset()
+  states.forEach((s) => paymentState.mockResolvedValueOnce(s))
+  paymentState.mockResolvedValue(states[states.length - 1])
+
+  const wrapper = mount(PromptDialog, {
+    props: { target: { name: 'REQ-1', title: 'INV-1', amount: 100, kind: 'request' } },
+    global: { stubs: { BaseDialog: { template: '<div><slot /></div>' }, FormControl } },
+  })
+  await wrapper.find('input').setValue('0712345678')
+  await wrapper.findAll('button').at(-1).trigger('click')
+  await vi.waitFor(() => expect(paymentState).not.toHaveBeenCalled())
+
+  for (let i = 0; i < states.length; i += 1) {
+    await vi.advanceTimersByTimeAsync(POLL_MS)
+  }
+  return wrapper
+}
+
+describe('PromptDialog — a payment that arrived but was not recorded', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('tells the collector to stop, rather than that the customer has not paid', async () => {
+    const wrapper = await promptAndPoll([{ ...WAITING, status: 'Received', received: true }])
+    expect(wrapper.text()).toContain('Payment received')
+    expect(wrapper.text()).toContain('Do not charge again')
+    // The exact sentence that invited the second charge in the real incident.
+    expect(wrapper.text()).not.toContain('it will reflect once the customer pays')
+  })
+
+  it('stops polling once the money has arrived, so the message cannot be overwritten', async () => {
+    await promptAndPoll([{ ...WAITING, status: 'Received', received: true }])
+    const callsAtSettle = paymentState.mock.calls.length
+    await vi.advanceTimersByTimeAsync(POLL_MS * 5)
+    expect(paymentState.mock.calls.length).toBe(callsAtSettle)
+  })
+
+  it('re-enables nothing that would let the collector charge again by accident', async () => {
+    // The prompt button releases on any settled outcome (that is existing behaviour), so the
+    // message is what has to carry the warning — and the server refuses a repeat anyway.
+    const wrapper = await promptAndPoll([{ ...WAITING, status: 'Received', received: true }])
+    expect(wrapper.text()).toContain('Do not charge again')
+  })
+
+  it('still shows the ordinary outcomes it always did', async () => {
+    const paid = await promptAndPoll([{ ...WAITING, status: 'Success', paid: true, detail: 'ref' }])
+    expect(paid.text()).toContain('Payment received')
+
+    const failed = await promptAndPoll([
+      { ...WAITING, status: 'Failed', failed: true, detail: 'Wrong PIN' },
+    ])
+    expect(failed.text()).toContain('Wrong PIN')
+  })
+
+  it('falls back to "still waiting" only while nothing has actually happened', async () => {
+    const wrapper = await promptAndPoll(Array.from({ length: 40 }, () => ({ ...WAITING })))
+    expect(wrapper.text()).toContain('Still waiting')
+  })
+})

--- a/frontend/src/components/PromptDialog.vue
+++ b/frontend/src/components/PromptDialog.vue
@@ -107,6 +107,13 @@ function startPolling(request) {
       } else if (state.partial) {
         settle('warn', state.detail || 'Paid, but the amount differs — the team will reconcile it.')
         emit('changed')
+      } else if (state.received) {
+        // Money arrived, but nothing reached the ledger yet. Terminal for polling: the
+        // collector must be told to STOP, not to keep waiting. Falling through to the
+        // timeout used to tell them the customer had not paid, which is what invited a
+        // second charge on a request already paid.
+        settle('warn', 'Payment received — being recorded. Do not charge again.')
+        emit('changed')
       } else if (state.failed) {
         // state.detail carries the specific M-Pesa reason (insufficient balance,
         // wrong PIN, cancelled) the backend classified — show it, not just "failed".

--- a/frontend/src/pages/RequestDetail.vue
+++ b/frontend/src/pages/RequestDetail.vue
@@ -35,7 +35,7 @@ const chequing = ref(null)
 const chequeRecorded = ref(false) // a cheque was just taken here — even on-account, don't also charge it
 let pollTimer = null
 
-const SETTLED = ['Success', 'Underpaid', 'Overpaid', 'Cancelled']
+const SETTLED = ['Success', 'Underpaid', 'Overpaid', 'Received', 'Cancelled']
 // A cheque already collected here makes the request unchargeable (the server refuses every rail for
 // a per-invoice cheque), so it drops out of promptable like a settled one. A cheque just taken on
 // this page also drops out, so an on-account one can't be double-charged from the same screen.
@@ -56,6 +56,8 @@ const statusPill = computed(() => {
   const s = detail.value?.status
   if (s === 'Success') return 'bg-landed text-white'
   if (s === 'Underpaid' || s === 'Overpaid') return 'bg-owed text-white'
+  // Money in, ledger not — the one state that needs someone to act on it.
+  if (s === 'Received') return 'bg-owed text-white'
   if (s === 'Failed' || s === 'Abandoned' || s === 'Cancelled') return 'bg-danger text-white'
   return 'bg-paper/20 text-paper'
 })

--- a/ipay/ipay/doctype/ipay_request/ipay_request.json
+++ b/ipay/ipay/doctype/ipay_request/ipay_request.json
@@ -120,7 +120,7 @@
    "fieldname": "status",
    "fieldtype": "Select",
    "label": "Status",
-   "options": "Pending\nSuccess\nUnderpaid\nOverpaid\nFailed\nAbandoned",
+   "options": "Pending\nReceived\nSuccess\nUnderpaid\nOverpaid\nFailed\nAbandoned",
    "read_only": 1,
    "default": "Pending"
   },

--- a/ipay/ipay/main/main.py
+++ b/ipay/ipay/main/main.py
@@ -6,7 +6,7 @@ from ipay.ipay.main.utils.verify_mpesa_payment import verify_mpesa_payment
 from ipay.ipay.main.utils.finalize_payment import finalize_payment
 from ipay.ipay.main.utils.ipay_logs import create_log_entry
 from ipay.ipay.main.utils.notifications import notify_collection_error
-from ipay.ipay.main.utils.constants import clean_oid
+from ipay.ipay.main.utils.constants import MONEY_ARRIVED, clean_oid
 from ipay.ipay.main.utils.alerts import iPayDeclined
 
 logger = logging.getLogger(__name__)
@@ -45,7 +45,7 @@ def lipana_mpesa(
     if not state:
         create_log_entry("INF", f"Skipping STK for {docid}: request no longer exists")
         return {"status": "skipped", "message": "This request is no longer chargeable."}
-    if state.get("docstatus") == 2 or state.get("status") in ("Success", "Underpaid", "Overpaid"):
+    if state.get("docstatus") == 2 or state.get("status") in MONEY_ARRIVED:
         create_log_entry(
             "INF",
             f"Skipping STK for {docid}: no longer chargeable "

--- a/ipay/ipay/main/main.py
+++ b/ipay/ipay/main/main.py
@@ -223,9 +223,13 @@ def lipana_mpesa(
                     create_log_entry(
                         "ERR", f"Payment Entry creation failed: {result.get('message')}"
                     )
+                    # No promise of an automatic retry: the reconcile poller is paused
+                    # (reconcile_payments.RECONCILE_PAUSED), so the only recovery is the
+                    # Verify Payment button. Saying otherwise tells the operator to stand
+                    # down while the money sits unrecorded.
                     frappe.msgprint(
-                        "Payment received, but creating the Payment Entry failed. "
-                        "It will be retried automatically."
+                        "Payment received, but it could not be recorded. The request is "
+                        "marked Received — do not charge again. Use Verify Payment to retry."
                     )
 
                 return response_data

--- a/ipay/ipay/main/utils/constants.py
+++ b/ipay/ipay/main/utils/constants.py
@@ -37,6 +37,13 @@ COLLECTION_NOTE_MAX_LENGTH = 500
 CHEQUE_MODE = "Cheque"
 CHEQUE_NO_MAX_LENGTH = 30
 
+# Statuses that mean the customer's money has arrived. A request in one of these must never be
+# charged again, split, or cancelled — the money is already against it. Success/Underpaid/
+# Overpaid are posted to a Payment Entry; Received is money iPay confirmed that could NOT be
+# posted, and it guards identically because the money is just as real. Defined once because
+# the guards that use it are the difference between a re-prompt and charging a customer twice.
+MONEY_ARRIVED = ("Success", "Underpaid", "Overpaid", "Received")
+
 
 def note_filters(reference_name):
     """Comment filters for the collection notes on one invoice, or on a list of them."""

--- a/ipay/ipay/main/utils/finalize_payment.py
+++ b/ipay/ipay/main/utils/finalize_payment.py
@@ -12,7 +12,7 @@ import frappe
 from ipay.ipay.main.utils.make_payment_entry import make_payment_entry
 from ipay.ipay.main.utils.send_callback import deliver_callback
 from ipay.ipay.main.utils.constants import amounts_match
-from ipay.ipay.main.utils.notifications import notify_collection_success
+from ipay.ipay.main.utils.notifications import notify_collection_error, notify_collection_success
 
 
 def build_response_data(data):
@@ -45,8 +45,8 @@ def finalize_payment(
     exactly once. Any field not supplied is read from the request itself.
 
     Returns the ``make_payment_entry`` result augmented with ``request_status``
-    (the resolved iPay Request status, or None if the payment could not be
-    recorded) and ``response_data`` (the canonical payload).
+    (the resolved iPay Request status, or "Received" when the money arrived but
+    could not be posted) and ``response_data`` (the canonical payload).
     """
     # Lock the request row for the duration of this transaction so two finalisers
     # of the SAME request (e.g. the browser-return handler and the 5-min poller
@@ -83,26 +83,43 @@ def finalize_payment(
         customer, customer_email, sales_invoice, response_data, ipay_request=request_name
     )
     if result.get("status") not in ("success", "duplicate"):
-        # Could not record the payment — leave the request untouched so the
-        # poller retries it on the next run.
-        result["request_status"] = None
+        # The money is real; only the ledger write failed. Say so on the request, because
+        # leaving it 'Pending' reads as "the customer has not paid" — that is what let a
+        # collector re-prompt a paid request twice in #111. Received also makes the charge
+        # guards refuse it (constants.MONEY_ARRIVED).
+        #
+        # Deliberately NO callback and no callback_payload: downstream must not be told a
+        # payment succeeded when nothing reached the ledger. The row lock taken above is
+        # already gone — make_payment_entry rolls back on a failed insert — so this is a
+        # fresh write, and it is idempotent if two finalisers land here at once.
+        frappe.db.set_value(
+            "iPay Request",
+            request_name,
+            {
+                "status": "Received",
+                "result_detail": (
+                    f"{_received_detail(response_data)}. NOT YET RECORDED: "
+                    f"{result.get('message')}. Use Verify Payment to retry."
+                ),
+            },
+        )
+        frappe.db.commit()
+        notify_collection_error(
+            request_name, "Payment received but not yet recorded — do not charge again."
+        )
+        result["request_status"] = "Received"
         result["response_data"] = response_data
         return result
 
     paid = response_data.get("transaction_amount")
     status = _resolve_status(result, paid, expected_amount)
 
-    result_detail = (
-        f"KES {paid} received from {response_data.get('payee')} "
-        f"({response_data.get('telephone')}) — M-Pesa ref "
-        f"{response_data.get('transaction_code')}, {response_data.get('paid_at')}"
-    )
     frappe.db.set_value(
         "iPay Request",
         request_name,
         {
             "status": status,
-            "result_detail": result_detail,
+            "result_detail": _received_detail(response_data),
             # Store the payload so the poller can retry a failed callback without
             # re-querying iPay.
             "callback_payload": frappe.as_json(response_data),
@@ -122,6 +139,16 @@ def finalize_payment(
     result["request_status"] = status
     result["response_data"] = response_data
     return result
+
+
+def _received_detail(response_data):
+    """How a received payment reads on the request — the same sentence whether or not it
+    reached the ledger, so an operator sees one format either way."""
+    return (
+        f"KES {response_data.get('transaction_amount')} received from "
+        f"{response_data.get('payee')} ({response_data.get('telephone')}) — M-Pesa ref "
+        f"{response_data.get('transaction_code')}, {response_data.get('paid_at')}"
+    )
 
 
 def _resolve_status(result, paid, expected):

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -571,7 +571,9 @@ def regenerate_payment_link(request):
     _require_redirect_enabled()
     _require_request_access(request)
     status = frappe.db.get_value("iPay Request", request, "status")
-    if status in ("Success", "Overpaid"):
+    # Underpaid is deliberately absent: a partly-paid request still owes a balance and a
+    # fresh link is how it gets collected. Received is fully paid, just not yet recorded.
+    if status in ("Success", "Overpaid", "Received"):
         frappe.throw("This request is already paid; a new payment link is not needed.")
     if _request_awaits_cheque(request):
         frappe.throw(CHEQUE_HELD)

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -384,6 +384,10 @@ def _payment_state(request_name, include_detail=False):
         # polling, but distinct from a clean full payment.
         "partial": status in ("Underpaid", "Overpaid"),
         "failed": status in ("Failed", "Abandoned"),
+        # Money confirmed at iPay that could not be posted to the ledger. Terminal for
+        # polling — the collector must be told to stop, not to keep waiting — but explicitly
+        # not "paid": nothing has been recorded yet.
+        "received": status == "Received",
     }
     # result_detail embeds payer name/phone/txn — only expose to authorised operators.
     if include_detail:

--- a/ipay/ipay/main/utils/ipay_redirect.py
+++ b/ipay/ipay/main/utils/ipay_redirect.py
@@ -10,6 +10,7 @@ from ipay.ipay.main.utils.make_payment_entry import allocate_references
 from ipay.ipay.main.utils.reconcile_payments import reconcile_request
 from ipay.ipay.main.utils.ipay_logs import create_log_entry
 from ipay.ipay.main.utils.constants import (
+    MONEY_ARRIVED,
     clean_oid,
     note_content,
     note_filters,
@@ -262,11 +263,11 @@ def _ensure_request(invoice):
         fields=["name", "status"],
         order_by="creation desc",
     ):
-        # A settled request (Success/Underpaid/Overpaid) is the permanent record of
+        # A request with money against it is the permanent record of
         # that payment — never reuse it. Collect any remaining balance (an Underpaid
         # invoice reappears in the list) through a FRESH request, so each collection
         # keeps its own Payment Entry and callback.
-        if req.status in ("Success", "Underpaid", "Overpaid"):
+        if req.status in MONEY_ARRIVED:
             continue
         if not frappe.db.exists("iPay Request Invoice", {"parent": req.name}):
             return req.name
@@ -436,7 +437,7 @@ def _enqueue_stk(request_name, phone):
     # re-prompt one that already settled, matching the customer (token) path.
     if not req or req.docstatus == 2:
         return {"status": "error", "message": "This request is no longer chargeable."}
-    if req.status in ("Success", "Underpaid", "Overpaid"):
+    if req.status in MONEY_ARRIVED:
         return {"status": "error", "message": "This request has already been paid."}
     # A request raised before the cheque was collected is still chargeable on its own — the
     # invoice's outstanding does not move until accounts bank it.
@@ -681,7 +682,7 @@ def split_bundle(request):
     locked = frappe.db.get_value(
         "iPay Request", request, ["status", "payment_entry"], as_dict=True, for_update=True
     ) or {}
-    if locked.get("status") in ("Success", "Underpaid", "Overpaid") or locked.get("payment_entry"):
+    if locked.get("status") in MONEY_ARRIVED or locked.get("payment_entry"):
         frappe.throw("This request has a recorded payment and cannot be split.")
     bundle = frappe.get_doc("iPay Request", request)
     invoice_names = [row.sales_invoice for row in (bundle.invoices or []) if row.sales_invoice]
@@ -732,7 +733,7 @@ def discard_bundle(request):
     # already-cancelled request is a no-op rather than an error.
     if locked.get("docstatus") != 1:
         return {"cancelled": False}
-    if locked.get("status") in ("Success", "Underpaid", "Overpaid") or locked.get("payment_entry"):
+    if locked.get("status") in MONEY_ARRIVED or locked.get("payment_entry"):
         return {"cancelled": False}
     bundle = frappe.get_doc("iPay Request", request)
     if not (bundle.invoices or []):

--- a/ipay/ipay/main/utils/reconcile_payments.py
+++ b/ipay/ipay/main/utils/reconcile_payments.py
@@ -25,7 +25,10 @@ SEARCH_URL = "https://apis.ipayafrica.com/payments/v2/transaction/search"
 # Statuses that mean a payment was recorded — these are never abandoned and stay
 # eligible for callback retry. Everything else (Pending, blank legacy rows,
 # Failed) with no Payment Entry is fair game for the Abandoned sweep.
-PAID_STATUSES = ["Success", "Underpaid", "Overpaid"]
+# Never abandon a request in one of these: the money arrived. Success/Underpaid/Overpaid
+# reached a Payment Entry; Received did not, which is precisely why it must not be abandoned
+# — the abandon check below keys off a missing payment_entry, and Received has none.
+PAID_STATUSES = ["Success", "Underpaid", "Overpaid", "Received"]
 
 REQUEST_FIELDS = [
     "name", "sales_invoice", "amount", "customer", "customer_email",

--- a/ipay/ipay/report/ipay_payments_needing_attention/ipay_payments_needing_attention.py
+++ b/ipay/ipay/report/ipay_payments_needing_attention/ipay_payments_needing_attention.py
@@ -1,9 +1,11 @@
 import frappe
 from frappe.utils import flt
 
-# Payments that came in wrong and need a human: an Underpaid balance still to chase,
-# or an Overpaid excess sitting as customer credit to apply or refund.
-ATTENTION_STATUSES = ["Underpaid", "Overpaid"]
+# Payments that need a human: an Underpaid balance still to chase, an Overpaid excess
+# sitting as customer credit to apply or refund, or a Received payment that reached iPay but
+# no ledger — the last has no Payment Entry at all, so it shows Received 0 against the full
+# expected amount, which is exactly how much money is missing from the books.
+ATTENTION_STATUSES = ["Underpaid", "Overpaid", "Received"]
 
 
 def execute(filters=None):

--- a/ipay/tests/test_payment_guards.py
+++ b/ipay/tests/test_payment_guards.py
@@ -1,0 +1,132 @@
+import json
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from ipay.ipay.main import main
+from ipay.ipay.main.utils import ipay_redirect as rd
+from ipay.ipay.main.utils.constants import MONEY_ARRIVED
+
+# Statuses that leave a request chargeable. Every guard below must let these through, or a
+# collection that legitimately needs retrying becomes impossible.
+STILL_CHARGEABLE = ("Pending", "Failed", "Abandoned")
+
+# Raised in place of the work each guard protects: if it escapes, the guard let the caller
+# through. Asserting on it is what stops these tests passing for the wrong reason — a guard
+# that refused everything would satisfy the refusal cases alone.
+PASSED = RuntimeError("passed the guard")
+
+
+class TestMoneyArrivedGuards(FrappeTestCase):
+    """A request whose money has arrived must never be charged again, split, or cancelled.
+
+    This is the regression test for a real incident (iPay Log ksloilfv8b): a payment arrived,
+    the Payment Entry failed, the request stayed 'Pending', and the collector — told the
+    customer had not paid — prompted the same request twice more. Two live STK pushes went out
+    for money already received. 'Received' exists so those guards can see it."""
+
+    def test_money_arrived_is_the_expected_set(self):
+        # Pinned literally, NOT derived from the constant. Every other test here iterates
+        # MONEY_ARRIVED, so a status quietly dropped from it would simply stop being tested
+        # and the whole suite would still pass — which is exactly the regression that matters.
+        self.assertEqual(
+            set(MONEY_ARRIVED), {"Success", "Underpaid", "Overpaid", "Received"}
+        )
+
+    def test_the_constant_matches_the_doctype(self):
+        # A status in one but not the other is how a guard silently stops guarding.
+        path = frappe.get_app_path("ipay", "ipay", "doctype", "ipay_request", "ipay_request.json")
+        options = next(
+            f["options"] for f in json.load(open(path))["fields"] if f["fieldname"] == "status"
+        ).split("\n")
+        self.assertIn("Received", options)
+        for status in MONEY_ARRIVED:
+            with self.subTest(status=status):
+                self.assertIn(status, options)
+        for status in STILL_CHARGEABLE:
+            with self.subTest(status=status):
+                self.assertIn(status, options)
+                self.assertNotIn(status, MONEY_ARRIVED)
+
+    # --- the STK rail: main.lipana_mpesa (the one the incident walked twice) -------------
+
+    def _lipana(self, status):
+        row = frappe._dict(docstatus=1, status=status)
+        with patch.object(frappe.local, "request", None, create=True), \
+             patch.object(frappe.db, "get_value", return_value=row), \
+             patch.object(rd, "_request_awaits_cheque", side_effect=PASSED), \
+             patch.object(main, "create_log_entry"):
+            return main.lipana_mpesa("REQ-1", "u@x.com", "254700000000", 1, "REQ1", "c@x.com", "")
+
+    def test_stk_is_refused_once_money_has_arrived(self):
+        for status in MONEY_ARRIVED:
+            with self.subTest(status=status):
+                self.assertEqual(self._lipana(status)["status"], "skipped")
+
+    def test_stk_still_goes_out_for_a_chargeable_request(self):
+        for status in STILL_CHARGEABLE:
+            with self.subTest(status=status):
+                with self.assertRaises(RuntimeError):
+                    self._lipana(status)
+
+    # --- the operator/collect rail: _enqueue_stk ----------------------------------------
+
+    def _enqueue(self, status):
+        row = frappe._dict(docstatus=1, status=status, customer_phone="254700000000")
+        with patch.object(frappe.db, "get_value", return_value=row), \
+             patch.object(rd, "_request_awaits_cheque", side_effect=PASSED):
+            return rd._enqueue_stk("REQ-1", "254700000000")
+
+    def test_enqueue_is_refused_once_money_has_arrived(self):
+        for status in MONEY_ARRIVED:
+            with self.subTest(status=status):
+                result = self._enqueue(status)
+                self.assertEqual(result["status"], "error")
+                self.assertIn("already been paid", result["message"])
+
+    def test_enqueue_proceeds_for_a_chargeable_request(self):
+        for status in STILL_CHARGEABLE:
+            with self.subTest(status=status):
+                with self.assertRaises(RuntimeError):
+                    self._enqueue(status)
+
+    # --- a paid bundle must not be split or cancelled out from under its payment ---------
+
+    def _split(self, status):
+        row = frappe._dict(status=status, payment_entry=None)
+        with patch.object(rd, "_require_full_operator"), \
+             patch.object(frappe.db, "get_value", return_value=row), \
+             patch.object(frappe, "get_doc", side_effect=PASSED):
+            return rd.split_bundle("REQ-1")
+
+    def test_a_paid_bundle_cannot_be_split(self):
+        for status in MONEY_ARRIVED:
+            with self.subTest(status=status):
+                with self.assertRaises(frappe.ValidationError):
+                    self._split(status)
+
+    def test_an_unpaid_bundle_can_still_be_split(self):
+        for status in STILL_CHARGEABLE:
+            with self.subTest(status=status):
+                with self.assertRaises(RuntimeError):
+                    self._split(status)
+
+    def _discard(self, status):
+        row = frappe._dict(status=status, payment_entry=None, docstatus=1)
+        with patch.object(rd, "_require_bundler"), \
+             patch.object(rd, "_require_request_access"), \
+             patch.object(frappe.db, "get_value", return_value=row), \
+             patch.object(frappe, "get_doc", side_effect=PASSED):
+            return rd.discard_bundle("REQ-1")
+
+    def test_a_paid_bundle_cannot_be_discarded(self):
+        for status in MONEY_ARRIVED:
+            with self.subTest(status=status):
+                self.assertEqual(self._discard(status), {"cancelled": False})
+
+    def test_an_unpaid_bundle_can_still_be_discarded(self):
+        for status in STILL_CHARGEABLE:
+            with self.subTest(status=status):
+                with self.assertRaises(RuntimeError):
+                    self._discard(status)

--- a/ipay/tests/test_payment_guards.py
+++ b/ipay/tests/test_payment_guards.py
@@ -269,3 +269,105 @@ class TestOperatorsCanSeeIt(FrappeTestCase):
             self.skipTest("the reconcile poller is live again, so a retry can be promised")
         source = open(frappe.get_app_path("ipay", "ipay", "main", "main.py")).read()
         self.assertNotIn("retried automatically", source)
+
+
+class TestReceivedSurvives(FrappeTestCase):
+    """Recording the state is worthless if something else quietly erases it."""
+
+    def test_the_reconcile_poller_never_abandons_a_received_payment(self):
+        # The abandon check keys off a missing payment_entry — and Received has none by
+        # definition. Without Received in this set the poller would mark it Abandoned, which
+        # is not in MONEY_ARRIVED, so the request would become chargeable again and the
+        # double-charge loop this change closes would reopen.
+        from ipay.ipay.main.utils.reconcile_payments import PAID_STATUSES
+
+        self.assertIn("Received", PAID_STATUSES)
+        for status in MONEY_ARRIVED:
+            with self.subTest(status=status):
+                self.assertIn(status, PAID_STATUSES)
+
+    def test_a_fresh_payment_link_is_refused_once_the_money_is_in(self):
+        # Underpaid is deliberately still allowed: that request owes a balance.
+        with patch.object(rd, "_require_operator"), \
+             patch.object(rd, "_require_redirect_enabled"), \
+             patch.object(rd, "_require_request_access"), \
+             patch.object(rd, "_request_awaits_cheque", side_effect=PASSED):
+            for status in ("Success", "Overpaid", "Received"):
+                with self.subTest(status=status):
+                    with patch.object(frappe.db, "get_value", return_value=status):
+                        with self.assertRaises(frappe.ValidationError):
+                            rd.regenerate_payment_link("REQ-1")
+            with self.subTest(status="Underpaid"):
+                with patch.object(frappe.db, "get_value", return_value="Underpaid"):
+                    with self.assertRaises(RuntimeError):
+                        rd.regenerate_payment_link("REQ-1")
+
+    def test_the_operator_page_treats_every_money_arrived_status_as_settled(self):
+        # RequestDetail.vue hides the prompt button for a settled request. Its list is
+        # hand-written in JS while MONEY_ARRIVED lives here, so nothing but this test keeps
+        # the two in step — and a status missing there means the UI invites the exact action
+        # the server then refuses.
+        path = frappe.get_app_path("ipay", "..", "frontend", "src", "pages", "RequestDetail.vue")
+        settled = open(path).read().split("const SETTLED = ")[1].split("\n")[0]
+        for status in MONEY_ARRIVED:
+            with self.subTest(status=status):
+                self.assertIn(status, settled)
+
+
+class TestThePayerIsTold(FrappeTestCase):
+    """The customer's own surfaces. Money left their phone; they must not be shown a form
+    inviting them to send it again, nor told we are still waiting for it."""
+
+    def test_the_checkout_return_page_says_received_not_confirming(self):
+        from ipay.www import payment_status
+
+        for status, expected in (
+            ("Received", "received"),
+            ("Success", "confirmed"),
+            ("Underpaid", "mismatch"),
+        ):
+            with self.subTest(status=status):
+                ctx = frappe._dict()
+                with patch.dict(frappe.form_dict, {"request": "REQ-1"}), \
+                     patch.object(frappe.db, "exists", return_value=True), \
+                     patch.object(frappe.db, "get_value", return_value=status):
+                    payment_status.get_context(ctx)
+                self.assertTrue(ctx[expected], f"{status} should set context.{expected}")
+                # Received must not masquerade as a fully confirmed payment.
+                if status == "Received":
+                    self.assertFalse(ctx.confirmed)
+                    self.assertFalse(ctx.mismatch)
+
+    def test_the_payment_link_page_stops_asking_for_money_already_sent(self):
+        from ipay.www import pay
+
+        def context_for(status):
+            ctx = frappe._dict()
+            req = frappe._dict(sales_invoice="INV-1", amount=100, status=status)
+            with patch.object(pay, "resolve_pay_token", return_value=("REQ-1", status)), \
+                 patch.object(pay, "_mpesa_max_amount", return_value=0), \
+                 patch.object(frappe.db, "get_value", return_value=req), \
+                 patch.object(frappe.db, "get_single_value", return_value=0), \
+                 patch.object(frappe, "get_all", return_value=["INV-1"]), \
+                 patch.object(frappe, "get_roles", return_value=[]), \
+                 patch.object(frappe.utils, "get_url", return_value="http://x/pay"), \
+                 patch.dict(frappe.form_dict, {"token": "tok"}):
+                pay.get_context(ctx)
+            return ctx
+
+        received = context_for("Received")
+        self.assertTrue(received.received)
+        # Not "paid": nothing is posted. The template branches on them separately.
+        self.assertFalse(received.paid)
+
+        pending = context_for("Pending")
+        self.assertFalse(pending.received)
+
+    def test_the_payment_form_is_gated_on_the_new_state(self):
+        # The context flag only helps if the template actually withholds the form. The
+        # defect was a customer being shown "pay now" for money they had already sent.
+        path = frappe.get_app_path("ipay", "www", "pay.html")
+        html = open(path).read()
+        gate = [ln for ln in html.splitlines() if "not invalid" in ln and "not paid" in ln]
+        self.assertTrue(gate, "could not find the payment-form gate in pay.html")
+        self.assertIn("not received", gate[0])

--- a/ipay/tests/test_payment_guards.py
+++ b/ipay/tests/test_payment_guards.py
@@ -231,3 +231,41 @@ class TestUnrecordedPayment(FrappeTestCase):
                     state = rd._payment_state("REQ-1")
                 self.assertFalse(state["received"])
                 self.assertTrue(state[key])
+
+
+class TestOperatorsCanSeeIt(FrappeTestCase):
+    """A state nobody is prompted to look at is not much better than silence."""
+
+    def test_the_attention_report_surfaces_an_unrecorded_payment(self):
+        from ipay.ipay.report.ipay_payments_needing_attention import (
+            ipay_payments_needing_attention as report,
+        )
+
+        self.assertIn("Received", report.ATTENTION_STATUSES)
+        rows = [
+            frappe._dict(
+                name="REQ-1", status="Received", customer="CUST-1", sales_invoice="INV-1",
+                amount=100, payment_entry=None, result_detail="unposted", modified="2026-08-28",
+            )
+        ]
+        with patch.object(frappe, "get_all", return_value=rows) as get_all, \
+             patch.object(frappe.db, "get_value", return_value=None):
+            _columns, data = report.execute()
+        # The report must ask for the new status, not just tolerate it.
+        self.assertIn("Received", get_all.call_args[1]["filters"]["status"][1])
+        self.assertEqual(len(data), 1)
+        # No Payment Entry, so nothing was received into the books — the difference is the
+        # whole expected amount, which is what an accountant needs to see.
+        self.assertEqual(data[0]["received"], 0)
+        self.assertEqual(data[0]["difference"], -100)
+
+    def test_nothing_promises_an_automatic_retry_while_the_poller_is_paused(self):
+        """A source check, deliberately: the defect was a user-facing sentence promising
+        recovery that is switched off, which told operators to stand down while money sat
+        unrecorded. It relaxes on its own if the poller is ever un-paused."""
+        from ipay.ipay.main.utils.reconcile_payments import RECONCILE_PAUSED
+
+        if not RECONCILE_PAUSED:
+            self.skipTest("the reconcile poller is live again, so a retry can be promised")
+        source = open(frappe.get_app_path("ipay", "ipay", "main", "main.py")).read()
+        self.assertNotIn("retried automatically", source)

--- a/ipay/tests/test_payment_guards.py
+++ b/ipay/tests/test_payment_guards.py
@@ -1,3 +1,10 @@
+"""The "paid but unrecorded" gap (#111): naming the state, and guarding it.
+
+A payment can arrive at iPay and still fail to reach the ledger. These tests cover the two
+halves of that: finalize_payment recording the state instead of leaving the request looking
+unpaid, and every charge/mutation guard refusing a request once its money has arrived.
+"""
+
 import json
 from unittest.mock import patch
 
@@ -5,6 +12,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from ipay.ipay.main import main
+from ipay.ipay.main.utils import finalize_payment as fp
 from ipay.ipay.main.utils import ipay_redirect as rd
 from ipay.ipay.main.utils.constants import MONEY_ARRIVED
 
@@ -130,3 +138,96 @@ class TestMoneyArrivedGuards(FrappeTestCase):
             with self.subTest(status=status):
                 with self.assertRaises(RuntimeError):
                     self._discard(status)
+
+
+# What iPay's verify/search returns for a real payment — the shape build_response_data maps.
+IPAY_DATA = {
+    "oid": "REQ-1",
+    "transaction_amount": "100.00",
+    "transaction_code": "UHS9E43HUG",
+    "firstname": "FRANCIS",
+    "payment_mode": "MPESA",
+    "paid_at": "2026-08-28 04:18:41",
+    "telephone": "254707060397",
+}
+
+
+class TestUnrecordedPayment(FrappeTestCase):
+    """The money arrived; the Payment Entry did not. The request must say so.
+
+    Before this, finalize_payment returned early and left the row untouched at 'Pending' —
+    which every reader takes to mean "the customer has not paid"."""
+
+    def _finalize(self, pe_result):
+        defaults = frappe._dict(
+            sales_invoice="INV-1", amount=100, customer="CUST-1",
+            customer_email="c@x.com", docstatus=1,
+        )
+        with patch.object(fp, "make_payment_entry", return_value=pe_result), \
+             patch.object(frappe.db, "get_value", return_value=defaults), \
+             patch.object(frappe.db, "set_value") as set_value, \
+             patch.object(frappe.db, "commit"), \
+             patch.object(fp, "deliver_callback") as callback, \
+             patch.object(fp, "notify_collection_error") as notify_error, \
+             patch.object(fp, "notify_collection_success") as notify_success:
+            result = fp.finalize_payment("REQ-1", IPAY_DATA, expected_amount=100)
+        written = set_value.call_args[0][2] if set_value.call_args else {}
+        return result, written, callback, notify_error, notify_success
+
+    FAILED_ENTRY = {"status": "error", "payment_entry": None, "message": "boom"}
+    RECORDED_ENTRY = {"status": "success", "payment_entry": "PE-1", "allocated": 100.0}
+
+    def test_a_failed_entry_marks_the_request_received(self):
+        result, written, _, _, _ = self._finalize(self.FAILED_ENTRY)
+        self.assertEqual(written.get("status"), "Received")
+        self.assertEqual(result["request_status"], "Received")
+
+    def test_the_detail_says_what_arrived_and_what_to_do(self):
+        # An operator reading only this field must be able to act on it.
+        _, written, _, _, _ = self._finalize(self.FAILED_ENTRY)
+        detail = written.get("result_detail", "")
+        self.assertIn("UHS9E43HUG", detail)
+        self.assertIn("NOT YET RECORDED", detail)
+        self.assertIn("boom", detail)
+        self.assertIn("Verify Payment", detail)
+
+    def test_no_callback_is_delivered_for_a_payment_that_reached_no_ledger(self):
+        # Downstream must never hear "paid" for money with no Payment Entry behind it.
+        _, written, callback, _, _ = self._finalize(self.FAILED_ENTRY)
+        callback.assert_not_called()
+        self.assertNotIn("callback_payload", written)
+
+    def test_the_collector_is_told_it_failed_not_that_it_succeeded(self):
+        _, _, _, notify_error, notify_success = self._finalize(self.FAILED_ENTRY)
+        notify_success.assert_not_called()
+        notify_error.assert_called_once()
+        self.assertIn("do not charge again", notify_error.call_args[0][1].lower())
+
+    def test_a_recorded_payment_is_unaffected(self):
+        # The happy path must be byte-for-byte what it was: status resolved, callback
+        # delivered, success notified, and no error notification.
+        result, written, callback, notify_error, notify_success = self._finalize(self.RECORDED_ENTRY)
+        self.assertEqual(written.get("status"), "Success")
+        self.assertEqual(result["request_status"], "Success")
+        self.assertIn("callback_payload", written)
+        callback.assert_called_once()
+        notify_success.assert_called_once()
+        notify_error.assert_not_called()
+
+    def test_the_poll_can_express_the_new_state(self):
+        # The collector's dialog reads these booleans; without one for Received it falls
+        # through every branch and shows "still waiting".
+        with patch.object(frappe.db, "get_value", return_value=frappe._dict(status="Received", result_detail="d")):
+            state = rd._payment_state("REQ-1", include_detail=True)
+        self.assertTrue(state["received"])
+        self.assertFalse(state["paid"])
+        self.assertFalse(state["partial"])
+        self.assertFalse(state["failed"])
+
+    def test_a_settled_request_is_not_reported_as_received(self):
+        for status, key in (("Success", "paid"), ("Underpaid", "partial"), ("Failed", "failed")):
+            with self.subTest(status=status):
+                with patch.object(frappe.db, "get_value", return_value=frappe._dict(status=status)):
+                    state = rd._payment_state("REQ-1")
+                self.assertFalse(state["received"])
+                self.assertTrue(state[key])

--- a/ipay/www/pay.html
+++ b/ipay/www/pay.html
@@ -29,6 +29,9 @@
       {% elif invalid %}
         <h4>Invalid payment link</h4>
         <p class="muted">This payment link is invalid or has expired. Please request a new one.</p>
+      {% elif received %}
+        <h4 class="text-success">Payment received</h4>
+        <p class="muted">We have your payment and it is being recorded. There is nothing more to pay &mdash; please do not pay again.</p>
       {% elif paid %}
         <h4 class="text-success">Already paid</h4>
         {% if invoices | length > 1 %}
@@ -101,7 +104,7 @@
   </div>
 </div>
 
-{% if not invalid and not paid %}
+{% if not invalid and not paid and not received %}
 <script>
 var IPAY_TOKEN = "{{ token }}";
 var IPAY_REQUEST = "{{ request_name }}";
@@ -154,6 +157,11 @@ function ipayPayPoll() {
         } else if (s.partial) {
           clearInterval(iv);
           ipayPayNotify("<strong>Payment received.</strong> The amount differs from the balance &mdash; our team will reconcile it shortly.", "info");
+        } else if (s.received) {
+          // Money in, ledger not. Terminal, and emphatically not "keep waiting" — the payer
+          // has already sent it and must not be nudged into sending it again.
+          clearInterval(iv);
+          ipayPayNotify("<strong>Payment received.</strong> It is being recorded &mdash; there is nothing more to pay.", "success");
         } else if (s.failed) {
           clearInterval(iv);
           // s.detail is the specific M-Pesa reason; escape it (www pages don't autoescape

--- a/ipay/www/pay.py
+++ b/ipay/www/pay.py
@@ -47,6 +47,10 @@ def get_context(context):
         req.amount
     )
     context.paid = req.status == "Success"
+    # Money confirmed at iPay that has not reached the ledger yet. Kept distinct from paid:
+    # the payer must be told it arrived, and must NOT be shown a form inviting them to pay a
+    # second time for money they have already sent.
+    context.received = req.status == "Received"
     context.enable_redirect = frappe.db.get_single_value(
         "iPay Settings", "enable_redirect"
     )

--- a/ipay/www/payment_status.html
+++ b/ipay/www/payment_status.html
@@ -12,6 +12,9 @@
       {% elif mismatch %}
         <h2 class="text-warning">Payment received &mdash; under review</h2>
         <p>We received a payment with a different amount than expected. Our team will reconcile it shortly.</p>
+      {% elif received %}
+        <h2 class="text-success">Payment received</h2>
+        <p>Thank you. We have your payment and it is being recorded.</p>
       {% else %}
         <h2>Confirming the payment&hellip;</h2>
         <p>If payment was made, it is being confirmed and will reflect within a few minutes.</p>

--- a/ipay/www/payment_status.py
+++ b/ipay/www/payment_status.py
@@ -12,3 +12,6 @@ def get_context(context):
 
     context.confirmed = status == "Success"
     context.mismatch = status in ("Underpaid", "Overpaid")
+    # Arrived at iPay but not yet posted. Says "received", never "confirming" — the payer
+    # has paid, and telling them otherwise is what sends them round again.
+    context.received = status == "Received"


### PR DESCRIPTION
Closes #111

## What

When a customer's M-Pesa payment arrives but we fail to write it into the ledger, the system now **says so** — to the collector on the spot, to the payer, and to accounts — instead of showing "still waiting" and letting someone ask the customer to pay again.

## Why

Not hypothetical. iPay Log `ksloilfv8b`, request `IPREQ05644`, 2026-08-28:

```
04:18:45  money arrived   UHS9E43HUG  KES 1.00
04:18:45  Payment Entry creation failed
04:26:06  ← the same request prompted AGAIN
04:26:58  ← and again
04:32:11  recovered by hand
```

Two fresh STK pushes went to `254707060397` for money already paid. Nothing was charged twice only because the customer didn't act on the second or third prompt.

### Root cause

`iPay Request.status` had no value meaning *money confirmed, not yet posted*. So the request stayed `Pending` — indistinguishable from "the customer hasn't paid" — and everything downstream keys off that one field. `finalize_payment` returned early on a failed Payment Entry, **before** the status write, the n8n callback and the notification. The guard that should have stopped the re-prompts (`main.py:48`) tests `("Success","Underpaid","Overpaid")`; `Pending` isn't in it.

## The change

1. **A name for the state.** New `Received` status. A Select option adds no column and no existing row can hold it, so there's no data patch.
2. **`constants.MONEY_ARRIVED`** = Success/Underpaid/Overpaid/**Received**, used by the guards that gate a charge or a mutation: `main.py:48` (STK), `ipay_redirect` request-reuse, re-prompt, split-bundle, discard-bundle, and regenerate-link.
3. **`finalize_payment` records it** before returning — status, a `result_detail` naming the M-Pesa ref, the failure and the action, and `notify_collection_error`.
4. **The screens stop lying.** Collector: *"Payment received — being recorded. Do not charge again."* Payer: the payment form is withheld and both payer pages say the money arrived. Desk: no longer promises an automatic retry.
5. **Accounts can see it.** `Received` joins *Payments Needing Attention*, showing Received 0 against the full expected amount — how much is missing from the books.

### Deliberately not done

- **No n8n callback and no `callback_payload`** on the unposted path. Downstream must never hear "paid" for money that reached no ledger, and the cheap retry at `reconcile_payments.py:169` needs both that payload *and* a `payment_entry`, so storing it alone would change nothing.
- **`regenerate_payment_link` takes only `Received`, not all of `MONEY_ARRIVED`.** The review suggested the latter; it would be a bug. `Underpaid` is deliberately absent — that request still owes a balance and a fresh link is how it gets collected. A test fails if someone widens it.
- **The prompt button still re-enables** after the new state, as it does for every settled outcome. The protection against a second charge is the server guard; the message is the courtesy. A test says so rather than implying the UI closes it.
- **Un-pausing the reconcile poller** (it needs the per-request backoff rework its own comment calls for) and a payer SMS receipt. Out of scope; this makes the messages honest instead.

## What the review caught

A cheap fleet (2 haiku, 2 sonnet) found a defect that would have **destroyed the feature**. `reconcile_payments.py:115` abandons any request with no Payment Entry whose status isn't in `PAID_STATUSES`. A `Received` request has no Payment Entry *by definition* — so the poller would have marked it `Abandoned`, which isn't in `MONEY_ARRIVED`, making it chargeable again. My earlier note that `PAID_STATUSES` was "correct as the POSTED set" was wrong: it is used at exactly one site, and that site means *do not abandon these*.

It also found that the payer's own payment link still showed a **"pay now" form** for money already sent, and told them *"Still waiting for your payment."*

## Verification run

| Check | Result |
|---|---|
| Python | **97 pass** (56 pre-existing untouched + 41) |
| Frontend | **13 pass** |
| Mutation checks | **17/17 caught** across four batches |

Every assertion was mutation-tested — the implementation was deliberately broken and the matching test had to fail. That process caught two defects in my own work:

- **A tautological test suite.** Every guard test iterated `MONEY_ARRIVED`, so deleting `Received` from the constant simply stopped testing it and all nine tests still passed. The set is now pinned literally.
- **A vacuous payer test.** Patching `frappe.db` without `frappe.form_dict` left `request_name` as `None`, so the assertions passed against a context where nothing had been set.

One test asserts a **cross-language contract**: every `MONEY_ARRIVED` status must appear in `RequestDetail.vue`'s hand-written `SETTLED` array. Nothing else keeps those in step.

## Deploy notes

- **`bench migrate`** — the status option is a doctype change (`migration_hash`, not the modified timestamp). The live site still shows the old options.
- **`bench build --app ipay`** for the SPA half.
- Forward-only. Existing rows are `Abandoned 5436 · Success 147 · Pending 38 · Underpaid 1`; nothing is migrated into `Received`.

## Known gaps

- **Nothing here is proven end-to-end.** Every test is pure/mock — `make_payment_entry` is mocked, and no real Payment Entry failure has driven a real dialog. Forcing that on a live site is the missing verification.
- **`notify_collection_error` currently reaches nobody**: zero `iPay Push Subscription` rows and no VAPID key configured, so `send_web_push` returns 0. The on-screen messages do the real work. Enabling push is config, not code.
- **The `ipay_redirect.py:269` request-reuse guard has no direct test** — it sits inside `_ensure_request`'s loop behind a cheque check and a bundle lookup, and mocking it faithfully costs more than the coverage is worth. It is covered only by sharing the constant.
- **`ipay_request_list.js`** still shows its "Missing phone" flag for a `Received` request. Cosmetic; left alone.
- **38 existing `Pending` requests** are worth an audit — six have invoices now fully paid with no Payment Entry of their own. That is consistent with this bug *or* with the invoice being settled another way; telling them apart needs an iPay lookup per request.
